### PR TITLE
feat(ci): add Linux musl build targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,14 @@ jobs:
             target: aarch64-unknown-linux-gnu
             artifact: toktrack-linux-arm64
             cross: true
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            artifact: toktrack-linux-musl-x64
+            cross: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            artifact: toktrack-linux-musl-arm64
+            cross: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: toktrack-win32-x64.exe
@@ -69,6 +77,10 @@ jobs:
       - name: Build (cargo)
         if: ${{ !matrix.cross }}
         run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Smoke test (cross)
+        if: matrix.cross
+        run: cross run --release --target ${{ matrix.target }} -- --version
 
       - name: Prepare artifact (Unix)
         if: matrix.os != 'windows-latest'
@@ -139,6 +151,8 @@ jobs:
           cp artifacts/toktrack-darwin-x64/toktrack-darwin-x64 npm/bin/
           cp artifacts/toktrack-linux-x64/toktrack-linux-x64 npm/bin/
           cp artifacts/toktrack-linux-arm64/toktrack-linux-arm64 npm/bin/
+          cp artifacts/toktrack-linux-musl-x64/toktrack-linux-musl-x64 npm/bin/
+          cp artifacts/toktrack-linux-musl-arm64/toktrack-linux-musl-arm64 npm/bin/
           cp artifacts/toktrack-win32-x64.exe/toktrack-win32-x64.exe npm/bin/
           chmod +x npm/bin/*
 

--- a/npm/bin/run.js
+++ b/npm/bin/run.js
@@ -1,10 +1,28 @@
 #!/usr/bin/env node
 const { execFileSync } = require('child_process');
+const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
 const platform = os.platform();
 const arch = os.arch();
+
+function isMusl() {
+  if (platform !== 'linux') return false;
+  try {
+    // Check for musl dynamic linker
+    const files = fs.readdirSync('/lib');
+    if (files.some(f => f.startsWith('ld-musl-'))) return true;
+  } catch {}
+  try {
+    const lddOutput = execFileSync('ldd', ['--version'], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    if (lddOutput.toLowerCase().includes('musl')) return true;
+  } catch (e) {
+    // ldd --version writes to stderr on musl systems
+    if (e.stderr && e.stderr.toString().toLowerCase().includes('musl')) return true;
+  }
+  return false;
+}
 
 // Platform mapping to binary names
 const platformMap = {
@@ -12,15 +30,18 @@ const platformMap = {
   'darwin-x64': 'toktrack-darwin-x64',
   'linux-x64': 'toktrack-linux-x64',
   'linux-arm64': 'toktrack-linux-arm64',
+  'linux-musl-x64': 'toktrack-linux-musl-x64',
+  'linux-musl-arm64': 'toktrack-linux-musl-arm64',
   'win32-x64': 'toktrack-win32-x64.exe',
 };
 
-const key = `${platform}-${arch}`;
+const libc = isMusl() ? 'musl-' : '';
+const key = `${platform}-${libc}${arch}`;
 const binaryName = platformMap[key];
 
 if (!binaryName) {
-  console.error(`Unsupported platform: ${platform}-${arch}`);
-  console.error('Supported platforms: darwin-arm64, darwin-x64, linux-x64, linux-arm64, win32-x64');
+  console.error(`Unsupported platform: ${key}`);
+  console.error('Supported platforms: darwin-arm64, darwin-x64, linux-x64, linux-arm64, linux-musl-x64, linux-musl-arm64, win32-x64');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- Add `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets to release workflow
- Add smoke test (`--version`) for all cross-compiled binaries
- Add musl libc auto-detection in npm runner (`run.js`)

Closes #98

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | musl matrix entries + smoke test step + npm artifact copy |
| `npm/bin/run.js` | `isMusl()` detection via `/lib/ld-musl-*` and `ldd --version` |

## Test plan
- [ ] `make check` passes (no Rust code changes)
- [ ] Release workflow builds musl binaries successfully
- [ ] Smoke test validates binary execution in cross environment
- [ ] npm runner selects musl binary on Alpine/musl-based Linux
- [ ] npm runner falls back to glibc binary on standard Linux