### PR TITLE
docs(npm): add Homebrew section, remove dead crates.io badge

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -1,7 +1,6 @@
 # toktrack
 
 [![CI](https://github.com/mag123c/toktrack/actions/workflows/ci.yml/badge.svg)](https://github.com/mag123c/toktrack/actions/workflows/ci.yml)
-[![Crates.io](https://img.shields.io/crates/v/toktrack)](https://crates.io/crates/toktrack)
 [![npm](https://img.shields.io/npm/v/toktrack)](https://www.npmjs.com/package/toktrack)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/mag123c/toktrack/blob/main/LICENSE)
 
@@ -27,6 +26,13 @@ npx toktrack
 
 # Or install globally
 npm install -g toktrack
+```
+
+### Homebrew (macOS / Linux)
+
+```bash
+brew tap mag123c/toktrack
+brew install toktrack
 ```
 
 ## Features


### PR DESCRIPTION
## Summary

Two small updates to `npm/README.md` (the README shown on npmjs.com):

1. Add Homebrew install section alongside npx/npm -g — lets macOS/Linux npm visitors discover the `brew tap` path.
2. Remove Crates.io badge — `toktrack` has never been published to crates.io, the badge link returns 404.

## Scope

`npm/README.md` only. Main `README.md` / `README.ko.md` already had the Homebrew section (from #125) and already lacked the crates.io badge — this aligns the npm-facing doc.

## Rollout note

Takes effect on the next npm publish (next release-please cycle). The already-published `toktrack@2.5.0` package page keeps the old README — that's how npmjs.com works.