### PR TITLE
fix(ci): switch release.yml to actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,12 +63,10 @@ jobs:
           ref: ${{ inputs.tag }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          targets: ${{ matrix.target }}
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+          toolchain: stable
+          target: ${{ matrix.target }}
 
       - name: Install cross
         if: matrix.cross


### PR DESCRIPTION
## Summary

Same dtolnay regression as ci.yml, now hit during release builds. The release-please workflow merged v2.7.1 → triggered release.yml → all 5 platform builds fail at `cargo build` with the same `rustup-init` error.

Apply the same fix that unblocked ci.yml in #146.

## Impact

- v2.7.1 and v2.7.2 tagged releases have no published binaries (release.yml failed on every platform). The tags exist, but the GitHub Release won't have asset uploads, and homebrew-tap/npm publish are gated on successful builds.
- The next release-please cycle (when this PR + new patch land) will produce binaries normally.

## Test plan

- [ ] CI passes (ci.yml only — this PR can't exercise release.yml without a tag push). Re-run release manually after merge with `gh workflow run release.yml -f tag=v2.7.2` if we want to retry the existing tag.