### PR TITLE
feat(ci): add Docker/Podman support with GHCR publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+target/
+.git/
+.github/
+.claude/
+.dev/
+assets/
+docs/
+npm/
+*.tape
+*.md
+!README.md

--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TAG: ${{ inputs.tag }}
-      TAP_REPO: mag123c/homebrew-toktrack
+      TAP_REPO: slmingol/homebrew-tap
     steps:
       - name: Checkout tap
         uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${TAG#v}"
-          base="https://github.com/mag123c/toktrack/releases/download/${TAG}"
+          base="https://github.com/slmingol/toktrack/releases/download/${TAG}"
           for f in toktrack-darwin-arm64 toktrack-darwin-x64 toktrack-linux-arm64 toktrack-linux-x64; do
             curl -sSfL -o "$f.tar.gz" "$base/$f.tar.gz"
           done
@@ -59,27 +59,27 @@ jobs:
           cat > Formula/toktrack.rb <<EOF
           class Toktrack < Formula
             desc "Ultra-fast token & cost tracker for AI CLIs (Claude, Codex, Gemini, OpenCode)"
-            homepage "https://github.com/mag123c/toktrack"
+            homepage "https://github.com/slmingol/toktrack"
             license "MIT"
 
             on_macos do
               on_arm do
-                url "https://github.com/mag123c/toktrack/releases/download/v${VERSION}/toktrack-darwin-arm64.tar.gz"
+                url "https://github.com/slmingol/toktrack/releases/download/v${VERSION}/toktrack-darwin-arm64.tar.gz"
                 sha256 "${DARWIN_ARM64}"
               end
               on_intel do
-                url "https://github.com/mag123c/toktrack/releases/download/v${VERSION}/toktrack-darwin-x64.tar.gz"
+                url "https://github.com/slmingol/toktrack/releases/download/v${VERSION}/toktrack-darwin-x64.tar.gz"
                 sha256 "${DARWIN_X64}"
               end
             end
 
             on_linux do
               on_arm do
-                url "https://github.com/mag123c/toktrack/releases/download/v${VERSION}/toktrack-linux-arm64.tar.gz"
+                url "https://github.com/slmingol/toktrack/releases/download/v${VERSION}/toktrack-linux-arm64.tar.gz"
                 sha256 "${LINUX_ARM64}"
               end
               on_intel do
-                url "https://github.com/mag123c/toktrack/releases/download/v${VERSION}/toktrack-linux-x64.tar.gz"
+                url "https://github.com/slmingol/toktrack/releases/download/v${VERSION}/toktrack-linux-x64.tar.gz"
                 sha256 "${LINUX_X64}"
               end
             end

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,50 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - '.release-please-manifest.json'
+      - 'Cargo.toml'
+  release:
+    types: [published]
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/toktrack
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,7 @@ jobs:
     name: Publish to npm
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ secrets.NPM_TOKEN != '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1.88-slim-bookworm AS builder
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY benches ./benches
+RUN CARGO_PROFILE_RELEASE_LTO=false \
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 \
+    cargo build --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/toktrack /usr/local/bin/toktrack
+
+CMD ["toktrack"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,39 @@
-.PHONY: check fmt clippy test build release setup
+.DEFAULT_GOAL := help
+
+DOCKER := $(shell command -v docker 2>/dev/null)
+PODMAN := $(shell command -v podman 2>/dev/null)
+ifdef DOCKER
+  RUNTIME := docker
+  COMPOSE  := docker compose
+else ifdef PODMAN
+  RUNTIME := podman
+  COMPOSE  := podman compose
+else
+  $(error Neither docker nor podman found in PATH)
+endif
+
+GHCR_OWNER ?= slmingol
+GHCR_IMAGE  := ghcr.io/$(GHCR_OWNER)/toktrack:latest
+
+.PHONY: check fmt clippy test build release setup docker-build docker-pull docker-run docker-report help
+
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "Dev"
+	@echo "  check        fmt + clippy + test (pre-commit)"
+	@echo "  fmt          Format code"
+	@echo "  clippy       Lint (warnings = errors)"
+	@echo "  test         Run tests"
+	@echo "  build        Build debug binary"
+	@echo "  release      Build release binary"
+	@echo "  setup        Configure git hooks"
+	@echo ""
+	@echo "Container (docker or podman, auto-detected)"
+	@echo "  docker-build  Build image locally"
+	@echo "  docker-pull   Pull image from GHCR (ghcr.io/$(GHCR_OWNER)/toktrack)"
+	@echo "  docker-run    Launch TUI (interactive)"
+	@echo "  docker-report Run CLI report mode"
 
 # Run all checks (used by pre-commit)
 check: fmt-check clippy test
@@ -26,6 +61,23 @@ build:
 # Build release
 release:
 	cargo build --release
+
+# Docker/Podman: build image locally
+docker-build:
+	$(COMPOSE) build
+
+# Pull image from GHCR and tag as toktrack:local for use with docker-run
+docker-pull:
+	$(RUNTIME) pull $(GHCR_IMAGE)
+	$(RUNTIME) tag $(GHCR_IMAGE) toktrack:local
+
+# Docker/Podman: run TUI (interactive)
+docker-run:
+	$(COMPOSE) run --rm toktrack
+
+# Docker/Podman: run CLI report (non-interactive)
+docker-report:
+	$(COMPOSE) run --rm toktrack report
 
 # Setup git hooks
 setup:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  toktrack:
+    build: .
+    image: toktrack:local
+    stdin_open: true
+    tty: true
+    environment:
+      - TERM=${TERM:-xterm-256color}
+      - COLORTERM=${COLORTERM:-truecolor}
+    volumes:
+      - ${HOME}/.claude:/root/.claude:ro
+      - ${HOME}/.codex:/root/.codex:ro
+      - ${HOME}/.gemini:/root/.gemini:ro
+      - ${HOME}/.local/share/opencode:/root/.local/share/opencode:ro
+      - ${HOME}/.toktrack:/root/.toktrack


### PR DESCRIPTION
## Summary

- `Dockerfile`: multi-stage build (`rust:1.88-slim-bookworm` builder + `debian:bookworm-slim` runtime); LTO disabled to avoid OOM in constrained container builds
- `docker-compose.yml`: volume mounts for `~/.claude`, `~/.codex`, `~/.gemini`, `~/.local/share/opencode` (ro) and `~/.toktrack` cache (rw)
- `.dockerignore`: excludes `target/`, `.git/`, assets, docs from build context
- `Makefile`: auto-detects `docker` or `podman`; adds `docker-build`, `docker-pull`, `docker-run`, `docker-report` targets; `make` with no args shows help
- `.github/workflows/docker.yml`: builds multi-platform (`amd64`+`arm64`) image and pushes to GHCR on push to `main` and on release

## Usage

```bash
make docker-build        # build locally
make docker-pull         # pull from ghcr.io/<owner>/toktrack:latest
make docker-run          # launch TUI (interactive)
make docker-report       # CLI report mode
```

## Test plan

- [ ] `make docker-build` succeeds
- [ ] `make docker-run` opens TUI with host log data visible
- [ ] `make docker-report` prints report and exits
- [ ] GHA workflow triggers on push to main and publishes to GHCR
- [ ] `make docker-pull` after GHA run pulls and re-tags image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)