### PR TITLE
feat(ci): add Homebrew tap support (#123)

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -1,0 +1,31 @@
+name: Bump Homebrew Formula
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to bump formula to (e.g., v2.5.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    name: Bump formula in tap repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bump Homebrew formula
+        uses: dawidd6/action-homebrew-bump-formula@v6
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          tap: mag123c/homebrew-toktrack
+          formula: toktrack
+          tag: ${{ inputs.tag }}
+          force: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,20 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: toktrack-darwin-arm64
+            brew: true
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact: toktrack-darwin-x64
+            brew: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: toktrack-linux-x64
+            brew: true
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact: toktrack-linux-arm64
             cross: true
+            brew: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             artifact: toktrack-linux-musl-x64
@@ -100,6 +104,21 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
+
+      - name: Package tar.gz for Homebrew
+        if: matrix.brew
+        env:
+          COPYFILE_DISABLE: 1
+        run: |
+          tar czf ${{ matrix.artifact }}.tar.gz -C target/${{ matrix.target }}/release toktrack
+          shasum -a 256 ${{ matrix.artifact }}.tar.gz
+
+      - name: Upload tar.gz artifact
+        if: matrix.brew
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact }}.tar.gz
+          path: ${{ matrix.artifact }}.tar.gz
 
   release:
     name: Create Release
@@ -162,3 +181,11 @@ jobs:
         run: cd npm && npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  bump-homebrew:
+    name: Bump Homebrew Formula
+    needs: release
+    uses: ./.github/workflows/bump-homebrew.yml
+    with:
+      tag: ${{ inputs.tag }}
+    secrets: inherit

--- a/README.ko.md
+++ b/README.ko.md
@@ -55,6 +55,13 @@ npx toktrack
 bunx toktrack
 ```
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew tap mag123c/toktrack
+brew install toktrack
+```
+
 ### 소스에서 설치
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ npx toktrack
 bunx toktrack
 ```
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew tap mag123c/toktrack
+brew install toktrack
+```
+
 ### From Source
 
 ```bash


### PR DESCRIPTION
## Summary

- Package tar.gz artifacts for darwin arm64/x64 and linux x64/arm64 alongside existing raw binaries (npm publish path unaffected)
- Add reusable `bump-homebrew` workflow (`workflow_call` + `workflow_dispatch`) chained from `release.yml` via `needs: release`
- Document `brew tap mag123c/toktrack && brew install toktrack` in README

Refs #123. The issue will be closed only after `brew install toktrack` is verified end-to-end (requires seed formula in tap repo + first successful bump cycle post-merge + actual install test).

## Design notes

Chose **workflow_call chain** over `on: release.published` trigger because GitHub Releases created with the default `GITHUB_TOKEN` do not trigger downstream workflows. The chain runs `bump-homebrew` after the `release` job completes, so GH Release (with tar.gz assets) exists before the bump action fetches sha256.

Failure isolation:
- `publish-npm` is `needs: build` → independent of `release` and `bump-homebrew`
- `bump-homebrew` is `needs: release` → runs after GH Release exists; failure doesn't affect release or npm publish (only marks workflow red cosmetically)

## Required external setup

1. `mag123c/homebrew-toktrack` public tap repo — **created**
2. `HOMEBREW_TAP_TOKEN` secret — fine-grained PAT scoped to tap repo only (Contents + PRs: read/write) — **added**
3. Seed `Formula/toktrack.rb` in tap repo — must be committed after the first release with tar.gz assets lands (using actual sha256 from released artifacts). Template at `.dev/specs/homebrew-tap/toktrack.rb.seed` (local-only)

First release after merge is expected to fail the bump step (seed missing) — recoverable via manual seed commit + `workflow_dispatch`.

## Acceptance (issue #123 close criteria)

- [ ] CI green (fmt, clippy, test on 3 OS)
- [ ] After merge + next release: tar.gz artifacts on GH Release
- [ ] Existing raw binaries + npm publish intact
- [ ] Seed formula committed to tap repo with real sha256
- [ ] `workflow_dispatch` (or next release) bumps formula successfully → PR in tap repo
- [ ] `brew tap mag123c/toktrack && brew install toktrack && toktrack --version` succeeds on clean macOS
- [ ] Close #123 manually