### PR TITLE
feat(cli): add report subcommand for usage receipt generation

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,11 @@
 //! CLI command handling
 
+use std::path::PathBuf;
+
+use chrono::Local;
 use clap::{Parser, Subcommand};
 
+use crate::report::data::ReportData;
 use crate::services::{Aggregator, DataLoaderService};
 use crate::tui::widgets::daily::DailyViewMode;
 use crate::tui::widgets::tabs::Tab;
@@ -49,6 +53,25 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+
+    /// Generate a usage report (text or SVG receipt)
+    Report {
+        /// Last 7 days (default)
+        #[arg(long, group = "period")]
+        week: bool,
+
+        /// Last 30 days
+        #[arg(long, group = "period")]
+        month: bool,
+
+        /// Last N days
+        #[arg(long, group = "period")]
+        days: Option<u32>,
+
+        /// Output SVG file (default: toktrack-report.svg)
+        #[arg(long, num_args = 0..=1, default_missing_value = "toktrack-report.svg")]
+        svg: Option<PathBuf>,
+    },
 }
 
 impl Cli {
@@ -95,6 +118,12 @@ impl Cli {
                     })
                 }
             }
+            Some(Commands::Report {
+                week,
+                month,
+                days,
+                svg,
+            }) => Ok(run_report(week, month, days, svg)?),
         }
     }
 }
@@ -104,6 +133,35 @@ impl Cli {
 fn load_data() -> Result<Vec<DailySummary>> {
     let result = DataLoaderService::new().load()?;
     Ok(result.summaries)
+}
+
+/// Load full result including source_usage
+fn load_data_full() -> Result<crate::services::data_loader::LoadResult> {
+    DataLoaderService::new().load()
+}
+
+/// Generate a usage report (text and optionally SVG)
+fn run_report(_week: bool, month: bool, days: Option<u32>, svg: Option<PathBuf>) -> Result<()> {
+    let n_days = if month { 30 } else { days.unwrap_or(7) };
+
+    let today = Local::now().date_naive();
+    let start = today - chrono::Duration::days(n_days as i64 - 1);
+    let end = today;
+
+    let result = load_data_full()?;
+    let data = ReportData::from_summaries(&result.summaries, &result.source_usage, start, end);
+
+    // Always print text report
+    println!("{}", crate::report::text::render(&data));
+
+    // Optionally write SVG
+    if let Some(path) = svg {
+        let svg_content = crate::report::svg::render(&data);
+        std::fs::write(&path, svg_content)?;
+        println!("\nSVG saved to: {}", path.display());
+    }
+
+    Ok(())
 }
 
 /// Output daily summaries as JSON
@@ -224,6 +282,90 @@ mod tests {
     fn test_cli_parse_backup_removed() {
         // backup subcommand should no longer exist
         let result = Cli::try_parse_from(["toktrack", "backup"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parse_report_default() {
+        let cli = Cli::try_parse_from(["toktrack", "report"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Report {
+                week: false,
+                month: false,
+                days: None,
+                svg: None,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_cli_parse_report_week() {
+        let cli = Cli::try_parse_from(["toktrack", "report", "--week"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Report {
+                week: true,
+                month: false,
+                days: None,
+                svg: None,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_cli_parse_report_month() {
+        let cli = Cli::try_parse_from(["toktrack", "report", "--month"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Report {
+                week: false,
+                month: true,
+                days: None,
+                svg: None,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_cli_parse_report_days() {
+        let cli = Cli::try_parse_from(["toktrack", "report", "--days", "14"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Report {
+                week: false,
+                month: false,
+                days: Some(14),
+                svg: None,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_cli_parse_report_svg_default_path() {
+        let cli = Cli::try_parse_from(["toktrack", "report", "--svg"]).unwrap();
+        match cli.command {
+            Some(Commands::Report { svg, .. }) => {
+                assert_eq!(svg, Some(PathBuf::from("toktrack-report.svg")));
+            }
+            _ => panic!("Expected Report command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_report_svg_custom_path() {
+        let cli = Cli::try_parse_from(["toktrack", "report", "--svg", "custom.svg"]).unwrap();
+        match cli.command {
+            Some(Commands::Report { svg, .. }) => {
+                assert_eq!(svg, Some(PathBuf::from("custom.svg")));
+            }
+            _ => panic!("Expected Report command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_report_week_month_conflict() {
+        let result = Cli::try_parse_from(["toktrack", "report", "--week", "--month"]);
         assert!(result.is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod parsers;
+mod report;
 mod services;
 mod tui;
 mod types;

--- a/src/report/data.rs
+++ b/src/report/data.rs
@@ -1,0 +1,340 @@
+//! Report data structures and period filtering
+
+use chrono::NaiveDate;
+
+use crate::services::{display_name, Aggregator};
+use crate::types::{DailySummary, SourceUsage};
+
+/// A single model's aggregated report
+#[derive(Debug, Clone)]
+pub struct ModelReport {
+    pub name: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_usd: f64,
+    #[allow(dead_code)]
+    pub count: u64,
+}
+
+/// A single source's aggregated report
+#[derive(Debug, Clone)]
+pub struct SourceReport {
+    pub name: String,
+    pub total_tokens: u64,
+    pub cost_usd: f64,
+}
+
+/// A single day's report
+#[derive(Debug, Clone)]
+pub struct DayReport {
+    pub date: NaiveDate,
+    #[allow(dead_code)]
+    pub total_tokens: u64,
+    pub cost_usd: f64,
+}
+
+/// Intermediate report data, ready for rendering
+#[derive(Debug, Clone)]
+pub struct ReportData {
+    pub period_label: String,
+    pub total_cost: f64,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub active_days: u32,
+    pub total_days: u32,
+    pub by_model: Vec<ModelReport>,
+    pub by_source: Vec<SourceReport>,
+    pub daily: Vec<DayReport>,
+    pub most_expensive_day: Option<DayReport>,
+}
+
+impl ReportData {
+    /// Build report data from summaries filtered to [start, end]
+    pub fn from_summaries(
+        summaries: &[DailySummary],
+        source_usage: &[SourceUsage],
+        start: NaiveDate,
+        end: NaiveDate,
+    ) -> Self {
+        let period_label = format!("{} ~ {}", start.format("%Y-%m-%d"), end.format("%Y-%m-%d"));
+        let total_days = (end - start).num_days().max(0) as u32 + 1;
+
+        let filtered: Vec<&DailySummary> = summaries
+            .iter()
+            .filter(|s| s.date >= start && s.date <= end)
+            .collect();
+
+        if filtered.is_empty() {
+            return Self {
+                period_label,
+                total_cost: 0.0,
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                active_days: 0,
+                total_days,
+                by_model: Vec::new(),
+                by_source: Vec::new(),
+                daily: Vec::new(),
+                most_expensive_day: None,
+            };
+        }
+
+        let active_days = filtered.len() as u32;
+        let mut total_cost = 0.0;
+        let mut total_input_tokens: u64 = 0;
+        let mut total_output_tokens: u64 = 0;
+        let mut most_expensive_day: Option<DayReport> = None;
+        let mut daily = Vec::with_capacity(filtered.len());
+
+        for s in &filtered {
+            total_cost += s.total_cost_usd;
+            total_input_tokens = total_input_tokens.saturating_add(s.total_input_tokens);
+            total_output_tokens = total_output_tokens.saturating_add(s.total_output_tokens);
+
+            let day_tokens = s.total_input_tokens.saturating_add(s.total_output_tokens);
+            let day = DayReport {
+                date: s.date,
+                total_tokens: day_tokens,
+                cost_usd: s.total_cost_usd,
+            };
+
+            match &most_expensive_day {
+                None => most_expensive_day = Some(day.clone()),
+                Some(prev) if s.total_cost_usd > prev.cost_usd => {
+                    most_expensive_day = Some(day.clone());
+                }
+                _ => {}
+            }
+
+            daily.push(day);
+        }
+
+        daily.sort_by_key(|d| d.date);
+
+        // Build model reports
+        let owned_filtered: Vec<DailySummary> = filtered.into_iter().cloned().collect();
+        let model_map = Aggregator::by_model_from_daily(&owned_filtered);
+        let mut by_model: Vec<ModelReport> = model_map
+            .into_iter()
+            .map(|(name, usage)| ModelReport {
+                name: display_name(&name),
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                cost_usd: usage.cost_usd,
+                count: usage.count,
+            })
+            .collect();
+        by_model.sort_by(|a, b| b.cost_usd.total_cmp(&a.cost_usd));
+
+        // Build source reports
+        let mut by_source: Vec<SourceReport> = source_usage
+            .iter()
+            .map(|s| SourceReport {
+                name: s.source.clone(),
+                total_tokens: s.total_tokens,
+                cost_usd: s.total_cost_usd,
+            })
+            .collect();
+        by_source.sort_by(|a, b| b.cost_usd.total_cmp(&a.cost_usd));
+
+        Self {
+            period_label,
+            total_cost,
+            total_input_tokens,
+            total_output_tokens,
+            active_days,
+            total_days,
+            by_model,
+            by_source,
+            daily,
+            most_expensive_day,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ModelUsage;
+    use std::collections::HashMap;
+
+    fn make_summary(year: i32, month: u32, day: u32, cost: f64) -> DailySummary {
+        let mut models = HashMap::new();
+        models.insert(
+            "claude-sonnet-4".to_string(),
+            ModelUsage {
+                input_tokens: 1000,
+                output_tokens: 500,
+                cost_usd: cost,
+                count: 5,
+                ..Default::default()
+            },
+        );
+        DailySummary {
+            date: NaiveDate::from_ymd_opt(year, month, day).unwrap(),
+            total_input_tokens: 1000,
+            total_output_tokens: 500,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_thinking_tokens: 0,
+            total_cost_usd: cost,
+            models,
+        }
+    }
+
+    #[test]
+    fn test_empty_data() {
+        let data = ReportData::from_summaries(
+            &[],
+            &[],
+            NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 1, 7).unwrap(),
+        );
+        assert_eq!(data.active_days, 0);
+        assert_eq!(data.total_days, 7);
+        assert!(data.by_model.is_empty());
+        assert!(data.most_expensive_day.is_none());
+    }
+
+    #[test]
+    fn test_single_day() {
+        let summaries = vec![make_summary(2024, 1, 5, 1.50)];
+        let data = ReportData::from_summaries(
+            &summaries,
+            &[],
+            NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 1, 7).unwrap(),
+        );
+        assert_eq!(data.active_days, 1);
+        assert_eq!(data.total_days, 7);
+        assert!((data.total_cost - 1.50).abs() < f64::EPSILON);
+        assert_eq!(data.total_input_tokens, 1000);
+        assert_eq!(data.total_output_tokens, 500);
+        assert_eq!(data.by_model.len(), 1);
+        assert_eq!(data.by_model[0].name, "Sonnet 4");
+        assert!(data.most_expensive_day.is_some());
+    }
+
+    #[test]
+    fn test_multiple_days_sorted() {
+        let summaries = vec![
+            make_summary(2024, 1, 3, 0.50),
+            make_summary(2024, 1, 5, 2.00),
+            make_summary(2024, 1, 1, 1.00),
+        ];
+        let data = ReportData::from_summaries(
+            &summaries,
+            &[],
+            NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 1, 7).unwrap(),
+        );
+        assert_eq!(data.active_days, 3);
+        assert!((data.total_cost - 3.50).abs() < f64::EPSILON);
+        assert_eq!(
+            data.daily[0].date,
+            NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()
+        );
+        assert_eq!(
+            data.daily[2].date,
+            NaiveDate::from_ymd_opt(2024, 1, 5).unwrap()
+        );
+        let expensive = data.most_expensive_day.unwrap();
+        assert_eq!(expensive.date, NaiveDate::from_ymd_opt(2024, 1, 5).unwrap());
+    }
+
+    #[test]
+    fn test_filter_excludes_out_of_range() {
+        let summaries = vec![
+            make_summary(2024, 1, 1, 1.00),
+            make_summary(2024, 1, 10, 2.00),
+        ];
+        let data = ReportData::from_summaries(
+            &summaries,
+            &[],
+            NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 1, 7).unwrap(),
+        );
+        assert_eq!(data.active_days, 1);
+        assert!((data.total_cost - 1.00).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_model_sort_by_cost_desc() {
+        let mut models = HashMap::new();
+        models.insert(
+            "claude-sonnet-4".to_string(),
+            ModelUsage {
+                input_tokens: 100,
+                output_tokens: 50,
+                cost_usd: 0.50,
+                count: 1,
+                ..Default::default()
+            },
+        );
+        models.insert(
+            "claude-opus-4-5".to_string(),
+            ModelUsage {
+                input_tokens: 200,
+                output_tokens: 100,
+                cost_usd: 2.00,
+                count: 1,
+                ..Default::default()
+            },
+        );
+        let summaries = vec![DailySummary {
+            date: NaiveDate::from_ymd_opt(2024, 1, 5).unwrap(),
+            total_input_tokens: 300,
+            total_output_tokens: 150,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_thinking_tokens: 0,
+            total_cost_usd: 2.50,
+            models,
+        }];
+        let data = ReportData::from_summaries(
+            &summaries,
+            &[],
+            NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 1, 7).unwrap(),
+        );
+        assert_eq!(data.by_model[0].name, "Opus 4.5");
+        assert_eq!(data.by_model[1].name, "Sonnet 4");
+    }
+
+    #[test]
+    fn test_source_reports() {
+        let sources = vec![
+            SourceUsage {
+                source: "claude".to_string(),
+                total_tokens: 5000,
+                total_cost_usd: 3.00,
+            },
+            SourceUsage {
+                source: "codex".to_string(),
+                total_tokens: 2000,
+                total_cost_usd: 1.00,
+            },
+        ];
+        let summaries = vec![make_summary(2024, 1, 5, 4.00)];
+        let data = ReportData::from_summaries(
+            &summaries,
+            &sources,
+            NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 1, 7).unwrap(),
+        );
+        assert_eq!(data.by_source.len(), 2);
+        assert_eq!(data.by_source[0].name, "claude");
+        assert_eq!(data.by_source[1].name, "codex");
+    }
+
+    #[test]
+    fn test_period_label_format() {
+        let data = ReportData::from_summaries(
+            &[],
+            &[],
+            NaiveDate::from_ymd_opt(2024, 3, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 3, 7).unwrap(),
+        );
+        assert_eq!(data.period_label, "2024-03-01 ~ 2024-03-07");
+    }
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,0 +1,5 @@
+//! Report generation for AI coding usage receipts
+
+pub mod data;
+pub mod svg;
+pub mod text;

--- a/src/report/svg.rs
+++ b/src/report/svg.rs
@@ -1,0 +1,448 @@
+//! SVG renderer for usage reports (receipt style)
+
+use std::fmt::Write;
+
+use crate::report::data::ReportData;
+
+const WIDTH: u32 = 600;
+const PADDING: u32 = 30;
+const LINE_HEIGHT: u32 = 24;
+const SECTION_GAP: u32 = 16;
+const BAR_HEIGHT: u32 = 14;
+const BAR_MAX_W: u32 = 160;
+const INNER_W: u32 = WIDTH - PADDING * 2;
+
+const COLORS: &[&str] = &[
+    "#4F46E5", // indigo
+    "#0EA5E9", // sky
+    "#10B981", // emerald
+    "#F59E0B", // amber
+    "#EF4444", // red
+    "#8B5CF6", // violet
+];
+
+fn color_for(index: usize) -> &'static str {
+    COLORS[index % COLORS.len()]
+}
+
+fn estimate_height(data: &ReportData) -> u32 {
+    let mut h: u32 = PADDING;
+    h += LINE_HEIGHT * 3 + SECTION_GAP; // header
+    h += LINE_HEIGHT * 4 + SECTION_GAP; // summary
+
+    if !data.by_model.is_empty() {
+        h += LINE_HEIGHT * (1 + data.by_model.len() as u32) + SECTION_GAP;
+    }
+    if !data.by_source.is_empty() {
+        h += LINE_HEIGHT * (1 + data.by_source.len() as u32) + SECTION_GAP;
+    }
+    if !data.daily.is_empty() {
+        h += LINE_HEIGHT * (1 + data.daily.len() as u32) + SECTION_GAP;
+    }
+    if data.most_expensive_day.is_some() {
+        h += LINE_HEIGHT + SECTION_GAP;
+    }
+    h += LINE_HEIGHT * 2 + PADDING; // footer
+    h
+}
+
+fn format_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        format!("{}", n)
+    }
+}
+
+fn format_cost(cost: f64) -> String {
+    format!("${:.2}", cost)
+}
+
+fn escape_xml(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Render report data as SVG string
+pub fn render(data: &ReportData) -> String {
+    let height = estimate_height(data);
+    let mut svg = String::with_capacity(4096);
+
+    // SVG header + styles
+    write!(
+        svg,
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="{WIDTH}" height="{height}" viewBox="0 0 {WIDTH} {height}">
+<defs>
+  <style>
+    .bg {{ fill: #ffffff; }}
+    .title {{ font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; font-size: 18px; font-weight: bold; fill: #111827; }}
+    .subtitle {{ font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; font-size: 12px; fill: #6B7280; }}
+    .label {{ font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; font-size: 13px; fill: #374151; }}
+    .value {{ font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; font-size: 13px; fill: #111827; font-weight: bold; }}
+    .section {{ font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; font-size: 11px; fill: #9CA3AF; font-weight: bold; letter-spacing: 1px; }}
+    .footer {{ font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; font-size: 10px; fill: #9CA3AF; }}
+    .bar {{ rx: 3; ry: 3; }}
+    .separator {{ stroke: #E5E7EB; stroke-dasharray: 4,4; }}
+  </style>
+</defs>
+<rect class="bg" width="{WIDTH}" height="{height}" rx="12" ry="12"/>
+<rect x="1" y="1" width="{w2}" height="{h2}" rx="12" ry="12" fill="none" stroke="#E5E7EB" stroke-width="1"/>"##,
+        w2 = WIDTH - 2,
+        h2 = height - 2,
+    )
+    .unwrap();
+
+    let mut y = PADDING;
+    let x = PADDING;
+    let right = WIDTH - PADDING;
+    let cx = WIDTH / 2;
+
+    // Title
+    y += LINE_HEIGHT;
+    write!(
+        svg,
+        r#"<text x="{cx}" y="{y}" class="title" text-anchor="middle">AI CODING RECEIPT</text>"#,
+    )
+    .unwrap();
+
+    // Period
+    y += LINE_HEIGHT;
+    write!(
+        svg,
+        r#"<text x="{cx}" y="{y}" class="subtitle" text-anchor="middle">{}</text>"#,
+        escape_xml(&data.period_label),
+    )
+    .unwrap();
+
+    // Separator
+    y += SECTION_GAP;
+    svg_separator(&mut svg, x, right, y);
+
+    // Summary
+    y += LINE_HEIGHT;
+    svg_label_value(
+        &mut svg,
+        x,
+        right,
+        y,
+        "Total Cost",
+        &format_cost(data.total_cost),
+    );
+    y += LINE_HEIGHT;
+    svg_label_value(
+        &mut svg,
+        x,
+        right,
+        y,
+        "Input Tokens",
+        &format_tokens(data.total_input_tokens),
+    );
+    y += LINE_HEIGHT;
+    svg_label_value(
+        &mut svg,
+        x,
+        right,
+        y,
+        "Output Tokens",
+        &format_tokens(data.total_output_tokens),
+    );
+    y += LINE_HEIGHT;
+    svg_label_value(
+        &mut svg,
+        x,
+        right,
+        y,
+        "Active Days",
+        &format!("{}/{}", data.active_days, data.total_days),
+    );
+
+    // By Model
+    if !data.by_model.is_empty() {
+        y += SECTION_GAP;
+        svg_separator(&mut svg, x, right, y);
+        y += LINE_HEIGHT;
+        write!(
+            svg,
+            r#"<text x="{x}" y="{y}" class="section">BY MODEL</text>"#
+        )
+        .unwrap();
+
+        let max_cost = data
+            .by_model
+            .iter()
+            .map(|m| m.cost_usd)
+            .fold(0.0_f64, f64::max);
+
+        for (i, model) in data.by_model.iter().enumerate() {
+            y += LINE_HEIGHT;
+            let name = escape_xml(&model.name);
+            let cost = format_cost(model.cost_usd);
+            let tokens = format_tokens(model.input_tokens.saturating_add(model.output_tokens));
+
+            write!(svg, r#"<text x="{x}" y="{y}" class="label">{name}</text>"#).unwrap();
+            write!(
+                svg,
+                r#"<text x="{mx}" y="{y}" class="value" text-anchor="end">{cost}</text>"#,
+                mx = x + 220,
+            )
+            .unwrap();
+            write!(
+                svg,
+                r#"<text x="{tx}" y="{y}" class="label" text-anchor="end">{tokens}</text>"#,
+                tx = x + 290,
+            )
+            .unwrap();
+
+            let ratio = if max_cost > 0.0 {
+                model.cost_usd / max_cost
+            } else {
+                0.0
+            };
+            let bar_w = (ratio * BAR_MAX_W as f64).round() as u32;
+            if bar_w > 0 {
+                let bar_x = x + 300;
+                let bar_y = y - BAR_HEIGHT + 3;
+                let color = color_for(i);
+                write!(
+                    svg,
+                    r#"<rect x="{bar_x}" y="{bar_y}" width="{bar_w}" height="{BAR_HEIGHT}" class="bar" fill="{color}" opacity="0.8"/>"#,
+                )
+                .unwrap();
+            }
+        }
+    }
+
+    // By Source
+    if !data.by_source.is_empty() {
+        y += SECTION_GAP;
+        svg_separator(&mut svg, x, right, y);
+        y += LINE_HEIGHT;
+        write!(
+            svg,
+            r#"<text x="{x}" y="{y}" class="section">BY SOURCE</text>"#
+        )
+        .unwrap();
+
+        for source in &data.by_source {
+            y += LINE_HEIGHT;
+            let name = escape_xml(&source.name);
+            let cost = format_cost(source.cost_usd);
+            let tokens = format_tokens(source.total_tokens);
+
+            write!(svg, r#"<text x="{x}" y="{y}" class="label">{name}</text>"#).unwrap();
+            write!(
+                svg,
+                r#"<text x="{mx}" y="{y}" class="value" text-anchor="end">{cost}</text>"#,
+                mx = x + 220,
+            )
+            .unwrap();
+            write!(
+                svg,
+                r#"<text x="{tx}" y="{y}" class="label" text-anchor="end">{tokens}</text>"#,
+                tx = x + 290,
+            )
+            .unwrap();
+        }
+    }
+
+    // Daily breakdown
+    if !data.daily.is_empty() {
+        y += SECTION_GAP;
+        svg_separator(&mut svg, x, right, y);
+        y += LINE_HEIGHT;
+        write!(
+            svg,
+            r#"<text x="{x}" y="{y}" class="section">DAILY BREAKDOWN</text>"#
+        )
+        .unwrap();
+
+        let max_cost = data
+            .daily
+            .iter()
+            .map(|d| d.cost_usd)
+            .fold(0.0_f64, f64::max);
+
+        for (i, day) in data.daily.iter().enumerate() {
+            y += LINE_HEIGHT;
+            let date_str = day.date.format("%m/%d").to_string();
+            let cost = format_cost(day.cost_usd);
+
+            write!(
+                svg,
+                r#"<text x="{x}" y="{y}" class="label">{date_str}</text>"#
+            )
+            .unwrap();
+            write!(
+                svg,
+                r#"<text x="{mx}" y="{y}" class="value" text-anchor="end">{cost}</text>"#,
+                mx = x + 140,
+            )
+            .unwrap();
+
+            let ratio = if max_cost > 0.0 {
+                day.cost_usd / max_cost
+            } else {
+                0.0
+            };
+            let bar_w = (ratio * (INNER_W - 180) as f64).round() as u32;
+            if bar_w > 0 {
+                let bar_x = x + 150;
+                let bar_y = y - BAR_HEIGHT + 3;
+                let color = color_for(i);
+                write!(
+                    svg,
+                    r#"<rect x="{bar_x}" y="{bar_y}" width="{bar_w}" height="{BAR_HEIGHT}" class="bar" fill="{color}" opacity="0.7"/>"#,
+                )
+                .unwrap();
+            }
+        }
+    }
+
+    // Most expensive day highlight
+    if let Some(ref day) = data.most_expensive_day {
+        y += SECTION_GAP;
+        svg_separator(&mut svg, x, right, y);
+        y += LINE_HEIGHT;
+        let highlight = format!(
+            "Peak: {} ({})",
+            day.date.format("%Y-%m-%d"),
+            format_cost(day.cost_usd)
+        );
+        write!(
+            svg,
+            r#"<text x="{cx}" y="{y}" class="label" text-anchor="middle">{}</text>"#,
+            escape_xml(&highlight),
+        )
+        .unwrap();
+    }
+
+    // Footer
+    y += SECTION_GAP;
+    svg_separator(&mut svg, x, right, y);
+    y += LINE_HEIGHT;
+    write!(
+        svg,
+        r#"<text x="{cx}" y="{y}" class="footer" text-anchor="middle">Generated by toktrack · github.com/mag123c/toktrack</text>"#,
+    )
+    .unwrap();
+
+    svg.push_str("\n</svg>");
+    svg
+}
+
+fn svg_separator(svg: &mut String, x: u32, right: u32, y: u32) {
+    write!(
+        svg,
+        r#"<line x1="{x}" y1="{y}" x2="{right}" y2="{y}" class="separator"/>"#,
+    )
+    .unwrap();
+}
+
+fn svg_label_value(svg: &mut String, x: u32, right: u32, y: u32, label: &str, value: &str) {
+    write!(
+        svg,
+        r#"<text x="{x}" y="{y}" class="label">{label}</text><text x="{right}" y="{y}" class="value" text-anchor="end">{value}</text>"#,
+    )
+    .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::data::{DayReport, ModelReport, ReportData, SourceReport};
+    use chrono::NaiveDate;
+
+    fn sample_data() -> ReportData {
+        ReportData {
+            period_label: "2024-01-01 ~ 2024-01-07".to_string(),
+            total_cost: 42.37,
+            total_input_tokens: 1_234_567,
+            total_output_tokens: 567_890,
+            active_days: 5,
+            total_days: 7,
+            by_model: vec![ModelReport {
+                name: "Opus 4.5".to_string(),
+                input_tokens: 800_000,
+                output_tokens: 400_000,
+                cost_usd: 30.00,
+                count: 50,
+            }],
+            by_source: vec![SourceReport {
+                name: "claude".to_string(),
+                total_tokens: 1_802_457,
+                cost_usd: 42.37,
+            }],
+            daily: vec![DayReport {
+                date: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+                total_tokens: 300_000,
+                cost_usd: 8.50,
+            }],
+            most_expensive_day: Some(DayReport {
+                date: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+                total_tokens: 300_000,
+                cost_usd: 8.50,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_valid_svg_structure() {
+        let output = render(&sample_data());
+        assert!(output.contains("<svg"));
+        assert!(output.contains("</svg>"));
+        assert!(output.contains("AI CODING RECEIPT"));
+        assert!(output.contains("github.com/mag123c/toktrack"));
+    }
+
+    #[test]
+    fn test_svg_contains_data() {
+        let output = render(&sample_data());
+        assert!(output.contains("$42.37"));
+        assert!(output.contains("Opus 4.5"));
+        assert!(output.contains("claude"));
+        assert!(output.contains("01/01"));
+    }
+
+    #[test]
+    fn test_empty_data_no_crash() {
+        let data = ReportData {
+            period_label: "2024-01-01 ~ 2024-01-07".to_string(),
+            total_cost: 0.0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            active_days: 0,
+            total_days: 7,
+            by_model: vec![],
+            by_source: vec![],
+            daily: vec![],
+            most_expensive_day: None,
+        };
+        let output = render(&data);
+        assert!(output.contains("<svg"));
+        assert!(output.contains("</svg>"));
+    }
+
+    #[test]
+    fn test_xml_escaping() {
+        let data = ReportData {
+            period_label: "test <>&\"".to_string(),
+            total_cost: 0.0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            active_days: 0,
+            total_days: 1,
+            by_model: vec![],
+            by_source: vec![],
+            daily: vec![],
+            most_expensive_day: None,
+        };
+        let output = render(&data);
+        assert!(output.contains("&lt;"));
+        assert!(output.contains("&gt;"));
+        assert!(output.contains("&amp;"));
+    }
+}

--- a/src/report/text.rs
+++ b/src/report/text.rs
@@ -1,0 +1,344 @@
+//! Terminal text renderer for usage reports
+
+use crate::report::data::ReportData;
+
+/// Format token count: 1234567 → "1.2M", 12345 → "12.3K", 999 → "999"
+fn format_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        format!("{}", n)
+    }
+}
+
+/// Format cost: 42.373 → "$42.37"
+fn format_cost(cost: f64) -> String {
+    format!("${:.2}", cost)
+}
+
+/// Render a horizontal bar using block chars
+fn render_bar(ratio: f64, max_width: usize) -> String {
+    let filled = (ratio * max_width as f64).round() as usize;
+    let filled = filled.min(max_width);
+    "\u{2588}".repeat(filled)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max - 1).collect();
+        format!("{}\u{2026}", truncated)
+    }
+}
+
+/// Render report data as a terminal text receipt
+pub fn render(data: &ReportData) -> String {
+    let w = 48usize;
+    let mut out = String::new();
+
+    // Top border
+    out.push_str(&format!("\u{256d}{}\u{256e}\n", "\u{2500}".repeat(w)));
+
+    // Header
+    center_line(&mut out, w, "AI CODING RECEIPT");
+    center_line(&mut out, w, &data.period_label);
+
+    // Separator
+    out.push_str(&format!("\u{2502}{}\u{2502}\n", "\u{2508}".repeat(w)));
+
+    // Summary
+    kv_line(&mut out, w, "Total Cost", &format_cost(data.total_cost));
+    kv_line(
+        &mut out,
+        w,
+        "Input Tokens",
+        &format_tokens(data.total_input_tokens),
+    );
+    kv_line(
+        &mut out,
+        w,
+        "Output Tokens",
+        &format_tokens(data.total_output_tokens),
+    );
+    kv_line(
+        &mut out,
+        w,
+        "Active Days",
+        &format!("{}/{}", data.active_days, data.total_days),
+    );
+
+    // By Model
+    if !data.by_model.is_empty() {
+        out.push_str(&format!("\u{2502}{}\u{2502}\n", "\u{2508}".repeat(w)));
+        section_title(&mut out, w, "BY MODEL");
+
+        let max_cost = data
+            .by_model
+            .iter()
+            .map(|m| m.cost_usd)
+            .fold(0.0_f64, f64::max);
+        let bar_width = 16;
+
+        for model in &data.by_model {
+            let ratio = if max_cost > 0.0 {
+                model.cost_usd / max_cost
+            } else {
+                0.0
+            };
+            let bar = render_bar(ratio, bar_width);
+            let name = truncate(&model.name, 14);
+            let cost = format_cost(model.cost_usd);
+            let tokens = format_tokens(model.input_tokens.saturating_add(model.output_tokens));
+
+            // "  name           $cost  tokens bar   "
+            let bar_chars = bar.chars().count();
+            let remaining = w.saturating_sub(33 + bar_chars);
+            out.push_str(&format!(
+                "\u{2502}  {:<14} {:>8} {:>6} {}{}\u{2502}\n",
+                name,
+                cost,
+                tokens,
+                bar,
+                " ".repeat(remaining)
+            ));
+        }
+    }
+
+    // By Source
+    if !data.by_source.is_empty() {
+        out.push_str(&format!("\u{2502}{}\u{2502}\n", "\u{2508}".repeat(w)));
+        section_title(&mut out, w, "BY SOURCE");
+
+        for source in &data.by_source {
+            let name = truncate(&source.name, 14);
+            let cost = format_cost(source.cost_usd);
+            let tokens = format_tokens(source.total_tokens);
+            let remaining = w.saturating_sub(32);
+            out.push_str(&format!(
+                "\u{2502}  {:<14} {:>8} {:>6}{}\u{2502}\n",
+                name,
+                cost,
+                tokens,
+                " ".repeat(remaining)
+            ));
+        }
+    }
+
+    // Daily
+    if !data.daily.is_empty() {
+        out.push_str(&format!("\u{2502}{}\u{2502}\n", "\u{2508}".repeat(w)));
+        section_title(&mut out, w, "DAILY BREAKDOWN");
+
+        let max_cost = data
+            .daily
+            .iter()
+            .map(|d| d.cost_usd)
+            .fold(0.0_f64, f64::max);
+        let bar_width = 16;
+
+        for day in &data.daily {
+            let date_str = day.date.format("%m/%d").to_string();
+            let cost = format_cost(day.cost_usd);
+            let ratio = if max_cost > 0.0 {
+                day.cost_usd / max_cost
+            } else {
+                0.0
+            };
+            let bar = render_bar(ratio, bar_width);
+            let bar_chars = bar.chars().count();
+            let remaining = w.saturating_sub(16 + bar_chars + 1);
+            out.push_str(&format!(
+                "\u{2502}  {} {:>8} {}{}\u{2502}\n",
+                date_str,
+                cost,
+                bar,
+                " ".repeat(remaining)
+            ));
+        }
+    }
+
+    // Highlight: most expensive day
+    if let Some(ref day) = data.most_expensive_day {
+        out.push_str(&format!("\u{2502}{}\u{2502}\n", "\u{2508}".repeat(w)));
+        let highlight = format!(
+            "Peak: {} ({})",
+            day.date.format("%Y-%m-%d"),
+            format_cost(day.cost_usd)
+        );
+        center_line(&mut out, w, &highlight);
+    }
+
+    // Footer
+    out.push_str(&format!("\u{2502}{}\u{2502}\n", "\u{2508}".repeat(w)));
+    center_line(&mut out, w, "Generated by toktrack");
+
+    // Bottom border
+    out.push_str(&format!("\u{2570}{}\u{256f}", "\u{2500}".repeat(w)));
+
+    out
+}
+
+fn center_line(out: &mut String, w: usize, text: &str) {
+    let text_len = text.chars().count();
+    let pad_left = w.saturating_sub(text_len) / 2;
+    let pad_right = w.saturating_sub(text_len + pad_left);
+    out.push_str(&format!(
+        "\u{2502}{}{}{}\u{2502}\n",
+        " ".repeat(pad_left),
+        text,
+        " ".repeat(pad_right)
+    ));
+}
+
+fn section_title(out: &mut String, w: usize, title: &str) {
+    let remaining = w.saturating_sub(title.len() + 1);
+    out.push_str(&format!(
+        "\u{2502} {}{}\u{2502}\n",
+        title,
+        " ".repeat(remaining)
+    ));
+}
+
+fn kv_line(out: &mut String, w: usize, key: &str, value: &str) {
+    // " key............ value "
+    let key_len = key.len();
+    let val_len = value.len();
+    let dots = w.saturating_sub(key_len + val_len + 3); // 2 spaces + 1 padding
+    out.push_str(&format!(
+        "\u{2502} {}{} {:>val_w$}\u{2502}\n",
+        key,
+        ".".repeat(dots),
+        value,
+        val_w = val_len
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::data::{DayReport, ModelReport, ReportData, SourceReport};
+    use chrono::NaiveDate;
+
+    fn sample_data() -> ReportData {
+        ReportData {
+            period_label: "2024-01-01 ~ 2024-01-07".to_string(),
+            total_cost: 42.37,
+            total_input_tokens: 1_234_567,
+            total_output_tokens: 567_890,
+            active_days: 5,
+            total_days: 7,
+            by_model: vec![
+                ModelReport {
+                    name: "Opus 4.5".to_string(),
+                    input_tokens: 800_000,
+                    output_tokens: 400_000,
+                    cost_usd: 30.00,
+                    count: 50,
+                },
+                ModelReport {
+                    name: "Sonnet 4".to_string(),
+                    input_tokens: 434_567,
+                    output_tokens: 167_890,
+                    cost_usd: 12.37,
+                    count: 30,
+                },
+            ],
+            by_source: vec![SourceReport {
+                name: "claude".to_string(),
+                total_tokens: 1_802_457,
+                cost_usd: 42.37,
+            }],
+            daily: vec![
+                DayReport {
+                    date: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+                    total_tokens: 300_000,
+                    cost_usd: 8.50,
+                },
+                DayReport {
+                    date: NaiveDate::from_ymd_opt(2024, 1, 2).unwrap(),
+                    total_tokens: 500_000,
+                    cost_usd: 15.00,
+                },
+            ],
+            most_expensive_day: Some(DayReport {
+                date: NaiveDate::from_ymd_opt(2024, 1, 2).unwrap(),
+                total_tokens: 500_000,
+                cost_usd: 15.00,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_render_contains_sections() {
+        let output = render(&sample_data());
+        assert!(output.contains("AI CODING RECEIPT"));
+        assert!(output.contains("2024-01-01 ~ 2024-01-07"));
+        assert!(output.contains("$42.37"));
+        assert!(output.contains("BY MODEL"));
+        assert!(output.contains("Opus 4.5"));
+        assert!(output.contains("Sonnet 4"));
+        assert!(output.contains("BY SOURCE"));
+        assert!(output.contains("claude"));
+        assert!(output.contains("DAILY BREAKDOWN"));
+        assert!(output.contains("Generated by toktrack"));
+    }
+
+    #[test]
+    fn test_render_empty_data() {
+        let data = ReportData {
+            period_label: "2024-01-01 ~ 2024-01-07".to_string(),
+            total_cost: 0.0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            active_days: 0,
+            total_days: 7,
+            by_model: vec![],
+            by_source: vec![],
+            daily: vec![],
+            most_expensive_day: None,
+        };
+        let output = render(&data);
+        assert!(output.contains("AI CODING RECEIPT"));
+        assert!(output.contains("$0.00"));
+        assert!(!output.contains("BY MODEL"));
+    }
+
+    #[test]
+    fn test_format_tokens() {
+        assert_eq!(format_tokens(999), "999");
+        assert_eq!(format_tokens(1_000), "1.0K");
+        assert_eq!(format_tokens(12_345), "12.3K");
+        assert_eq!(format_tokens(1_234_567), "1.2M");
+    }
+
+    #[test]
+    fn test_format_cost() {
+        assert_eq!(format_cost(0.0), "$0.00");
+        assert_eq!(format_cost(42.373), "$42.37");
+        assert_eq!(format_cost(1.5), "$1.50");
+    }
+
+    #[test]
+    fn test_box_drawing_borders() {
+        let output = render(&sample_data());
+        let lines: Vec<&str> = output.lines().collect();
+        // First line starts with ╭
+        assert!(lines[0].starts_with('\u{256d}'));
+        // Last line starts with ╰ and ends with ╯
+        let last = lines.last().unwrap();
+        assert!(last.starts_with('\u{2570}'));
+        assert!(last.ends_with('\u{256f}'));
+        // Middle lines have │ borders
+        for line in &lines[1..lines.len() - 1] {
+            assert!(
+                line.starts_with('\u{2502}'),
+                "Missing left border: {}",
+                line
+            );
+            assert!(line.ends_with('\u{2502}'), "Missing right border: {}", line);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `toktrack report` 서브커맨드 추가 — 기간별 AI 코딩 사용량 영수증 생성
- 터미널 텍스트(box-drawing) + SVG 두 가지 렌더러 지원
- `--week` (기본), `--month`, `--days N` 기간 옵션 + `--svg [PATH]` 출력

## Changes
| File | Description |
|------|-------------|
| `src/report/data.rs` | `ReportData` 중간 구조체 + `from_summaries()` 기간 필터링 |
| `src/report/text.rs` | Box-drawing 터미널 영수증 렌더러 |
| `src/report/svg.rs` | 600px SVG 영수증 렌더러 (외부 크레이트 없음) |
| `src/cli/mod.rs` | `Commands::Report` + clap period group + `run_report()` |

## Test plan
- [x] `make check` (fmt + clippy + test) 통과 — 412 tests
- [ ] CI (3 OS) 통과 확인
- [ ] `cargo run -- report --week` 텍스트 출력 확인
- [ ] `cargo run -- report --month --svg` SVG 파일 생성 확인
- [ ] 브라우저에서 SVG 레이아웃/가독성 확인