### PR TITLE
fix(clippy): resolve lints introduced in rust 1.95

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -167,7 +167,7 @@ fn run_report(_week: bool, month: bool, days: Option<u32>, svg: Option<PathBuf>)
 /// Output daily summaries as JSON
 fn run_daily_json() -> Result<()> {
     let mut summaries = load_data()?;
-    summaries.sort_by(|a, b| b.date.cmp(&a.date));
+    summaries.sort_by_key(|b| std::cmp::Reverse(b.date));
     println!(
         "{}",
         serde_json::to_string_pretty(&summaries)
@@ -180,7 +180,7 @@ fn run_daily_json() -> Result<()> {
 fn run_weekly_json() -> Result<()> {
     let summaries = load_data()?;
     let mut weekly = Aggregator::weekly(&summaries);
-    weekly.sort_by(|a, b| b.date.cmp(&a.date));
+    weekly.sort_by_key(|b| std::cmp::Reverse(b.date));
     println!(
         "{}",
         serde_json::to_string_pretty(&weekly).map_err(|e| ToktrackError::Parse(e.to_string()))?
@@ -192,7 +192,7 @@ fn run_weekly_json() -> Result<()> {
 fn run_monthly_json() -> Result<()> {
     let summaries = load_data()?;
     let mut monthly = Aggregator::monthly(&summaries);
-    monthly.sort_by(|a, b| b.date.cmp(&a.date));
+    monthly.sort_by_key(|b| std::cmp::Reverse(b.date));
     println!(
         "{}",
         serde_json::to_string_pretty(&monthly).map_err(|e| ToktrackError::Parse(e.to_string()))?

--- a/src/services/aggregator.rs
+++ b/src/services/aggregator.rs
@@ -351,7 +351,7 @@ impl Aggregator {
             .collect();
 
         // Sort by total_tokens descending
-        result.sort_by(|a, b| b.total_tokens.cmp(&a.total_tokens));
+        result.sort_by_key(|b| std::cmp::Reverse(b.total_tokens));
         result
     }
 

--- a/src/services/data_loader.rs
+++ b/src/services/data_loader.rs
@@ -335,7 +335,7 @@ impl DataLoaderService {
             })
             .collect();
         // Sort by total_tokens descending
-        result.sort_by(|a, b| b.total_tokens.cmp(&a.total_tokens));
+        result.sort_by_key(|b| std::cmp::Reverse(b.total_tokens));
         result
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -299,10 +299,8 @@ impl App {
         // Tab-specific keys
         match self.current_tab() {
             Tab::Overview => match code {
-                KeyCode::Up | KeyCode::Char('k') => {
-                    if self.source_selected > 0 {
-                        self.source_selected -= 1;
-                    }
+                KeyCode::Up | KeyCode::Char('k') if self.source_selected > 0 => {
+                    self.source_selected -= 1;
                 }
                 KeyCode::Down | KeyCode::Char('j') => {
                     if let AppState::Ready { data } = &self.state {


### PR DESCRIPTION
## Summary

CI (`dtolnay/rust-toolchain@stable`) now pulls rust 1.95.0, which enabled two clippy lints that flag pre-existing code. PRs are failing CI even though the flagged code wasn't modified.

## Fixes

| Lint | Count | Sites |
|------|-------|-------|
| `unnecessary_sort_by` | 5 | `src/cli/mod.rs` (3), `src/services/aggregator.rs`, `src/services/data_loader.rs` |
| `collapsible_match` | 1 | `src/tui/app.rs` |

All changes are mechanical clippy-auto-suggested rewrites. Behavior unchanged (449 tests pass locally on rust 1.95.0).

## Why merge this first

Opened to unblock CI on #125 (Homebrew tap). Green main → rebase feature branches → clean merge. Avoids bundling unrelated fixes into feature PRs.

## Test plan

- [ ] CI green (fmt, clippy, test) on 3 OS with rust 1.95