### PR TITLE
feat(services): expose provider info in JSON model breakdown (#134)

### DIFF
--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -30,7 +30,7 @@ struct CodexPayload {
     #[serde(default)]
     id: Option<String>,
     #[serde(default)]
-    model_provider_id: Option<String>,
+    model_provider: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -104,12 +104,12 @@ impl CodexParser {
         }
 
         if data.line_type == "session_meta" {
-            if payload.id.is_none() && payload.model_provider_id.is_none() {
+            if payload.id.is_none() && payload.model_provider.is_none() {
                 return ParseResult::Skip;
             }
             return ParseResult::SessionMeta {
                 id: payload.id.clone(),
-                provider: payload.model_provider_id.clone(),
+                provider: payload.model_provider.clone(),
             };
         }
 
@@ -412,21 +412,25 @@ mod tests {
 
     #[test]
     fn test_provider_extracted_from_session_meta() {
-        // session_meta.payload.model_provider_id 가 있으면 모든 entry 의 provider 에 반영
+        // 실 Codex CLI v0.116+ 의 session_meta.payload.model_provider 추출 검증
+        // (실데이터 schema 기준 — `model_provider`, 소문자 값)
         let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
         let entries = parser
-            .parse_file(&fixture_path("bedrock-session.jsonl"))
+            .parse_file(&fixture_path("openai-session.jsonl"))
             .unwrap();
 
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].provider, Some("AmazonBedrock".to_string()));
+        assert_eq!(entries[0].provider, Some("openai".to_string()));
         assert_eq!(entries[0].model, Some("o4-mini".to_string()));
-        assert_eq!(entries[0].message_id, Some("session-bedrock".to_string()));
+        assert_eq!(
+            entries[0].message_id,
+            Some("019d2e4c-e19a-7662-b2eb-0629d5ddd78b".to_string())
+        );
     }
 
     #[test]
     fn test_provider_resets_when_later_session_meta_omits_it() {
-        // 두 번째 session_meta 가 model_provider_id 를 생략하면
+        // 두 번째 session_meta 가 model_provider 를 생략하면
         // 이전 provider 가 sticky 하게 남으면 안 됨 (잘못된 비용 귀속 방지)
         let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
         let entries = parser
@@ -434,12 +438,18 @@ mod tests {
             .unwrap();
 
         assert_eq!(entries.len(), 2);
-        // 첫 entry: Bedrock session
-        assert_eq!(entries[0].provider, Some("AmazonBedrock".to_string()));
-        assert_eq!(entries[0].message_id, Some("session-bedrock".to_string()));
-        // 두 번째 entry: provider 가 None 으로 리셋 — Bedrock 으로 sticky 되면 안 됨
+        // 첫 entry: provider 가 있는 session
+        assert_eq!(entries[0].provider, Some("openai".to_string()));
+        assert_eq!(
+            entries[0].message_id,
+            Some("session-with-provider".to_string())
+        );
+        // 두 번째 entry: provider 가 None 으로 리셋 — sticky 되면 안 됨
         assert_eq!(entries[1].provider, None);
-        assert_eq!(entries[1].message_id, Some("session-direct".to_string()));
+        assert_eq!(
+            entries[1].message_id,
+            Some("session-without-provider".to_string())
+        );
     }
 
     #[test]

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -412,8 +412,8 @@ mod tests {
 
     #[test]
     fn test_provider_extracted_from_session_meta() {
-        // 실 Codex CLI v0.116+ 의 session_meta.payload.model_provider 추출 검증
-        // (실데이터 schema 기준 — `model_provider`, 소문자 값)
+        // Real Codex CLI v0.116+ writes `session_meta.payload.model_provider`
+        // as a lowercase string (e.g. "openai"); verified against live data.
         let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
         let entries = parser
             .parse_file(&fixture_path("openai-session.jsonl"))
@@ -430,21 +430,19 @@ mod tests {
 
     #[test]
     fn test_provider_resets_when_later_session_meta_omits_it() {
-        // 두 번째 session_meta 가 model_provider 를 생략하면
-        // 이전 provider 가 sticky 하게 남으면 안 됨 (잘못된 비용 귀속 방지)
+        // A later session_meta without model_provider must clear the previous
+        // value; sticking would silently misattribute billing.
         let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
         let entries = parser
             .parse_file(&fixture_path("multi-session-meta.jsonl"))
             .unwrap();
 
         assert_eq!(entries.len(), 2);
-        // 첫 entry: provider 가 있는 session
         assert_eq!(entries[0].provider, Some("openai".to_string()));
         assert_eq!(
             entries[0].message_id,
             Some("session-with-provider".to_string())
         );
-        // 두 번째 entry: provider 가 None 으로 리셋 — sticky 되면 안 됨
         assert_eq!(entries[1].provider, None);
         assert_eq!(
             entries[1].message_id,
@@ -454,7 +452,7 @@ mod tests {
 
     #[test]
     fn test_provider_none_when_session_meta_lacks_provider() {
-        // model_provider_id 가 없으면 provider=None (기존 fixture 회귀 검증)
+        // Regression: legacy fixture without model_provider must keep provider=None.
         let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
         let entries = parser
             .parse_file(&fixture_path("sample-session.jsonl"))

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -29,6 +29,8 @@ struct CodexPayload {
     info: Option<CodexInfo>,
     #[serde(default)]
     id: Option<String>,
+    #[serde(default)]
+    model_provider_id: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -102,10 +104,13 @@ impl CodexParser {
         }
 
         if data.line_type == "session_meta" {
-            if let Some(ref id) = payload.id {
-                return ParseResult::SessionId(id.clone());
+            if payload.id.is_none() && payload.model_provider_id.is_none() {
+                return ParseResult::Skip;
             }
-            return ParseResult::Skip;
+            return ParseResult::SessionMeta {
+                id: payload.id.clone(),
+                provider: payload.model_provider_id.clone(),
+            };
         }
 
         if data.line_type != "event_msg" {
@@ -154,7 +159,10 @@ impl CodexParser {
 enum ParseResult {
     Skip,
     Model(String),
-    SessionId(String),
+    SessionMeta {
+        id: Option<String>,
+        provider: Option<String>,
+    },
     TokenCount(TokenCountData),
 }
 
@@ -183,6 +191,7 @@ impl CLIParser for CodexParser {
         let mut entries: Vec<UsageEntry> = Vec::new();
         let mut current_model: Option<String> = None;
         let mut session_id: Option<String> = None;
+        let mut current_provider: Option<String> = None;
         let mut prev_totals = CodexTokenUsage {
             input_tokens: 0,
             output_tokens: 0,
@@ -203,7 +212,15 @@ impl CLIParser for CodexParser {
             match self.parse_line(&mut line_bytes) {
                 ParseResult::Skip => {}
                 ParseResult::Model(m) => current_model = Some(m),
-                ParseResult::SessionId(id) => session_id = Some(id),
+                ParseResult::SessionMeta { id, provider } => {
+                    if let Some(id) = id {
+                        session_id = Some(id);
+                    }
+                    // Replace unconditionally: if a later session_meta lacks
+                    // model_provider_id, the previous provider must NOT stick —
+                    // sticking would silently misattribute billing.
+                    current_provider = provider;
+                }
                 ParseResult::TokenCount(data) => {
                     // Compute delta: prefer last_token_usage, fallback to diff
                     let (delta_input, delta_output, delta_cached) =
@@ -252,7 +269,7 @@ impl CLIParser for CodexParser {
                         message_id: session_id.clone(),
                         request_id: None,
                         source: Some("codex".into()),
-                        provider: None,
+                        provider: current_provider.clone(),
                     });
                 }
             }
@@ -389,5 +406,53 @@ mod tests {
         let parser = CodexParser::new();
         let result = parser.parse_file(Path::new("/nonexistent/file.jsonl"));
         assert!(result.is_err());
+    }
+
+    // ========== Issue #134: provider extraction from session_meta ==========
+
+    #[test]
+    fn test_provider_extracted_from_session_meta() {
+        // session_meta.payload.model_provider_id 가 있으면 모든 entry 의 provider 에 반영
+        let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
+        let entries = parser
+            .parse_file(&fixture_path("bedrock-session.jsonl"))
+            .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].provider, Some("AmazonBedrock".to_string()));
+        assert_eq!(entries[0].model, Some("o4-mini".to_string()));
+        assert_eq!(entries[0].message_id, Some("session-bedrock".to_string()));
+    }
+
+    #[test]
+    fn test_provider_resets_when_later_session_meta_omits_it() {
+        // 두 번째 session_meta 가 model_provider_id 를 생략하면
+        // 이전 provider 가 sticky 하게 남으면 안 됨 (잘못된 비용 귀속 방지)
+        let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
+        let entries = parser
+            .parse_file(&fixture_path("multi-session-meta.jsonl"))
+            .unwrap();
+
+        assert_eq!(entries.len(), 2);
+        // 첫 entry: Bedrock session
+        assert_eq!(entries[0].provider, Some("AmazonBedrock".to_string()));
+        assert_eq!(entries[0].message_id, Some("session-bedrock".to_string()));
+        // 두 번째 entry: provider 가 None 으로 리셋 — Bedrock 으로 sticky 되면 안 됨
+        assert_eq!(entries[1].provider, None);
+        assert_eq!(entries[1].message_id, Some("session-direct".to_string()));
+    }
+
+    #[test]
+    fn test_provider_none_when_session_meta_lacks_provider() {
+        // model_provider_id 가 없으면 provider=None (기존 fixture 회귀 검증)
+        let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
+        let entries = parser
+            .parse_file(&fixture_path("sample-session.jsonl"))
+            .unwrap();
+
+        assert!(!entries.is_empty());
+        for entry in &entries {
+            assert_eq!(entry.provider, None);
+        }
     }
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -224,7 +224,7 @@ mod tests {
         let files = parser.collect_files();
         // claude-sample.jsonl, empty.jsonl, multi/file1.jsonl, multi/file2.jsonl,
         // codex/sample-session.jsonl, codex/multi-turn-session.jsonl,
-        // codex/bedrock-session.jsonl, codex/multi-session-meta.jsonl,
+        // codex/openai-session.jsonl, codex/multi-session-meta.jsonl,
         // pi_agent/sample-session.jsonl
         assert_eq!(files.len(), 9);
     }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -222,7 +222,10 @@ mod tests {
     fn test_collect_files() {
         let parser = ClaudeCodeParser::with_data_dir(PathBuf::from("tests/fixtures"));
         let files = parser.collect_files();
-        // claude-sample.jsonl, empty.jsonl, multi/file1.jsonl, multi/file2.jsonl, codex/sample-session.jsonl, codex/multi-turn-session.jsonl, pi_agent/sample-session.jsonl
-        assert_eq!(files.len(), 7);
+        // claude-sample.jsonl, empty.jsonl, multi/file1.jsonl, multi/file2.jsonl,
+        // codex/sample-session.jsonl, codex/multi-turn-session.jsonl,
+        // codex/bedrock-session.jsonl, codex/multi-session-meta.jsonl,
+        // pi_agent/sample-session.jsonl
+        assert_eq!(files.len(), 9);
     }
 }

--- a/src/services/aggregator.rs
+++ b/src/services/aggregator.rs
@@ -9,10 +9,10 @@ pub struct Aggregator;
 
 /// Build the per-model breakdown key.
 ///
-/// `provider` 가 `None` 또는 빈 문자열이면 정규화된 모델명을 그대로 사용한다
-/// (legacy JSON consumer 호환). provider 가 있으면 `"{model}::{provider}"`
-/// 형태로 분리하여 같은 모델이라도 청구 주체가 다르면 별개의 엔트리로 집계된다.
-/// (Issue #134)
+/// Returns the normalized model name when `provider` is `None` or empty
+/// (legacy JSON consumers stay unaffected). When a provider is present the
+/// key becomes `"{model}::{provider}"` so the same model billed through
+/// different providers aggregates into separate entries. (Issue #134)
 pub fn format_model_key(model: &str, provider: Option<&str>) -> String {
     let normalized = normalize_model_name(model);
     match provider {
@@ -1690,13 +1690,13 @@ mod tests {
 
     #[test]
     fn test_format_model_key_provider_none() {
-        // provider=None → 기존 키 형식 유지 (backward compatible)
+        // provider=None preserves the legacy key (backward compatible).
         assert_eq!(format_model_key("claude-opus-4-5", None), "claude-opus-4-5");
     }
 
     #[test]
     fn test_format_model_key_provider_empty() {
-        // empty 문자열도 None과 동일 처리
+        // Empty string is treated as None.
         assert_eq!(format_model_key("gpt-4", Some("")), "gpt-4");
     }
 
@@ -1710,7 +1710,7 @@ mod tests {
 
     #[test]
     fn test_format_model_key_normalizes_model() {
-        // 정규화(date suffix 제거)도 함께 적용되어야 함
+        // Model normalization (date-suffix removal) still applies.
         assert_eq!(
             format_model_key("claude-opus-4-5-20251101", Some("anthropic")),
             "claude-opus-4-5::anthropic"
@@ -1719,7 +1719,7 @@ mod tests {
 
     #[test]
     fn test_daily_separates_same_model_different_providers() {
-        // Issue #134: 같은 모델이 다른 provider에서 오면 분리되어야 함
+        // Issue #134: same model billed through different providers must split.
         let entries = vec![
             make_entry_with_provider(
                 2026,
@@ -1758,7 +1758,7 @@ mod tests {
 
     #[test]
     fn test_daily_keeps_legacy_key_when_provider_none() {
-        // 회귀 방지: provider=None인 entry는 기존 키 형식 유지
+        // Regression: provider=None entries must keep the legacy key format.
         let entries = vec![make_entry_with_provider(
             2026,
             4,
@@ -1811,7 +1811,7 @@ mod tests {
 
     #[test]
     fn test_weekly_separates_providers_across_days() {
-        // weekly() 가 같은 주 내에서 같은 모델 + 다른 provider 를 분리 유지하는지
+        // weekly() must keep same-model/different-provider entries separate.
         let entries = vec![
             make_entry_with_provider(
                 2026,
@@ -1839,7 +1839,6 @@ mod tests {
         let weekly = Aggregator::weekly(&daily);
 
         assert_eq!(weekly.len(), 1);
-        // 주간 합산 시에도 provider 별 분리 유지
         assert!(weekly[0].models.contains_key("gpt-5-4::github-copilot"));
         assert!(weekly[0].models.contains_key("gpt-5-4::openai"));
         assert_eq!(weekly[0].models.len(), 2);
@@ -1881,7 +1880,7 @@ mod tests {
 
     #[test]
     fn test_merge_by_date_preserves_provider_separation() {
-        // 같은 날짜 + 같은 모델 + 다른 provider 가 합쳐질 때 분리 유지
+        // merge_by_date must keep different-provider entries on the same date separate.
         let mut models_a = HashMap::new();
         models_a.insert(
             "gpt-5-4::github-copilot".to_string(),
@@ -1921,8 +1920,8 @@ mod tests {
 
     #[test]
     fn test_json_serialization_exposes_composite_keys() {
-        // JSON 출력 (cli/mod.rs::run_daily_json) 이 사용하는 직렬화 경로가
-        // composite key 를 그대로 노출하는지 검증 (이슈 #134 의 핵심 기대치)
+        // Verify the serialization path used by run_*_json exposes composite keys
+        // verbatim — the user-visible contract of issue #134.
         let entries = vec![make_entry_with_provider(
             2026,
             4,
@@ -1936,7 +1935,6 @@ mod tests {
         let summaries = Aggregator::daily(&entries);
         let json = serde_json::to_string(&summaries).expect("daily summary serializes");
 
-        // composite key 가 JSON 문자열에 포함되어야 함
         assert!(
             json.contains("\"gpt-5-4::github-copilot\""),
             "composite key not exposed in JSON: {}",
@@ -1946,7 +1944,7 @@ mod tests {
 
     #[test]
     fn test_by_model_aggregates_same_provider() {
-        // 같은 모델 + 같은 provider → 합산
+        // Same model + same provider must aggregate into one entry.
         let entries = vec![
             make_entry_with_provider(
                 2026,

--- a/src/services/aggregator.rs
+++ b/src/services/aggregator.rs
@@ -1810,6 +1810,141 @@ mod tests {
     }
 
     #[test]
+    fn test_weekly_separates_providers_across_days() {
+        // weekly() 가 같은 주 내에서 같은 모델 + 다른 provider 를 분리 유지하는지
+        let entries = vec![
+            make_entry_with_provider(
+                2026,
+                4,
+                14,
+                Some("gpt-5.4"),
+                Some("github-copilot"),
+                100,
+                50,
+                Some(0.0),
+            ),
+            make_entry_with_provider(
+                2026,
+                4,
+                15,
+                Some("gpt-5.4"),
+                Some("openai"),
+                200,
+                100,
+                Some(0.05),
+            ),
+        ];
+
+        let daily = Aggregator::daily(&entries);
+        let weekly = Aggregator::weekly(&daily);
+
+        assert_eq!(weekly.len(), 1);
+        // 주간 합산 시에도 provider 별 분리 유지
+        assert!(weekly[0].models.contains_key("gpt-5-4::github-copilot"));
+        assert!(weekly[0].models.contains_key("gpt-5-4::openai"));
+        assert_eq!(weekly[0].models.len(), 2);
+    }
+
+    #[test]
+    fn test_monthly_separates_providers_across_days() {
+        let entries = vec![
+            make_entry_with_provider(
+                2026,
+                4,
+                5,
+                Some("gpt-5.4"),
+                Some("github-copilot"),
+                100,
+                50,
+                Some(0.0),
+            ),
+            make_entry_with_provider(
+                2026,
+                4,
+                25,
+                Some("gpt-5.4"),
+                Some("openai"),
+                200,
+                100,
+                Some(0.05),
+            ),
+        ];
+
+        let daily = Aggregator::daily(&entries);
+        let monthly = Aggregator::monthly(&daily);
+
+        assert_eq!(monthly.len(), 1);
+        assert!(monthly[0].models.contains_key("gpt-5-4::github-copilot"));
+        assert!(monthly[0].models.contains_key("gpt-5-4::openai"));
+        assert_eq!(monthly[0].models.len(), 2);
+    }
+
+    #[test]
+    fn test_merge_by_date_preserves_provider_separation() {
+        // 같은 날짜 + 같은 모델 + 다른 provider 가 합쳐질 때 분리 유지
+        let mut models_a = HashMap::new();
+        models_a.insert(
+            "gpt-5-4::github-copilot".to_string(),
+            ModelUsage {
+                input_tokens: 100,
+                output_tokens: 50,
+                cost_usd: 0.0,
+                count: 1,
+                ..Default::default()
+            },
+        );
+        let mut models_b = HashMap::new();
+        models_b.insert(
+            "gpt-5-4::openai".to_string(),
+            ModelUsage {
+                input_tokens: 200,
+                output_tokens: 100,
+                cost_usd: 0.05,
+                count: 1,
+                ..Default::default()
+            },
+        );
+        let summaries = vec![
+            make_daily_summary_with_models(2026, 4, 14, 100, 50, 0.0, models_a),
+            make_daily_summary_with_models(2026, 4, 14, 200, 100, 0.05, models_b),
+        ];
+
+        let result = Aggregator::merge_by_date(summaries);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].models.len(), 2);
+        let copilot = result[0].models.get("gpt-5-4::github-copilot").unwrap();
+        assert_eq!(copilot.input_tokens, 100);
+        let direct = result[0].models.get("gpt-5-4::openai").unwrap();
+        assert_eq!(direct.input_tokens, 200);
+    }
+
+    #[test]
+    fn test_json_serialization_exposes_composite_keys() {
+        // JSON 출력 (cli/mod.rs::run_daily_json) 이 사용하는 직렬화 경로가
+        // composite key 를 그대로 노출하는지 검증 (이슈 #134 의 핵심 기대치)
+        let entries = vec![make_entry_with_provider(
+            2026,
+            4,
+            14,
+            Some("gpt-5.4"),
+            Some("github-copilot"),
+            100,
+            50,
+            Some(0.0),
+        )];
+        let summaries = Aggregator::daily(&entries);
+        let json = serde_json::to_string(&summaries).expect("daily summary serializes");
+
+        // composite key 가 JSON 문자열에 포함되어야 함
+        assert!(
+            json.contains("\"gpt-5-4::github-copilot\""),
+            "composite key not exposed in JSON: {}",
+            json
+        );
+    }
+
+    #[test]
     fn test_by_model_aggregates_same_provider() {
         // 같은 모델 + 같은 provider → 합산
         let entries = vec![

--- a/src/services/aggregator.rs
+++ b/src/services/aggregator.rs
@@ -7,6 +7,20 @@ use std::collections::{HashMap, HashSet};
 
 pub struct Aggregator;
 
+/// Build the per-model breakdown key.
+///
+/// `provider` 가 `None` 또는 빈 문자열이면 정규화된 모델명을 그대로 사용한다
+/// (legacy JSON consumer 호환). provider 가 있으면 `"{model}::{provider}"`
+/// 형태로 분리하여 같은 모델이라도 청구 주체가 다르면 별개의 엔트리로 집계된다.
+/// (Issue #134)
+pub fn format_model_key(model: &str, provider: Option<&str>) -> String {
+    let normalized = normalize_model_name(model);
+    match provider {
+        Some(p) if !p.is_empty() => format!("{}::{}", normalized, p),
+        _ => normalized,
+    }
+}
+
 /// Accumulate token fields and cost from `source` into `target`
 fn accumulate_summary(target: &mut DailySummary, source: &DailySummary) {
     target.total_input_tokens = target
@@ -79,7 +93,10 @@ impl Aggregator {
         for entry in entries {
             let date = entry.local_date();
             let cost = entry.cost_usd.unwrap_or(0.0);
-            let model_name = normalize_model_name(entry.model.as_deref().unwrap_or("unknown"));
+            let model_name = format_model_key(
+                entry.model.as_deref().unwrap_or("unknown"),
+                entry.provider.as_deref(),
+            );
 
             let summary = daily_map.entry(date).or_insert_with(|| DailySummary {
                 date,
@@ -210,7 +227,10 @@ impl Aggregator {
         let mut model_map: HashMap<String, ModelUsage> = HashMap::new();
 
         for entry in entries {
-            let model_name = normalize_model_name(entry.model.as_deref().unwrap_or("unknown"));
+            let model_name = format_model_key(
+                entry.model.as_deref().unwrap_or("unknown"),
+                entry.provider.as_deref(),
+            );
             let cost = entry.cost_usd.unwrap_or(0.0);
 
             let usage = model_map.entry(model_name).or_default();
@@ -1634,5 +1654,192 @@ mod tests {
         assert_eq!(result[0].models.len(), 2);
         assert!(result[0].models.contains_key("claude"));
         assert!(result[0].models.contains_key("gpt-4"));
+    }
+
+    // ========== Issue #134: provider-aware model key ==========
+
+    #[allow(clippy::too_many_arguments)]
+    fn make_entry_with_provider(
+        year: i32,
+        month: u32,
+        day: u32,
+        model: Option<&str>,
+        provider: Option<&str>,
+        input: u64,
+        output: u64,
+        cost: Option<f64>,
+    ) -> UsageEntry {
+        UsageEntry {
+            timestamp: Utc.with_ymd_and_hms(year, month, day, 12, 0, 0).unwrap(),
+            model: model.map(String::from),
+            input_tokens: input,
+            output_tokens: output,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            thinking_tokens: 0,
+            cache_creation_5m_tokens: 0,
+            cache_creation_1h_tokens: 0,
+            web_search_requests: 0,
+            cost_usd: cost,
+            message_id: None,
+            request_id: None,
+            source: None,
+            provider: provider.map(String::from),
+        }
+    }
+
+    #[test]
+    fn test_format_model_key_provider_none() {
+        // provider=None → 기존 키 형식 유지 (backward compatible)
+        assert_eq!(format_model_key("claude-opus-4-5", None), "claude-opus-4-5");
+    }
+
+    #[test]
+    fn test_format_model_key_provider_empty() {
+        // empty 문자열도 None과 동일 처리
+        assert_eq!(format_model_key("gpt-4", Some("")), "gpt-4");
+    }
+
+    #[test]
+    fn test_format_model_key_provider_some() {
+        assert_eq!(
+            format_model_key("gpt-5-4", Some("github-copilot")),
+            "gpt-5-4::github-copilot"
+        );
+    }
+
+    #[test]
+    fn test_format_model_key_normalizes_model() {
+        // 정규화(date suffix 제거)도 함께 적용되어야 함
+        assert_eq!(
+            format_model_key("claude-opus-4-5-20251101", Some("anthropic")),
+            "claude-opus-4-5::anthropic"
+        );
+    }
+
+    #[test]
+    fn test_daily_separates_same_model_different_providers() {
+        // Issue #134: 같은 모델이 다른 provider에서 오면 분리되어야 함
+        let entries = vec![
+            make_entry_with_provider(
+                2026,
+                4,
+                14,
+                Some("gpt-5.4"),
+                Some("github-copilot"),
+                100,
+                50,
+                Some(0.0),
+            ),
+            make_entry_with_provider(
+                2026,
+                4,
+                14,
+                Some("gpt-5.4"),
+                Some("openai"),
+                200,
+                100,
+                Some(0.05),
+            ),
+        ];
+
+        let result = Aggregator::daily(&entries);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].models.len(), 2);
+        assert!(result[0].models.contains_key("gpt-5-4::github-copilot"));
+        assert!(result[0].models.contains_key("gpt-5-4::openai"));
+
+        let copilot = result[0].models.get("gpt-5-4::github-copilot").unwrap();
+        assert_eq!(copilot.input_tokens, 100);
+        let direct = result[0].models.get("gpt-5-4::openai").unwrap();
+        assert_eq!(direct.input_tokens, 200);
+    }
+
+    #[test]
+    fn test_daily_keeps_legacy_key_when_provider_none() {
+        // 회귀 방지: provider=None인 entry는 기존 키 형식 유지
+        let entries = vec![make_entry_with_provider(
+            2026,
+            4,
+            14,
+            Some("claude-opus-4-5"),
+            None,
+            100,
+            50,
+            Some(0.01),
+        )];
+
+        let result = Aggregator::daily(&entries);
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].models.contains_key("claude-opus-4-5"));
+        assert!(!result[0].models.keys().any(|k| k.contains("::")));
+    }
+
+    #[test]
+    fn test_by_model_separates_providers() {
+        let entries = vec![
+            make_entry_with_provider(
+                2026,
+                4,
+                14,
+                Some("gpt-5.4"),
+                Some("github-copilot"),
+                100,
+                50,
+                Some(0.0),
+            ),
+            make_entry_with_provider(
+                2026,
+                4,
+                14,
+                Some("gpt-5.4"),
+                Some("openai"),
+                200,
+                100,
+                Some(0.05),
+            ),
+        ];
+
+        let result = Aggregator::by_model(&entries);
+
+        assert_eq!(result.len(), 2);
+        assert!(result.contains_key("gpt-5-4::github-copilot"));
+        assert!(result.contains_key("gpt-5-4::openai"));
+    }
+
+    #[test]
+    fn test_by_model_aggregates_same_provider() {
+        // 같은 모델 + 같은 provider → 합산
+        let entries = vec![
+            make_entry_with_provider(
+                2026,
+                4,
+                14,
+                Some("gpt-5.4"),
+                Some("github-copilot"),
+                100,
+                50,
+                Some(0.0),
+            ),
+            make_entry_with_provider(
+                2026,
+                4,
+                15,
+                Some("gpt-5.4"),
+                Some("github-copilot"),
+                300,
+                150,
+                Some(0.0),
+            ),
+        ];
+
+        let result = Aggregator::by_model(&entries);
+
+        assert_eq!(result.len(), 1);
+        let usage = result.get("gpt-5-4::github-copilot").unwrap();
+        assert_eq!(usage.input_tokens, 400);
+        assert_eq!(usage.count, 2);
     }
 }

--- a/src/services/cache.rs
+++ b/src/services/cache.rs
@@ -993,7 +993,7 @@ mod tests {
 
     #[test]
     fn test_normalize_composite_key_preserves_provider() {
-        // 모델 부분만 정규화되고 provider 부분은 절대 건드리지 않음
+        // Only the model part is normalized; the provider must not be touched.
         assert_eq!(
             normalize_composite_key("claude-opus-4.5::anthropic"),
             "claude-opus-4-5::anthropic"
@@ -1006,8 +1006,8 @@ mod tests {
 
     #[test]
     fn test_normalize_composite_key_provider_with_date_like_suffix() {
-        // 가상의 provider 가 8자리 숫자 suffix 를 포함하더라도 truncate 되면 안 됨
-        // (normalize_model_name 의 date suffix 제거 로직이 provider 에 적용되면 안 됨)
+        // A provider name ending in an 8-digit `20…` suffix must not be truncated
+        // by normalize_model_name's date-suffix stripping logic.
         assert_eq!(
             normalize_composite_key("gpt-4::custom-20250101"),
             "gpt-4::custom-20250101"
@@ -1016,7 +1016,7 @@ mod tests {
 
     #[test]
     fn test_normalize_composite_key_plain_key_unchanged_behavior() {
-        // :: 가 없는 키는 기존과 동일하게 normalize_model_name 적용
+        // Plain (non-composite) keys keep the original normalize_model_name behavior.
         assert_eq!(
             normalize_composite_key("claude-opus-4.5"),
             "claude-opus-4-5"
@@ -1026,8 +1026,8 @@ mod tests {
 
     #[test]
     fn test_cache_roundtrip_preserves_composite_keys() {
-        // 캐시에 composite key 를 저장하고 다시 읽었을 때 키 형식이 보존되어야 함
-        // (실제 운영에서 발생할 수 있는 시나리오)
+        // Composite keys written to disk must round-trip through load_or_compute
+        // unchanged.
         let (service, _temp) = create_test_service();
         let yesterday = Local::now().date_naive() - chrono::Duration::days(1);
 
@@ -1076,13 +1076,12 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(&cache_path, serde_json::to_string(&cache).unwrap()).unwrap();
 
-        // load_or_compute (caller path): 캐시만 있고 entries 없을 때 캐시 그대로 반환
+        // With no entries to recompute, load_or_compute returns the cached data as-is.
         let entries: Vec<UsageEntry> = vec![];
         let (result, warning) = service.load_or_compute("codex", &entries).unwrap();
 
         assert!(warning.is_none());
         assert_eq!(result.len(), 1);
-        // composite key 두 개 모두 정확히 보존
         assert_eq!(result[0].models.len(), 2);
         assert!(result[0].models.contains_key("gpt-5-4::github-copilot"));
         assert!(result[0].models.contains_key("gpt-5-4::openai"));
@@ -1090,12 +1089,14 @@ mod tests {
 
     #[test]
     fn test_cache_roundtrip_normalizes_composite_with_dotted_model() {
-        // dot-bearing model 이 composite key 안에 있을 때 정규화가 모델 부분에만 적용
+        // When a composite key carries a dotted model, normalization touches
+        // only the model part — provider remains intact.
         let (service, _temp) = create_test_service();
         let yesterday = Local::now().date_naive() - chrono::Duration::days(1);
 
         let mut models = HashMap::new();
-        // 비정규화된 키 (model 에 . 포함) — 캐시 v0 시뮬레이션 (version mismatch path)
+        // Pre-normalization key (model contains '.') simulating a stale v0 cache,
+        // forcing the version-mismatch normalization path.
         models.insert(
             "claude-opus-4.5::anthropic".to_string(),
             ModelUsage {
@@ -1117,7 +1118,7 @@ mod tests {
             total_cost_usd: 0.0,
             models,
         };
-        // version=0 → mismatch path → normalize_model_keys 호출됨
+        // version=0 triggers the mismatch path which runs normalize_model_keys.
         let cache = serde_json::json!({
             "cli": "codex",
             "version": 0,
@@ -1133,7 +1134,7 @@ mod tests {
 
         assert!(warning.is_some()); // version mismatch warning
         assert_eq!(result.len(), 1);
-        // 모델 부분만 정규화 (4.5 → 4-5), provider 부분 그대로
+        // Model normalized (4.5 -> 4-5); provider preserved.
         assert!(result[0].models.contains_key("claude-opus-4-5::anthropic"));
     }
 }

--- a/src/services/cache.rs
+++ b/src/services/cache.rs
@@ -14,11 +14,22 @@ use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
 
+/// Normalize a composite "model::provider" key by normalizing only the model
+/// portion. Plain (non-composite) keys are normalized as before.
+/// (Issue #134: provider strings must not be subject to model-name normalization)
+fn normalize_composite_key(key: &str) -> String {
+    if let Some((model, provider)) = key.split_once("::") {
+        format!("{}::{}", normalize_model_name(model), provider)
+    } else {
+        normalize_model_name(key)
+    }
+}
+
 /// Normalize model name keys in a HashMap, merging duplicates.
 fn normalize_model_keys(models: HashMap<String, ModelUsage>) -> HashMap<String, ModelUsage> {
     let mut normalized: HashMap<String, ModelUsage> = HashMap::new();
     for (name, usage) in models {
-        let key = normalize_model_name(&name);
+        let key = normalize_composite_key(&name);
         normalized
             .entry(key)
             .and_modify(|existing| {
@@ -52,7 +63,7 @@ fn normalize_model_keys(models: HashMap<String, ModelUsage>) -> HashMap<String, 
 
 /// Bump when aggregation logic changes (e.g., timezone fix).
 /// Mismatched version → full cache invalidation.
-const CACHE_VERSION: u32 = 11;
+const CACHE_VERSION: u32 = 12;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DailySummaryCache {
@@ -976,5 +987,40 @@ mod tests {
         fs::write(&cache_path, serde_json::to_string(&cache).unwrap()).unwrap();
 
         assert_eq!(service.latest_cached_date("claude-code"), None);
+    }
+
+    // ========== Issue #134: composite key normalization ==========
+
+    #[test]
+    fn test_normalize_composite_key_preserves_provider() {
+        // 모델 부분만 정규화되고 provider 부분은 절대 건드리지 않음
+        assert_eq!(
+            normalize_composite_key("claude-opus-4.5::anthropic"),
+            "claude-opus-4-5::anthropic"
+        );
+        assert_eq!(
+            normalize_composite_key("claude-opus-4-5-20251101::anthropic"),
+            "claude-opus-4-5::anthropic"
+        );
+    }
+
+    #[test]
+    fn test_normalize_composite_key_provider_with_date_like_suffix() {
+        // 가상의 provider 가 8자리 숫자 suffix 를 포함하더라도 truncate 되면 안 됨
+        // (normalize_model_name 의 date suffix 제거 로직이 provider 에 적용되면 안 됨)
+        assert_eq!(
+            normalize_composite_key("gpt-4::custom-20250101"),
+            "gpt-4::custom-20250101"
+        );
+    }
+
+    #[test]
+    fn test_normalize_composite_key_plain_key_unchanged_behavior() {
+        // :: 가 없는 키는 기존과 동일하게 normalize_model_name 적용
+        assert_eq!(
+            normalize_composite_key("claude-opus-4.5"),
+            "claude-opus-4-5"
+        );
+        assert_eq!(normalize_composite_key("gpt-4"), "gpt-4");
     }
 }

--- a/src/services/cache.rs
+++ b/src/services/cache.rs
@@ -1023,4 +1023,117 @@ mod tests {
         );
         assert_eq!(normalize_composite_key("gpt-4"), "gpt-4");
     }
+
+    #[test]
+    fn test_cache_roundtrip_preserves_composite_keys() {
+        // 캐시에 composite key 를 저장하고 다시 읽었을 때 키 형식이 보존되어야 함
+        // (실제 운영에서 발생할 수 있는 시나리오)
+        let (service, _temp) = create_test_service();
+        let yesterday = Local::now().date_naive() - chrono::Duration::days(1);
+
+        let mut models = HashMap::new();
+        models.insert(
+            "gpt-5-4::github-copilot".to_string(),
+            ModelUsage {
+                input_tokens: 100,
+                output_tokens: 50,
+                cost_usd: 0.0,
+                count: 1,
+                ..Default::default()
+            },
+        );
+        models.insert(
+            "gpt-5-4::openai".to_string(),
+            ModelUsage {
+                input_tokens: 200,
+                output_tokens: 100,
+                cost_usd: 0.05,
+                count: 1,
+                ..Default::default()
+            },
+        );
+
+        let cached = DailySummary {
+            date: yesterday,
+            total_input_tokens: 300,
+            total_output_tokens: 150,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_thinking_tokens: 0,
+            total_cache_creation_5m_tokens: 0,
+            total_cache_creation_1h_tokens: 0,
+            total_web_search_requests: 0,
+            total_cost_usd: 0.05,
+            models,
+        };
+        let cache = DailySummaryCache {
+            cli: "codex".to_string(),
+            version: CACHE_VERSION,
+            updated_at: chrono::Utc::now().timestamp(),
+            summaries: vec![cached],
+        };
+        let cache_path = service.cache_path("codex");
+        fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        fs::write(&cache_path, serde_json::to_string(&cache).unwrap()).unwrap();
+
+        // load_or_compute (caller path): 캐시만 있고 entries 없을 때 캐시 그대로 반환
+        let entries: Vec<UsageEntry> = vec![];
+        let (result, warning) = service.load_or_compute("codex", &entries).unwrap();
+
+        assert!(warning.is_none());
+        assert_eq!(result.len(), 1);
+        // composite key 두 개 모두 정확히 보존
+        assert_eq!(result[0].models.len(), 2);
+        assert!(result[0].models.contains_key("gpt-5-4::github-copilot"));
+        assert!(result[0].models.contains_key("gpt-5-4::openai"));
+    }
+
+    #[test]
+    fn test_cache_roundtrip_normalizes_composite_with_dotted_model() {
+        // dot-bearing model 이 composite key 안에 있을 때 정규화가 모델 부분에만 적용
+        let (service, _temp) = create_test_service();
+        let yesterday = Local::now().date_naive() - chrono::Duration::days(1);
+
+        let mut models = HashMap::new();
+        // 비정규화된 키 (model 에 . 포함) — 캐시 v0 시뮬레이션 (version mismatch path)
+        models.insert(
+            "claude-opus-4.5::anthropic".to_string(),
+            ModelUsage {
+                input_tokens: 100,
+                ..Default::default()
+            },
+        );
+
+        let cached = DailySummary {
+            date: yesterday,
+            total_input_tokens: 100,
+            total_output_tokens: 0,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_thinking_tokens: 0,
+            total_cache_creation_5m_tokens: 0,
+            total_cache_creation_1h_tokens: 0,
+            total_web_search_requests: 0,
+            total_cost_usd: 0.0,
+            models,
+        };
+        // version=0 → mismatch path → normalize_model_keys 호출됨
+        let cache = serde_json::json!({
+            "cli": "codex",
+            "version": 0,
+            "updated_at": chrono::Utc::now().timestamp(),
+            "summaries": [cached],
+        });
+        let cache_path = service.cache_path("codex");
+        fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        fs::write(&cache_path, cache.to_string()).unwrap();
+
+        let entries: Vec<UsageEntry> = vec![];
+        let (result, warning) = service.load_or_compute("codex", &entries).unwrap();
+
+        assert!(warning.is_some()); // version mismatch warning
+        assert_eq!(result.len(), 1);
+        // 모델 부분만 정규화 (4.5 → 4-5), provider 부분 그대로
+        assert!(result[0].models.contains_key("claude-opus-4-5::anthropic"));
+    }
 }

--- a/tests/fixtures/codex/bedrock-session.jsonl
+++ b/tests/fixtures/codex/bedrock-session.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-02-10T08:00:00.000Z","type":"session_meta","payload":{"id":"session-bedrock","model_provider_id":"AmazonBedrock","model_provider_name":"Amazon Bedrock"}}
+{"timestamp":"2026-02-10T08:00:01.000Z","type":"turn_context","payload":{"model":"o4-mini"}}
+{"timestamp":"2026-02-10T08:00:10.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":120,"output_tokens":60,"cached_input_tokens":20},"last_token_usage":{"input_tokens":120,"output_tokens":60,"cached_input_tokens":20}}}}

--- a/tests/fixtures/codex/multi-session-meta.jsonl
+++ b/tests/fixtures/codex/multi-session-meta.jsonl
@@ -1,5 +1,5 @@
-{"timestamp":"2026-03-01T08:00:00.000Z","type":"session_meta","payload":{"id":"session-bedrock","model_provider_id":"AmazonBedrock"}}
+{"timestamp":"2026-03-01T08:00:00.000Z","type":"session_meta","payload":{"id":"session-with-provider","cli_version":"0.116.0","model_provider":"openai"}}
 {"timestamp":"2026-03-01T08:00:01.000Z","type":"turn_context","payload":{"model":"o4-mini"}}
 {"timestamp":"2026-03-01T08:00:10.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"output_tokens":50,"cached_input_tokens":20},"last_token_usage":{"input_tokens":100,"output_tokens":50,"cached_input_tokens":20}}}}
-{"timestamp":"2026-03-01T08:01:00.000Z","type":"session_meta","payload":{"id":"session-direct"}}
+{"timestamp":"2026-03-01T08:01:00.000Z","type":"session_meta","payload":{"id":"session-without-provider"}}
 {"timestamp":"2026-03-01T08:01:10.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"output_tokens":150,"cached_input_tokens":40},"last_token_usage":{"input_tokens":200,"output_tokens":100,"cached_input_tokens":20}}}}

--- a/tests/fixtures/codex/multi-session-meta.jsonl
+++ b/tests/fixtures/codex/multi-session-meta.jsonl
@@ -1,0 +1,5 @@
+{"timestamp":"2026-03-01T08:00:00.000Z","type":"session_meta","payload":{"id":"session-bedrock","model_provider_id":"AmazonBedrock"}}
+{"timestamp":"2026-03-01T08:00:01.000Z","type":"turn_context","payload":{"model":"o4-mini"}}
+{"timestamp":"2026-03-01T08:00:10.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"output_tokens":50,"cached_input_tokens":20},"last_token_usage":{"input_tokens":100,"output_tokens":50,"cached_input_tokens":20}}}}
+{"timestamp":"2026-03-01T08:01:00.000Z","type":"session_meta","payload":{"id":"session-direct"}}
+{"timestamp":"2026-03-01T08:01:10.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"output_tokens":150,"cached_input_tokens":40},"last_token_usage":{"input_tokens":200,"output_tokens":100,"cached_input_tokens":20}}}}

--- a/tests/fixtures/codex/openai-session.jsonl
+++ b/tests/fixtures/codex/openai-session.jsonl
@@ -1,3 +1,3 @@
-{"timestamp":"2026-02-10T08:00:00.000Z","type":"session_meta","payload":{"id":"session-bedrock","model_provider_id":"AmazonBedrock","model_provider_name":"Amazon Bedrock"}}
+{"timestamp":"2026-02-10T08:00:00.000Z","type":"session_meta","payload":{"id":"019d2e4c-e19a-7662-b2eb-0629d5ddd78b","cli_version":"0.116.0","model_provider":"openai"}}
 {"timestamp":"2026-02-10T08:00:01.000Z","type":"turn_context","payload":{"model":"o4-mini"}}
 {"timestamp":"2026-02-10T08:00:10.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":120,"output_tokens":60,"cached_input_tokens":20},"last_token_usage":{"input_tokens":120,"output_tokens":60,"cached_input_tokens":20}}}}


### PR DESCRIPTION
## Summary
- Switch `DailySummary.models` keying to `format_model_key(model, provider)` — entries with a provider use the composite `"{model}::{provider}"` form, others keep the legacy model-only key (partial backward compat).
- Codex parser: extract `session_meta.payload.model_provider` and replace `current_provider` unconditionally on every `session_meta` line so a stale provider never sticks across sessions.
- Cache: bump `CACHE_VERSION` 11 → 12 and add `normalize_composite_key` so the `::` separator is preserved through normalization.
- Claude / Gemini parsers stay `None` — neither file format carries a deterministic in-file provider signal.

Refs #134 (do not auto-close — verification in real consumer environments still pending).

## Test plan
- [x] `make check` — 469 passed / 0 failed / clippy clean / fmt clean
- [x] Schema cross-checked against five real Codex session files in `~/.codex/sessions/` (CLI v0.116.0 and v0.118.0)
- [x] e2e: `./target/release/toktrack daily --json` emits the `gpt-5-4::openai` composite key from real Codex sessions; existing claude/gemini keys remain unchanged
- [x] Aggregator: `daily` / `by_model` / `weekly` / `monthly` / `merge_by_date` all assert provider separation
- [x] Cache: roundtrip + version-mismatch + composite-key normalization regression coverage
- [x] Codex parser: provider extraction + sticky-reset regression coverage

## Breaking change scope
Limited to entries that carry a provider (opencode / pi-agent / codex). Claude-only users see no change.

## Out of scope (follow-up issues recommended)
- TUI Models tab renders the raw composite key — needs a display-layer split
- Real-data integration verification for pi-agent / opencode (no such data in the author's environment; covered by fixture-based tests only)
