### PR TITLE
feat: Add support for tracking codex usage from SSH remote environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,63 @@ toktrack report --days 14    # Last N days
 toktrack report --svg        # Text + SVG file
 ```
 
+### Remote Codex Sources
+
+toktrack can include Codex session logs from SSH servers by syncing remote JSONL
+files into a local snapshot and parsing them with the existing Codex parser. It
+uses your existing `ssh`/`rsync` setup and never stores SSH passwords or keys.
+
+Create `~/.toktrack/config.toml`:
+
+```toml
+default_remotes = ["devbox"]
+
+[[remotes]]
+name = "devbox"
+target = "ubuntu@devbox"
+
+[remotes.paths]
+codex = "~/.codex/sessions"
+
+[[remotes]]
+name = "prod"
+target = "prod-alias"
+
+[remotes.paths]
+codex = "/home/codex/.codex/sessions"
+```
+
+You can also manage the same config from the CLI:
+
+```bash
+toktrack remote add devbox ubuntu@devbox --default
+toktrack remote add prod prod-alias --codex-path /home/codex/.codex/sessions
+toktrack remote default add prod
+toktrack remote default remove devbox
+toktrack remote remove prod
+toktrack remote list
+```
+
+By default, commands read local data plus `default_remotes`:
+
+```bash
+toktrack report
+toktrack daily --json
+```
+
+Override the configured defaults when needed:
+
+```bash
+toktrack --remote prod report      # local + default_remotes + prod
+toktrack --all-remotes stats       # local + every configured remote
+toktrack --local-only report       # local only
+```
+
+Remote Codex sources appear as `codex@<remote-name>` and use separate cache
+files such as `~/.toktrack/cache/codex@devbox_daily.json`.
+If a remote sync fails, toktrack warns and continues with local data plus any
+existing snapshot/cache for that remote.
+
 ### Keyboard Shortcuts
 
 | Key | Action |
@@ -206,9 +263,13 @@ Custom pricing (including `web_search` / `web_fetch` per-request rates) can be s
 ├── cache/
 │   ├── claude-code_daily.json   # Daily cost summaries
 │   ├── codex_daily.json
+│   ├── codex@devbox_daily.json
 │   ├── gemini_daily.json
 │   ├── opencode_daily.json
 │   └── pi-agent_daily.json
+├── remotes/
+│   └── devbox/codex/sessions/   # Synced remote Codex JSONL snapshots
+├── config.toml                  # Optional remote source configuration
 └── pricing.json                 # LiteLLM pricing (1h TTL)
 ```
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,7 +6,8 @@ use chrono::Local;
 use clap::{Parser, Subcommand};
 
 use crate::report::data::ReportData;
-use crate::services::{Aggregator, DataLoaderService};
+use crate::services::config::{ConfigService, RemoteConfig as StoredRemoteConfig};
+use crate::services::{Aggregator, DataLoaderService, RemoteOptions, RemoteSourceService};
 use crate::tui::widgets::daily::DailyViewMode;
 use crate::tui::widgets::tabs::Tab;
 use crate::tui::TuiConfig;
@@ -17,6 +18,18 @@ use crate::types::{DailySummary, Result, StatsData, ToktrackError};
 #[command(name = "toktrack")]
 #[command(version, about, long_about = None)]
 pub struct Cli {
+    /// Include a configured SSH remote source. Can be repeated.
+    #[arg(long = "remote", global = true, value_name = "NAME")]
+    remotes: Vec<String>,
+
+    /// Include every configured remote source.
+    #[arg(long, global = true)]
+    all_remotes: bool,
+
+    /// Read only local usage data, ignoring configured default remotes.
+    #[arg(long, global = true)]
+    local_only: bool,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -72,49 +85,118 @@ enum Commands {
         #[arg(long, num_args = 0..=1, default_missing_value = "toktrack-report.svg")]
         svg: Option<PathBuf>,
     },
+
+    /// Manage configured SSH remote sources
+    Remote {
+        #[command(subcommand)]
+        command: RemoteCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum RemoteCommand {
+    /// Add a configured SSH remote source
+    Add {
+        /// Remote name used by toktrack
+        name: String,
+
+        /// SSH target, for example user@host or an SSH config alias
+        target: String,
+
+        /// Remote Codex sessions path
+        #[arg(long, value_name = "PATH")]
+        codex_path: Option<String>,
+
+        /// Include this remote by default in normal commands
+        #[arg(long = "default")]
+        make_default: bool,
+    },
+
+    /// Remove a configured SSH remote source
+    Remove {
+        /// Remote name used by toktrack
+        name: String,
+    },
+
+    /// List configured SSH remote sources
+    List,
+
+    /// Manage the default remote list
+    Default {
+        #[command(subcommand)]
+        command: RemoteDefaultCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum RemoteDefaultCommand {
+    /// Include a configured remote by default
+    Add {
+        /// Remote name used by toktrack
+        name: String,
+    },
+
+    /// Stop including a remote by default
+    Remove {
+        /// Remote name used by toktrack
+        name: String,
+    },
 }
 
 impl Cli {
     pub fn run(self) -> anyhow::Result<()> {
+        let remote_options = RemoteOptions {
+            remote_names: self.remotes,
+            all_remotes: self.all_remotes,
+            local_only: self.local_only,
+        };
+
         match self.command {
-            None | Some(Commands::Tui) => crate::tui::run(TuiConfig::default()),
+            None | Some(Commands::Tui) => crate::tui::run(TuiConfig {
+                remote_options,
+                ..TuiConfig::default()
+            }),
             Some(Commands::Daily { json }) => {
                 if json {
-                    Ok(run_daily_json()?)
+                    Ok(run_daily_json(&remote_options)?)
                 } else {
                     crate::tui::run(TuiConfig {
                         initial_view_mode: DailyViewMode::Daily,
                         initial_tab: None,
+                        remote_options,
                     })
                 }
             }
             Some(Commands::Stats { json }) => {
                 if json {
-                    Ok(run_stats_json()?)
+                    Ok(run_stats_json(&remote_options)?)
                 } else {
                     crate::tui::run(TuiConfig {
                         initial_view_mode: DailyViewMode::Daily,
                         initial_tab: Some(Tab::Stats),
+                        remote_options,
                     })
                 }
             }
             Some(Commands::Weekly { json }) => {
                 if json {
-                    Ok(run_weekly_json()?)
+                    Ok(run_weekly_json(&remote_options)?)
                 } else {
                     crate::tui::run(TuiConfig {
                         initial_view_mode: DailyViewMode::Weekly,
                         initial_tab: None,
+                        remote_options,
                     })
                 }
             }
             Some(Commands::Monthly { json }) => {
                 if json {
-                    Ok(run_monthly_json()?)
+                    Ok(run_monthly_json(&remote_options)?)
                 } else {
                     crate::tui::run(TuiConfig {
                         initial_view_mode: DailyViewMode::Monthly,
                         initial_tab: None,
+                        remote_options,
                     })
                 }
             }
@@ -123,32 +205,120 @@ impl Cli {
                 month,
                 days,
                 svg,
-            }) => Ok(run_report(week, month, days, svg)?),
+            }) => Ok(run_report(week, month, days, svg, &remote_options)?),
+            Some(Commands::Remote { command }) => Ok(run_remote_config(command)?),
+        }
+    }
+}
+
+fn run_remote_config(command: RemoteCommand) -> Result<()> {
+    let path = ConfigService::default_config_path()?;
+
+    match command {
+        RemoteCommand::List => {
+            let config = ConfigService::load_or_default(&path)?;
+            if config.remotes.is_empty() {
+                println!("No remote sources configured at {}", path.display());
+                return Ok(());
+            }
+
+            for remote in &config.remotes {
+                let default_marker = if config.default_remotes.contains(&remote.name) {
+                    " (default)"
+                } else {
+                    ""
+                };
+                println!(
+                    "{}{} -> {} (codex: {})",
+                    remote.name,
+                    default_marker,
+                    remote.target,
+                    remote.codex_sessions_path()
+                );
+            }
+            Ok(())
+        }
+        RemoteCommand::Add {
+            name,
+            target,
+            codex_path,
+            make_default,
+        } => {
+            let mut config = ConfigService::load_or_default(&path)?;
+            config.add_remote(
+                StoredRemoteConfig::new(name.clone(), target.clone(), codex_path),
+                make_default,
+            )?;
+            ConfigService::save(&path, &config)?;
+            if make_default {
+                println!("Added remote '{}' ({}) as a default remote", name, target);
+            } else {
+                println!("Added remote '{}' ({})", name, target);
+            }
+            Ok(())
+        }
+        RemoteCommand::Remove { name } => {
+            let mut config = ConfigService::load_or_default(&path)?;
+            config.remove_remote(&name)?;
+            ConfigService::save(&path, &config)?;
+            println!("Removed remote '{}'", name);
+            Ok(())
+        }
+        RemoteCommand::Default { command } => {
+            let mut config = ConfigService::load_or_default(&path)?;
+            match command {
+                RemoteDefaultCommand::Add { name } => {
+                    if config.add_default_remote(&name)? {
+                        ConfigService::save(&path, &config)?;
+                        println!("Added '{}' to default remotes", name);
+                    } else {
+                        println!("Remote '{}' is already a default remote", name);
+                    }
+                }
+                RemoteDefaultCommand::Remove { name } => {
+                    if config.remove_default_remote(&name)? {
+                        ConfigService::save(&path, &config)?;
+                        println!("Removed '{}' from default remotes", name);
+                    } else {
+                        println!("Remote '{}' is not a default remote", name);
+                    }
+                }
+            }
+            Ok(())
         }
     }
 }
 
 /// Load and process usage data from all CLI parsers.
 /// Uses cache-first strategy via DataLoaderService.
-fn load_data() -> Result<Vec<DailySummary>> {
-    let result = DataLoaderService::new().load()?;
+fn load_data(remote_options: &RemoteOptions) -> Result<Vec<DailySummary>> {
+    let result = load_data_full(remote_options)?;
     Ok(result.summaries)
 }
 
 /// Load full result including source_usage
-fn load_data_full() -> Result<crate::services::data_loader::LoadResult> {
-    DataLoaderService::new().load()
+fn load_data_full(
+    remote_options: &RemoteOptions,
+) -> Result<crate::services::data_loader::LoadResult> {
+    let extra_sources = RemoteSourceService::sync_and_build_sources(remote_options)?;
+    DataLoaderService::with_extra_sources(extra_sources).load()
 }
 
 /// Generate a usage report (text and optionally SVG)
-fn run_report(_week: bool, month: bool, days: Option<u32>, svg: Option<PathBuf>) -> Result<()> {
+fn run_report(
+    _week: bool,
+    month: bool,
+    days: Option<u32>,
+    svg: Option<PathBuf>,
+    remote_options: &RemoteOptions,
+) -> Result<()> {
     let n_days = if month { 30 } else { days.unwrap_or(7) };
 
     let today = Local::now().date_naive();
     let start = today - chrono::Duration::days(n_days as i64 - 1);
     let end = today;
 
-    let result = load_data_full()?;
+    let result = load_data_full(remote_options)?;
     let mut data =
         ReportData::from_summaries(&result.summaries, &result.source_summaries, start, end);
     // Carry per-source "estimated" (LiteLLM-calculated cost) onto the report.
@@ -175,8 +345,8 @@ fn run_report(_week: bool, month: bool, days: Option<u32>, svg: Option<PathBuf>)
 }
 
 /// Output daily summaries as JSON
-fn run_daily_json() -> Result<()> {
-    let mut summaries = load_data()?;
+fn run_daily_json(remote_options: &RemoteOptions) -> Result<()> {
+    let mut summaries = load_data(remote_options)?;
     summaries.sort_by_key(|b| std::cmp::Reverse(b.date));
     println!(
         "{}",
@@ -187,8 +357,8 @@ fn run_daily_json() -> Result<()> {
 }
 
 /// Output weekly summaries as JSON
-fn run_weekly_json() -> Result<()> {
-    let summaries = load_data()?;
+fn run_weekly_json(remote_options: &RemoteOptions) -> Result<()> {
+    let summaries = load_data(remote_options)?;
     let mut weekly = Aggregator::weekly(&summaries);
     weekly.sort_by_key(|b| std::cmp::Reverse(b.date));
     println!(
@@ -199,8 +369,8 @@ fn run_weekly_json() -> Result<()> {
 }
 
 /// Output monthly summaries as JSON
-fn run_monthly_json() -> Result<()> {
-    let summaries = load_data()?;
+fn run_monthly_json(remote_options: &RemoteOptions) -> Result<()> {
+    let summaries = load_data(remote_options)?;
     let mut monthly = Aggregator::monthly(&summaries);
     monthly.sort_by_key(|b| std::cmp::Reverse(b.date));
     println!(
@@ -211,8 +381,8 @@ fn run_monthly_json() -> Result<()> {
 }
 
 /// Output stats as JSON
-fn run_stats_json() -> Result<()> {
-    let summaries = load_data()?;
+fn run_stats_json(remote_options: &RemoteOptions) -> Result<()> {
+    let summaries = load_data(remote_options)?;
     let stats = StatsData::from_daily_summaries(&summaries);
     println!(
         "{}",
@@ -229,6 +399,9 @@ mod tests {
     fn test_cli_parse_no_args() {
         let cli = Cli::try_parse_from(["toktrack"]).unwrap();
         assert!(cli.command.is_none());
+        assert!(cli.remotes.is_empty());
+        assert!(!cli.all_remotes);
+        assert!(!cli.local_only);
     }
 
     #[test]
@@ -377,5 +550,100 @@ mod tests {
     fn test_cli_parse_report_week_month_conflict() {
         let result = Cli::try_parse_from(["toktrack", "report", "--week", "--month"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parse_remote_global_before_command() {
+        let cli = Cli::try_parse_from(["toktrack", "--remote", "devbox", "report"]).unwrap();
+        assert_eq!(cli.remotes, vec!["devbox"]);
+        assert!(matches!(cli.command, Some(Commands::Report { .. })));
+    }
+
+    #[test]
+    fn test_cli_parse_remote_global_after_command() {
+        let cli = Cli::try_parse_from(["toktrack", "report", "--remote", "devbox"]).unwrap();
+        assert_eq!(cli.remotes, vec!["devbox"]);
+        assert!(matches!(cli.command, Some(Commands::Report { .. })));
+    }
+
+    #[test]
+    fn test_cli_parse_all_remotes() {
+        let cli = Cli::try_parse_from(["toktrack", "--all-remotes", "daily", "--json"]).unwrap();
+        assert!(cli.all_remotes);
+        assert!(matches!(cli.command, Some(Commands::Daily { json: true })));
+    }
+
+    #[test]
+    fn test_cli_parse_local_only() {
+        let cli = Cli::try_parse_from(["toktrack", "--local-only", "stats"]).unwrap();
+        assert!(cli.local_only);
+        assert!(matches!(cli.command, Some(Commands::Stats { json: false })));
+    }
+
+    #[test]
+    fn test_cli_parse_remote_add_default() {
+        let cli = Cli::try_parse_from([
+            "toktrack",
+            "remote",
+            "add",
+            "devbox",
+            "ubuntu@devbox",
+            "--codex-path",
+            "/home/ubuntu/.codex/sessions",
+            "--default",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Remote {
+                command: RemoteCommand::Add {
+                    name,
+                    target,
+                    codex_path: Some(path),
+                    make_default: true,
+                },
+            }) if name == "devbox"
+                && target == "ubuntu@devbox"
+                && path == "/home/ubuntu/.codex/sessions"
+        ));
+    }
+
+    #[test]
+    fn test_cli_parse_remote_remove() {
+        let cli = Cli::try_parse_from(["toktrack", "remote", "remove", "devbox"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Remote {
+                command: RemoteCommand::Remove { name },
+            }) if name == "devbox"
+        ));
+    }
+
+    #[test]
+    fn test_cli_parse_remote_default_add() {
+        let cli = Cli::try_parse_from(["toktrack", "remote", "default", "add", "devbox"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Remote {
+                command: RemoteCommand::Default {
+                    command: RemoteDefaultCommand::Add { name },
+                },
+            }) if name == "devbox"
+        ));
+    }
+
+    #[test]
+    fn test_cli_parse_remote_default_remove() {
+        let cli =
+            Cli::try_parse_from(["toktrack", "remote", "default", "remove", "devbox"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Remote {
+                command: RemoteCommand::Default {
+                    command: RemoteDefaultCommand::Remove { name },
+                },
+            }) if name == "devbox"
+        ));
     }
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -158,17 +158,17 @@ impl ParserRegistry {
         }
     }
 
-    /// Create a registry with default sources plus additional source instances.
-    pub fn with_extra_sources(mut extra_sources: Vec<SourceInstance>) -> Self {
-        let mut registry = Self::new();
-        registry.sources.append(&mut extra_sources);
-        registry
-    }
-
     /// Create a registry from explicit source instances.
     #[allow(dead_code)] // Used by tests and future remote-source configuration.
     pub fn with_sources(sources: Vec<SourceInstance>) -> Self {
         Self { sources }
+    }
+
+    /// Create the default registry and append extra source instances.
+    pub fn with_extra_sources(mut extra_sources: Vec<SourceInstance>) -> Self {
+        let mut registry = Self::new();
+        registry.sources.append(&mut extra_sources);
+        registry
     }
 
     /// Get all registered source instances
@@ -251,6 +251,21 @@ mod tests {
             registry.get_source("codex@testbox").unwrap().id,
             "codex@testbox"
         );
+    }
+
+    #[test]
+    fn test_registry_appends_extra_sources_after_defaults() {
+        let registry = ParserRegistry::with_extra_sources(vec![SourceInstance::new(
+            "codex@testbox",
+            "codex (testbox)",
+            "codex",
+            Box::new(CodexParser::with_data_dir(PathBuf::from(
+                "tests/fixtures/codex",
+            ))),
+        )]);
+
+        assert_eq!(registry.sources().len(), 7);
+        assert_eq!(registry.sources()[6].id, "codex@testbox");
     }
 
     #[test]

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -97,38 +97,95 @@ pub trait CLIParser: Send + Sync {
     }
 }
 
-/// Registry of available parsers
+/// A concrete source of usage data backed by one parser.
+///
+/// The parser kind identifies the log format (for example, `codex`), while the
+/// source id identifies one concrete location that uses that format (for
+/// example, `codex` locally or `codex@devbox` for a future remote snapshot).
+pub struct SourceInstance {
+    pub id: String,
+    pub label: String,
+    pub kind: String,
+    pub parser: Box<dyn CLIParser>,
+}
+
+impl SourceInstance {
+    /// Create a source instance with explicit identity metadata.
+    #[allow(dead_code)] // Used by tests and future remote-source registration.
+    pub fn new(
+        id: impl Into<String>,
+        label: impl Into<String>,
+        kind: impl Into<String>,
+        parser: Box<dyn CLIParser>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            kind: kind.into(),
+            parser,
+        }
+    }
+
+    /// Create the default local source for a parser.
+    pub fn local(parser: Box<dyn CLIParser>) -> Self {
+        let kind = parser.name().to_string();
+        Self {
+            id: kind.clone(),
+            label: kind.clone(),
+            kind,
+            parser,
+        }
+    }
+}
+
+/// Registry of available usage sources
 pub struct ParserRegistry {
-    parsers: Vec<Box<dyn CLIParser>>,
+    sources: Vec<SourceInstance>,
 }
 
 impl ParserRegistry {
     /// Create a new registry with default parsers
     pub fn new() -> Self {
         Self {
-            parsers: vec![
-                Box::new(ClaudeCodeParser::new()),
-                Box::new(CodexParser::new()),
-                Box::new(GeminiParser::new()),
-                Box::new(GeminiParser::new_qwen()),
-                Box::new(OpenCodeParser::new()),
-                Box::new(PiAgentParser::new()),
+            sources: vec![
+                SourceInstance::local(Box::new(ClaudeCodeParser::new())),
+                SourceInstance::local(Box::new(CodexParser::new())),
+                SourceInstance::local(Box::new(GeminiParser::new())),
+                SourceInstance::local(Box::new(GeminiParser::new_qwen())),
+                SourceInstance::local(Box::new(OpenCodeParser::new())),
+                SourceInstance::local(Box::new(PiAgentParser::new())),
             ],
         }
     }
 
-    /// Get all registered parsers
-    pub fn parsers(&self) -> &[Box<dyn CLIParser>] {
-        &self.parsers
+    /// Create a registry with default sources plus additional source instances.
+    pub fn with_extra_sources(mut extra_sources: Vec<SourceInstance>) -> Self {
+        let mut registry = Self::new();
+        registry.sources.append(&mut extra_sources);
+        registry
     }
 
-    /// Find a parser by name
+    /// Create a registry from explicit source instances.
+    #[allow(dead_code)] // Used by tests and future remote-source configuration.
+    pub fn with_sources(sources: Vec<SourceInstance>) -> Self {
+        Self { sources }
+    }
+
+    /// Get all registered source instances
+    pub fn sources(&self) -> &[SourceInstance] {
+        &self.sources
+    }
+
+    /// Find a parser by source id.
     #[allow(dead_code)] // Used in tests and future features
-    pub fn get(&self, name: &str) -> Option<&dyn CLIParser> {
-        self.parsers
-            .iter()
-            .find(|p| p.name() == name)
-            .map(|p| p.as_ref())
+    pub fn get(&self, id: &str) -> Option<&dyn CLIParser> {
+        self.get_source(id).map(|source| source.parser.as_ref())
+    }
+
+    /// Find a source instance by id.
+    #[allow(dead_code)] // Used in tests and future features
+    pub fn get_source(&self, id: &str) -> Option<&SourceInstance> {
+        self.sources.iter().find(|source| source.id == id)
     }
 }
 
@@ -145,13 +202,55 @@ mod tests {
     #[test]
     fn test_registry_default_parsers() {
         let registry = ParserRegistry::new();
-        assert_eq!(registry.parsers().len(), 6);
+        assert_eq!(registry.sources().len(), 6);
         assert!(registry.get("claude-code").is_some());
         assert!(registry.get("codex").is_some());
         assert!(registry.get("gemini").is_some());
         assert!(registry.get("qwen").is_some());
         assert!(registry.get("opencode").is_some());
         assert!(registry.get("pi-agent").is_some());
+    }
+
+    #[test]
+    fn test_local_source_uses_parser_name_as_identity() {
+        let source = SourceInstance::local(Box::new(CodexParser::with_data_dir(PathBuf::from(
+            "tests/fixtures/codex",
+        ))));
+
+        assert_eq!(source.id, "codex");
+        assert_eq!(source.label, "codex");
+        assert_eq!(source.kind, "codex");
+        assert_eq!(source.parser.name(), "codex");
+    }
+
+    #[test]
+    fn test_registry_accepts_multiple_sources_for_same_parser_kind() {
+        let registry = ParserRegistry::with_sources(vec![
+            SourceInstance::new(
+                "codex",
+                "codex",
+                "codex",
+                Box::new(CodexParser::with_data_dir(PathBuf::from(
+                    "tests/fixtures/codex",
+                ))),
+            ),
+            SourceInstance::new(
+                "codex@testbox",
+                "codex (testbox)",
+                "codex",
+                Box::new(CodexParser::with_data_dir(PathBuf::from(
+                    "tests/fixtures/codex",
+                ))),
+            ),
+        ]);
+
+        assert_eq!(registry.sources().len(), 2);
+        assert_eq!(registry.get("codex").unwrap().name(), "codex");
+        assert_eq!(registry.get("codex@testbox").unwrap().name(), "codex");
+        assert_eq!(
+            registry.get_source("codex@testbox").unwrap().id,
+            "codex@testbox"
+        );
     }
 
     #[test]

--- a/src/services/config.rs
+++ b/src/services/config.rs
@@ -1,0 +1,444 @@
+//! Configuration loading for toktrack.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use directories::BaseDirs;
+use serde::{Deserialize, Serialize};
+
+use crate::types::{Result, ToktrackError};
+
+const DEFAULT_CODEX_SESSIONS_PATH: &str = "~/.codex/sessions";
+
+/// User configuration loaded from `~/.toktrack/config.toml`.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct ToktrackConfig {
+    /// Remote names that are included unless `--local-only` is used.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub default_remotes: Vec<String>,
+    /// Configured remote machines.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub remotes: Vec<RemoteConfig>,
+}
+
+/// One configured SSH remote.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RemoteConfig {
+    pub name: String,
+    pub target: String,
+    #[serde(default, skip_serializing_if = "RemotePaths::is_empty")]
+    pub paths: RemotePaths,
+}
+
+/// Per-tool remote data paths.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct RemotePaths {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub codex: Option<String>,
+}
+
+impl RemoteConfig {
+    pub fn new(name: impl Into<String>, target: impl Into<String>, codex: Option<String>) -> Self {
+        Self {
+            name: name.into(),
+            target: target.into(),
+            paths: RemotePaths { codex },
+        }
+    }
+
+    pub fn codex_sessions_path(&self) -> &str {
+        self.paths
+            .codex
+            .as_deref()
+            .filter(|path| !path.trim().is_empty())
+            .unwrap_or(DEFAULT_CODEX_SESSIONS_PATH)
+    }
+}
+
+impl RemotePaths {
+    fn is_empty(&self) -> bool {
+        self.codex.is_none()
+    }
+}
+
+impl ToktrackConfig {
+    pub fn remote(&self, name: &str) -> Option<&RemoteConfig> {
+        self.remotes.iter().find(|remote| remote.name == name)
+    }
+
+    pub fn remote_names(&self) -> Vec<String> {
+        self.remotes
+            .iter()
+            .map(|remote| remote.name.clone())
+            .collect()
+    }
+
+    pub fn add_remote(&mut self, remote: RemoteConfig, make_default: bool) -> Result<()> {
+        validate_remote_name(&remote.name)?;
+        if remote.target.trim().is_empty() {
+            return Err(ToktrackError::Config(format!(
+                "remote '{}' has an empty target",
+                remote.name
+            )));
+        }
+        if self.remote(&remote.name).is_some() {
+            return Err(ToktrackError::Config(format!(
+                "remote '{}' is already configured",
+                remote.name
+            )));
+        }
+
+        let name = remote.name.clone();
+        self.remotes.push(remote);
+        if make_default {
+            self.add_default_remote(&name)?;
+        }
+        self.validate()
+    }
+
+    pub fn remove_remote(&mut self, name: &str) -> Result<()> {
+        let original_len = self.remotes.len();
+        self.remotes.retain(|remote| remote.name != name);
+        if self.remotes.len() == original_len {
+            return Err(ToktrackError::Config(format!(
+                "remote '{}' is not configured",
+                name
+            )));
+        }
+
+        self.default_remotes
+            .retain(|default_name| default_name != name);
+        self.validate()
+    }
+
+    pub fn add_default_remote(&mut self, name: &str) -> Result<bool> {
+        validate_remote_name(name)?;
+        if self.remote(name).is_none() {
+            return Err(ToktrackError::Config(format!(
+                "remote '{}' is not configured",
+                name
+            )));
+        }
+        if self
+            .default_remotes
+            .iter()
+            .any(|default_name| default_name == name)
+        {
+            return Ok(false);
+        }
+
+        self.default_remotes.push(name.to_string());
+        self.validate()?;
+        Ok(true)
+    }
+
+    pub fn remove_default_remote(&mut self, name: &str) -> Result<bool> {
+        validate_remote_name(name)?;
+        let original_len = self.default_remotes.len();
+        self.default_remotes
+            .retain(|default_name| default_name != name);
+        self.validate()?;
+        Ok(self.default_remotes.len() != original_len)
+    }
+
+    fn validate(&self) -> Result<()> {
+        let mut names = HashSet::new();
+
+        for remote in &self.remotes {
+            validate_remote_name(&remote.name)?;
+            if remote.target.trim().is_empty() {
+                return Err(ToktrackError::Config(format!(
+                    "remote '{}' has an empty target",
+                    remote.name
+                )));
+            }
+            if !names.insert(remote.name.clone()) {
+                return Err(ToktrackError::Config(format!(
+                    "duplicate remote '{}'",
+                    remote.name
+                )));
+            }
+        }
+
+        for name in &self.default_remotes {
+            if self.remote(name).is_none() {
+                return Err(ToktrackError::Config(format!(
+                    "default remote '{}' is not configured",
+                    name
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Load toktrack configuration from disk.
+pub struct ConfigService;
+
+impl ConfigService {
+    pub fn default_config_path() -> Result<PathBuf> {
+        let base_dirs = BaseDirs::new()
+            .ok_or_else(|| ToktrackError::Config("cannot determine home directory".into()))?;
+        Ok(base_dirs.home_dir().join(".toktrack").join("config.toml"))
+    }
+
+    pub fn load_default() -> Result<Option<ToktrackConfig>> {
+        let path = Self::default_config_path()?;
+        Self::load_optional(&path)
+    }
+
+    pub fn load_optional(path: &Path) -> Result<Option<ToktrackConfig>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let content = fs::read_to_string(path)?;
+        let config: ToktrackConfig = toml::from_str(&content)
+            .map_err(|e| ToktrackError::Config(format!("failed to parse config: {}", e)))?;
+        config.validate()?;
+        Ok(Some(config))
+    }
+
+    pub fn load_or_default(path: &Path) -> Result<ToktrackConfig> {
+        Ok(Self::load_optional(path)?.unwrap_or_default())
+    }
+
+    pub fn save(path: &Path, config: &ToktrackConfig) -> Result<()> {
+        config.validate()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let content = toml::to_string_pretty(config)
+            .map_err(|e| ToktrackError::Config(format!("failed to serialize config: {}", e)))?;
+        fs::write(path, content)?;
+        Ok(())
+    }
+}
+
+fn validate_remote_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(ToktrackError::Config("remote name cannot be empty".into()));
+    }
+
+    if !name
+        .bytes()
+        .next()
+        .is_some_and(|b| b.is_ascii_alphanumeric())
+    {
+        return Err(ToktrackError::Config(format!(
+            "remote name '{}' must start with a letter or number and may only contain letters, numbers, '.', '_' and '-'",
+            name
+        )));
+    }
+
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+    {
+        return Err(ToktrackError::Config(format!(
+            "remote name '{}' may only contain letters, numbers, '.', '_' and '-'",
+            name
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_config(content: &str) -> Result<ToktrackConfig> {
+        let config: ToktrackConfig = toml::from_str(content)
+            .map_err(|e| ToktrackError::Config(format!("failed to parse config: {}", e)))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    #[test]
+    fn parses_remote_config() {
+        let config = load_config(
+            r#"
+default_remotes = ["devbox"]
+
+[[remotes]]
+name = "devbox"
+target = "ubuntu@devbox"
+
+[remotes.paths]
+codex = "/home/ubuntu/.codex/sessions"
+"#,
+        )
+        .unwrap();
+
+        let remote = config.remote("devbox").unwrap();
+        assert_eq!(config.default_remotes, vec!["devbox"]);
+        assert_eq!(remote.target, "ubuntu@devbox");
+        assert_eq!(remote.codex_sessions_path(), "/home/ubuntu/.codex/sessions");
+    }
+
+    #[test]
+    fn codex_path_defaults_to_standard_location() {
+        let config = load_config(
+            r#"
+[[remotes]]
+name = "devbox"
+target = "ubuntu@devbox"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.remote("devbox").unwrap().codex_sessions_path(),
+            DEFAULT_CODEX_SESSIONS_PATH
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_remote_names() {
+        let error = load_config(
+            r#"
+[[remotes]]
+name = "devbox"
+target = "ubuntu@devbox"
+
+[[remotes]]
+name = "devbox"
+target = "root@devbox"
+"#,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("duplicate remote"));
+    }
+
+    #[test]
+    fn rejects_unknown_default_remote() {
+        let error = load_config(r#"default_remotes = ["devbox"]"#).unwrap_err();
+        assert!(error.to_string().contains("default remote 'devbox'"));
+    }
+
+    #[test]
+    fn rejects_remote_name_with_path_separator() {
+        let error = load_config(
+            r#"
+[[remotes]]
+name = "../devbox"
+target = "ubuntu@devbox"
+"#,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("may only contain"));
+    }
+
+    #[test]
+    fn rejects_dot_remote_name() {
+        let error = load_config(
+            r#"
+[[remotes]]
+name = "."
+target = "ubuntu@devbox"
+"#,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("must start"));
+    }
+
+    #[test]
+    fn rejects_dot_dot_remote_name() {
+        let error = load_config(
+            r#"
+[[remotes]]
+name = ".."
+target = "ubuntu@devbox"
+"#,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("must start"));
+    }
+
+    #[test]
+    fn add_remote_can_mark_it_default() {
+        let mut config = ToktrackConfig::default();
+        config
+            .add_remote(
+                RemoteConfig::new("devbox", "ubuntu@devbox", Some("~/.codex/sessions".into())),
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(config.remote_names(), vec!["devbox"]);
+        assert_eq!(config.default_remotes, vec!["devbox"]);
+    }
+
+    #[test]
+    fn add_remote_rejects_duplicate_name() {
+        let mut config = ToktrackConfig::default();
+        config
+            .add_remote(RemoteConfig::new("devbox", "ubuntu@devbox", None), false)
+            .unwrap();
+        let error = config
+            .add_remote(RemoteConfig::new("devbox", "root@devbox", None), false)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("already configured"));
+    }
+
+    #[test]
+    fn remove_remote_also_removes_it_from_defaults() {
+        let mut config = ToktrackConfig::default();
+        config
+            .add_remote(RemoteConfig::new("devbox", "ubuntu@devbox", None), true)
+            .unwrap();
+
+        config.remove_remote("devbox").unwrap();
+
+        assert!(config.remotes.is_empty());
+        assert!(config.default_remotes.is_empty());
+    }
+
+    #[test]
+    fn add_default_remote_is_idempotent() {
+        let mut config = ToktrackConfig::default();
+        config
+            .add_remote(RemoteConfig::new("devbox", "ubuntu@devbox", None), false)
+            .unwrap();
+
+        assert!(config.add_default_remote("devbox").unwrap());
+        assert!(!config.add_default_remote("devbox").unwrap());
+        assert_eq!(config.default_remotes, vec!["devbox"]);
+    }
+
+    #[test]
+    fn remove_default_remote_reports_whether_it_changed_config() {
+        let mut config = ToktrackConfig::default();
+        config
+            .add_remote(RemoteConfig::new("devbox", "ubuntu@devbox", None), true)
+            .unwrap();
+
+        assert!(config.remove_default_remote("devbox").unwrap());
+        assert!(!config.remove_default_remote("devbox").unwrap());
+        assert!(config.default_remotes.is_empty());
+    }
+
+    #[test]
+    fn save_creates_parent_dirs_and_round_trips() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join(".toktrack").join("config.toml");
+        let mut config = ToktrackConfig::default();
+        config
+            .add_remote(RemoteConfig::new("devbox", "ubuntu@devbox", None), true)
+            .unwrap();
+
+        ConfigService::save(&path, &config).unwrap();
+        let loaded = ConfigService::load_optional(&path).unwrap().unwrap();
+
+        assert_eq!(loaded.default_remotes, vec!["devbox"]);
+        assert_eq!(loaded.remote("devbox").unwrap().target, "ubuntu@devbox");
+    }
+}

--- a/src/services/data_loader.rs
+++ b/src/services/data_loader.rs
@@ -8,7 +8,7 @@ use std::time::SystemTime;
 
 use chrono::{Local, TimeZone};
 
-use crate::parsers::ParserRegistry;
+use crate::parsers::{ParserRegistry, SourceInstance};
 use crate::services::{Aggregator, DailySummaryCacheService, PricingService};
 use crate::types::{CacheWarning, DailySummary, Result, SourceUsage, ToktrackError, UsageEntry};
 
@@ -83,6 +83,15 @@ impl DataLoaderService {
         }
     }
 
+    /// Create a data loader with default local sources plus additional sources.
+    pub fn with_extra_sources(extra_sources: Vec<SourceInstance>) -> Self {
+        Self {
+            registry: ParserRegistry::with_extra_sources(extra_sources),
+            cache_service: DailySummaryCacheService::new().ok(),
+            pricing: PricingService::from_cache_only(),
+        }
+    }
+
     /// Load data from all parsers using cache-first strategy
     pub fn load(&self) -> Result<LoadResult> {
         if self.has_valid_cache() {
@@ -96,13 +105,13 @@ impl DataLoaderService {
         self.load_cold_path()
     }
 
-    /// Check if any parser has a valid (version-matching) cache
+    /// Check if any source has a valid (version-matching) cache
     fn has_valid_cache(&self) -> bool {
         self.cache_service.as_ref().is_some_and(|cs| {
             self.registry
-                .parsers()
+                .sources()
                 .iter()
-                .any(|p| cs.is_version_current(p.name()))
+                .any(|source| cs.is_version_current(&source.id))
         })
     }
 
@@ -122,17 +131,19 @@ impl DataLoaderService {
         let mut source_summaries: HashMap<String, Vec<DailySummary>> = HashMap::new();
         let mut cache_warning = None;
 
-        for parser in self.registry.parsers() {
-            let has_parser_cache = cache_service.cache_path(parser.name()).exists();
+        for source in self.registry.sources() {
+            let parser = source.parser.as_ref();
+            debug_assert_eq!(source.kind, parser.name());
+            let has_source_cache = cache_service.cache_path(&source.id).exists();
 
-            let entries = if has_parser_cache {
-                let latest = cache_service.latest_cached_date(parser.name());
+            let entries = if has_source_cache {
+                let latest = cache_service.latest_cached_date(&source.id);
                 if has_date_gap(latest, yesterday) {
                     // Gap detected: full re-parse to fill missing dates
                     match parser.parse_all() {
                         Ok(e) => e,
                         Err(e) => {
-                            eprintln!("[toktrack] Warning: {} failed: {}", parser.name(), e);
+                            eprintln!("[toktrack] Warning: {} failed: {}", source.label, e);
                             continue;
                         }
                     }
@@ -143,7 +154,7 @@ impl DataLoaderService {
                             .filter(|entry| entry.local_date() >= yesterday)
                             .collect(),
                         Err(e) => {
-                            eprintln!("[toktrack] Warning: {} failed: {}", parser.name(), e);
+                            eprintln!("[toktrack] Warning: {} failed: {}", source.label, e);
                             continue;
                         }
                     }
@@ -152,7 +163,7 @@ impl DataLoaderService {
                 match parser.parse_all() {
                     Ok(e) => e,
                     Err(e) => {
-                        eprintln!("[toktrack] Warning: {} failed: {}", parser.name(), e);
+                        eprintln!("[toktrack] Warning: {} failed: {}", source.label, e);
                         continue;
                     }
                 }
@@ -160,19 +171,20 @@ impl DataLoaderService {
 
             let est = Self::batch_estimated(&entries);
             source_estimated
-                .entry(parser.name().to_string())
+                .entry(source.id.clone())
                 .and_modify(|e| *e |= est)
                 .or_insert(est);
+            let entries = Self::assign_source_id(entries, &source.id);
             let entries = self.apply_pricing(entries);
 
-            match cache_service.load_or_compute(parser.name(), &entries) {
+            match cache_service.load_or_compute(&source.id, &entries) {
                 Ok((summaries, warning)) => {
                     if warning.is_some() && cache_warning.is_none() {
                         cache_warning = warning;
                     }
-                    self.collect_source_stats(&summaries, parser.name(), &mut source_stats);
+                    self.collect_source_stats(&summaries, &source.id, &mut source_stats);
                     source_summaries
-                        .entry(parser.name().to_string())
+                        .entry(source.id.clone())
                         .or_default()
                         .extend(summaries.iter().cloned());
                     all_summaries.extend(summaries);
@@ -180,8 +192,7 @@ impl DataLoaderService {
                 Err(e) => {
                     eprintln!(
                         "[toktrack] Warning: cache for {} failed: {}",
-                        parser.name(),
-                        e
+                        source.label, e
                     );
                 }
             }
@@ -199,7 +210,7 @@ impl DataLoaderService {
         })
     }
 
-    /// Cold path: full parse_all() per parser + build cache
+    /// Cold path: full parse_all() per source + build cache
     fn load_cold_path(&self) -> Result<LoadResult> {
         // Try network pricing if cache-only failed
         let fallback_pricing;
@@ -218,11 +229,13 @@ impl DataLoaderService {
         let mut cache_warning = None;
         let mut any_entries = false;
 
-        for parser in self.registry.parsers() {
+        for source in self.registry.sources() {
+            let parser = source.parser.as_ref();
+            debug_assert_eq!(source.kind, parser.name());
             let entries = match parser.parse_all() {
                 Ok(e) => e,
                 Err(e) => {
-                    eprintln!("[toktrack] Warning: {} failed: {}", parser.name(), e);
+                    eprintln!("[toktrack] Warning: {} failed: {}", source.label, e);
                     continue;
                 }
             };
@@ -234,21 +247,22 @@ impl DataLoaderService {
 
             let est = Self::batch_estimated(&entries);
             source_estimated
-                .entry(parser.name().to_string())
+                .entry(source.id.clone())
                 .and_modify(|e| *e |= est)
                 .or_insert(est);
+            let entries = Self::assign_source_id(entries, &source.id);
             let entries = self.apply_pricing_with_ref(entries, pricing_ref);
 
             // Try to use cache service
             if let Some(cs) = &self.cache_service {
-                match cs.load_or_compute(parser.name(), &entries) {
+                match cs.load_or_compute(&source.id, &entries) {
                     Ok((summaries, warning)) => {
                         if warning.is_some() && cache_warning.is_none() {
                             cache_warning = warning;
                         }
-                        self.collect_source_stats(&summaries, parser.name(), &mut source_stats);
+                        self.collect_source_stats(&summaries, &source.id, &mut source_stats);
                         source_summaries
-                            .entry(parser.name().to_string())
+                            .entry(source.id.clone())
                             .or_default()
                             .extend(summaries.iter().cloned());
                         all_summaries.extend(summaries);
@@ -257,8 +271,7 @@ impl DataLoaderService {
                     Err(e) => {
                         eprintln!(
                             "[toktrack] Warning: cache for {} failed: {}",
-                            parser.name(),
-                            e
+                            source.label, e
                         );
                     }
                 }
@@ -266,9 +279,9 @@ impl DataLoaderService {
 
             // Cache unavailable: compute summaries directly
             let summaries = Aggregator::daily(&entries);
-            self.collect_source_stats(&summaries, parser.name(), &mut source_stats);
+            self.collect_source_stats(&summaries, &source.id, &mut source_stats);
             source_summaries
-                .entry(parser.name().to_string())
+                .entry(source.id.clone())
                 .or_default()
                 .extend(summaries.iter().cloned());
             all_summaries.extend(summaries);
@@ -303,6 +316,17 @@ impl DataLoaderService {
         entries
             .iter()
             .any(|e| e.cost_usd.is_none() && !is_copilot_provider(e.provider.as_deref()))
+    }
+
+    /// Override parser-provided source names with the concrete source id.
+    fn assign_source_id(entries: Vec<UsageEntry>, source_id: &str) -> Vec<UsageEntry> {
+        entries
+            .into_iter()
+            .map(|mut entry| {
+                entry.source = Some(source_id.to_string());
+                entry
+            })
+            .collect()
     }
 
     /// Apply pricing to entries using the given pricing service reference
@@ -408,7 +432,10 @@ pub fn is_copilot_provider(provider: Option<&str>) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::parsers::{CodexParser, SourceInstance};
+
     use super::*;
+    use std::path::PathBuf;
 
     // ========== is_copilot_provider tests ==========
 
@@ -594,13 +621,67 @@ mod tests {
     fn test_data_loader_service_new() {
         let service = DataLoaderService::new();
         // Just verify it can be constructed
-        assert!(!service.registry.parsers().is_empty());
+        assert!(!service.registry.sources().is_empty());
     }
 
     #[test]
     fn test_data_loader_service_default() {
         let service = DataLoaderService::default();
-        assert!(!service.registry.parsers().is_empty());
+        assert!(!service.registry.sources().is_empty());
+    }
+
+    #[test]
+    fn test_load_uses_source_id_for_cache_and_source_breakdown() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cache_dir = temp_dir.path().join("cache");
+        let pricing_path = temp_dir.path().join("pricing.json");
+        let fetched_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        std::fs::write(
+            &pricing_path,
+            format!(r#"{{"fetched_at":{},"models":{{}}}}"#, fetched_at),
+        )
+        .unwrap();
+
+        let service = DataLoaderService {
+            registry: ParserRegistry::with_sources(vec![
+                SourceInstance::new(
+                    "codex",
+                    "codex",
+                    "codex",
+                    Box::new(CodexParser::with_data_dir(PathBuf::from(
+                        "tests/fixtures/codex",
+                    ))),
+                ),
+                SourceInstance::new(
+                    "codex@testbox",
+                    "codex (testbox)",
+                    "codex",
+                    Box::new(CodexParser::with_data_dir(PathBuf::from(
+                        "tests/fixtures/codex",
+                    ))),
+                ),
+            ]),
+            cache_service: Some(DailySummaryCacheService::with_cache_dir(cache_dir.clone())),
+            pricing: PricingService::from_cache_only_with_path(&pricing_path),
+        };
+
+        let result = service.load().unwrap();
+
+        assert!(cache_dir.join("codex_daily.json").exists());
+        assert!(cache_dir.join("codex@testbox_daily.json").exists());
+        assert!(result.source_summaries.contains_key("codex"));
+        assert!(result.source_summaries.contains_key("codex@testbox"));
+
+        let sources: std::collections::HashSet<&str> = result
+            .source_usage
+            .iter()
+            .map(|usage| usage.source.as_str())
+            .collect();
+        assert!(sources.contains("codex"));
+        assert!(sources.contains("codex@testbox"));
     }
 
     // ========== apply_pricing tests ==========

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,9 +2,11 @@
 
 pub mod aggregator;
 pub mod cache;
+pub mod config;
 pub mod data_loader;
 pub mod normalizer;
 pub mod pricing;
+pub mod remote;
 pub mod update_checker;
 
 pub use aggregator::Aggregator;
@@ -12,3 +14,4 @@ pub use cache::DailySummaryCacheService;
 pub use data_loader::DataLoaderService;
 pub use normalizer::{display_name, normalize_model_name};
 pub use pricing::PricingService;
+pub use remote::{RemoteOptions, RemoteSourceService};

--- a/src/services/remote.rs
+++ b/src/services/remote.rs
@@ -1,0 +1,375 @@
+//! SSH remote source support.
+
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use directories::BaseDirs;
+
+use crate::parsers::{CodexParser, SourceInstance};
+use crate::services::config::{ConfigService, RemoteConfig, ToktrackConfig};
+use crate::types::{Result, ToktrackError};
+
+const RSYNC_SSH_COMMAND: &str = "ssh -o BatchMode=yes -o ConnectTimeout=5";
+
+/// CLI-selected remote source options.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RemoteOptions {
+    pub remote_names: Vec<String>,
+    pub all_remotes: bool,
+    pub local_only: bool,
+}
+
+/// Builds remote `SourceInstance`s by syncing configured Codex session files.
+pub struct RemoteSourceService {
+    snapshot_root: PathBuf,
+}
+
+impl RemoteSourceService {
+    pub fn new() -> Result<Self> {
+        let base_dirs = BaseDirs::new()
+            .ok_or_else(|| ToktrackError::Config("cannot determine home directory".into()))?;
+        Ok(Self {
+            snapshot_root: base_dirs.home_dir().join(".toktrack").join("remotes"),
+        })
+    }
+
+    pub fn sync_and_build_sources(options: &RemoteOptions) -> Result<Vec<SourceInstance>> {
+        Self::new()?.sync_and_build_sources_with_options(options)
+    }
+
+    fn sync_and_build_sources_with_options(
+        &self,
+        options: &RemoteOptions,
+    ) -> Result<Vec<SourceInstance>> {
+        let config = ConfigService::load_default()?;
+        let remote_names = resolve_remote_names(config.as_ref(), options)?;
+        let Some(config) = config else {
+            return Ok(Vec::new());
+        };
+
+        let mut sources = Vec::with_capacity(remote_names.len());
+        for name in remote_names {
+            let remote = config.remote(&name).ok_or_else(|| {
+                ToktrackError::Config(format!("remote '{}' is not configured", name))
+            })?;
+            let snapshot_dir = self.snapshot_dir(remote);
+            let sync_result = self.sync_codex(remote, &snapshot_dir);
+            sources.push(build_source_after_sync_attempt(
+                remote,
+                snapshot_dir,
+                sync_result,
+            ));
+        }
+
+        Ok(sources)
+    }
+
+    fn snapshot_dir(&self, remote: &RemoteConfig) -> PathBuf {
+        self.snapshot_root
+            .join(&remote.name)
+            .join("codex")
+            .join("sessions")
+    }
+
+    fn sync_codex(&self, remote: &RemoteConfig, snapshot_dir: &Path) -> Result<()> {
+        fs::create_dir_all(snapshot_dir)?;
+        let args = build_rsync_args(remote, snapshot_dir);
+        let output = Command::new("rsync").args(&args).output().map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                ToktrackError::Remote("rsync not found; install rsync to use remote sources".into())
+            } else {
+                ToktrackError::Io(e)
+            }
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(ToktrackError::Remote(format!(
+                "failed to sync remote '{}': {}",
+                remote.name,
+                stderr.trim()
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+pub fn resolve_remote_names(
+    config: Option<&ToktrackConfig>,
+    options: &RemoteOptions,
+) -> Result<Vec<String>> {
+    if options.local_only && (!options.remote_names.is_empty() || options.all_remotes) {
+        return Err(ToktrackError::Config(
+            "--local-only cannot be combined with --remote or --all-remotes".into(),
+        ));
+    }
+
+    if options.local_only {
+        return Ok(Vec::new());
+    }
+
+    let Some(config) = config else {
+        if options.remote_names.is_empty() && !options.all_remotes {
+            return Ok(Vec::new());
+        }
+        return Err(ToktrackError::Config(
+            "remote sources require ~/.toktrack/config.toml".into(),
+        ));
+    };
+
+    if options.all_remotes {
+        return Ok(config.remote_names());
+    }
+
+    let mut names = Vec::new();
+    for name in config
+        .default_remotes
+        .iter()
+        .chain(options.remote_names.iter())
+    {
+        if config.remote(name).is_none() {
+            let available = config.remote_names().join(", ");
+            return Err(ToktrackError::Config(format!(
+                "remote '{}' is not configured{}",
+                name,
+                if available.is_empty() {
+                    String::new()
+                } else {
+                    format!("; available remotes: {}", available)
+                }
+            )));
+        }
+        if !names.contains(name) {
+            names.push(name.clone());
+        }
+    }
+
+    Ok(names)
+}
+
+fn build_codex_source(remote: &RemoteConfig, snapshot_dir: PathBuf) -> SourceInstance {
+    SourceInstance::new(
+        format!("codex@{}", remote.name),
+        format!("codex ({})", remote.name),
+        "codex",
+        Box::new(CodexParser::with_data_dir(snapshot_dir)),
+    )
+}
+
+fn build_source_after_sync_attempt(
+    remote: &RemoteConfig,
+    snapshot_dir: PathBuf,
+    sync_result: Result<()>,
+) -> SourceInstance {
+    if let Err(error) = sync_result {
+        warn_sync_failed(remote, &snapshot_dir, &error);
+    }
+    build_codex_source(remote, snapshot_dir)
+}
+
+pub fn build_rsync_args(remote: &RemoteConfig, snapshot_dir: &Path) -> Vec<OsString> {
+    vec![
+        OsString::from("-az"),
+        OsString::from("--delete"),
+        OsString::from("-e"),
+        OsString::from(RSYNC_SSH_COMMAND),
+        OsString::from("--include"),
+        OsString::from("*/"),
+        OsString::from("--include"),
+        OsString::from("*.jsonl"),
+        OsString::from("--exclude"),
+        OsString::from("*"),
+        OsString::from("--"),
+        OsString::from(remote_codex_spec(remote)),
+        snapshot_dir.as_os_str().to_os_string(),
+    ]
+}
+
+fn warn_sync_failed(remote: &RemoteConfig, snapshot_dir: &Path, error: &ToktrackError) {
+    eprintln!(
+        "[toktrack] Warning: {}. Using existing snapshot/cache for remote '{}' if available (snapshot: {}).",
+        error,
+        remote.name,
+        snapshot_dir.display()
+    );
+}
+
+fn remote_codex_spec(remote: &RemoteConfig) -> String {
+    format!(
+        "{}:{}/",
+        remote.target,
+        remote.codex_sessions_path().trim_end_matches('/')
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::config::RemotePaths;
+
+    fn config() -> ToktrackConfig {
+        ToktrackConfig {
+            default_remotes: vec!["devbox".to_string()],
+            remotes: vec![
+                RemoteConfig {
+                    name: "devbox".to_string(),
+                    target: "ubuntu@devbox".to_string(),
+                    paths: RemotePaths {
+                        codex: Some("~/.codex/sessions".to_string()),
+                    },
+                },
+                RemoteConfig {
+                    name: "prod".to_string(),
+                    target: "prod-alias".to_string(),
+                    paths: RemotePaths {
+                        codex: Some("/home/codex/.codex/sessions".to_string()),
+                    },
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn default_remotes_are_used_without_cli_overrides() {
+        let options = RemoteOptions::default();
+        let names = resolve_remote_names(Some(&config()), &options).unwrap();
+        assert_eq!(names, vec!["devbox"]);
+    }
+
+    #[test]
+    fn explicit_remotes_are_appended_after_defaults() {
+        let options = RemoteOptions {
+            remote_names: vec!["prod".to_string(), "devbox".to_string()],
+            all_remotes: false,
+            local_only: false,
+        };
+        let names = resolve_remote_names(Some(&config()), &options).unwrap();
+        assert_eq!(names, vec!["devbox", "prod"]);
+    }
+
+    #[test]
+    fn local_only_ignores_default_remotes() {
+        let options = RemoteOptions {
+            local_only: true,
+            ..RemoteOptions::default()
+        };
+        let names = resolve_remote_names(Some(&config()), &options).unwrap();
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn all_remotes_uses_config_order() {
+        let options = RemoteOptions {
+            all_remotes: true,
+            ..RemoteOptions::default()
+        };
+        let names = resolve_remote_names(Some(&config()), &options).unwrap();
+        assert_eq!(names, vec!["devbox", "prod"]);
+    }
+
+    #[test]
+    fn local_only_conflicts_with_explicit_remote() {
+        let options = RemoteOptions {
+            remote_names: vec!["devbox".to_string()],
+            local_only: true,
+            all_remotes: false,
+        };
+        let error = resolve_remote_names(Some(&config()), &options).unwrap_err();
+        assert!(error.to_string().contains("cannot be combined"));
+    }
+
+    #[test]
+    fn local_only_conflicts_with_all_remotes() {
+        let options = RemoteOptions {
+            all_remotes: true,
+            local_only: true,
+            ..RemoteOptions::default()
+        };
+        let error = resolve_remote_names(Some(&config()), &options).unwrap_err();
+        assert!(error.to_string().contains("cannot be combined"));
+    }
+
+    #[test]
+    fn unknown_remote_returns_available_names() {
+        let options = RemoteOptions {
+            remote_names: vec!["unknown".to_string()],
+            ..RemoteOptions::default()
+        };
+        let error = resolve_remote_names(Some(&config()), &options).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("available remotes: devbox, prod"));
+    }
+
+    #[test]
+    fn missing_config_without_remote_options_is_local_only() {
+        let options = RemoteOptions::default();
+        let names = resolve_remote_names(None, &options).unwrap();
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn missing_config_with_explicit_remote_is_error() {
+        let options = RemoteOptions {
+            remote_names: vec!["devbox".to_string()],
+            ..RemoteOptions::default()
+        };
+        let error = resolve_remote_names(None, &options).unwrap_err();
+        assert!(error.to_string().contains("config.toml"));
+    }
+
+    #[test]
+    fn builds_remote_codex_source_identity() {
+        let remote = &config().remotes[0];
+        let source = build_codex_source(remote, PathBuf::from("/tmp/devbox/codex/sessions"));
+
+        assert_eq!(source.id, "codex@devbox");
+        assert_eq!(source.label, "codex (devbox)");
+        assert_eq!(source.kind, "codex");
+    }
+
+    #[test]
+    fn sync_failure_still_returns_remote_source_for_cache_fallback() {
+        let remote = &config().remotes[0];
+        let source = build_source_after_sync_attempt(
+            remote,
+            PathBuf::from("/tmp/devbox/codex/sessions"),
+            Err(ToktrackError::Remote("boom".into())),
+        );
+
+        assert_eq!(source.id, "codex@devbox");
+        assert_eq!(source.kind, "codex");
+    }
+
+    #[test]
+    fn builds_rsync_args_for_codex_sessions() {
+        let remote = &config().remotes[1];
+        let args = build_rsync_args(remote, Path::new("/tmp/toktrack/prod"));
+        let args: Vec<String> = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            args,
+            vec![
+                "-az",
+                "--delete",
+                "-e",
+                "ssh -o BatchMode=yes -o ConnectTimeout=5",
+                "--include",
+                "*/",
+                "--include",
+                "*.jsonl",
+                "--exclude",
+                "*",
+                "--",
+                "prod-alias:/home/codex/.codex/sessions/",
+                "/tmp/toktrack/prod"
+            ]
+        );
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -14,7 +14,7 @@ use ratatui::{
 use super::theme::Theme;
 
 use crate::services::update_checker::{check_for_update, execute_update, UpdateCheckResult};
-use crate::services::{Aggregator, DataLoaderService};
+use crate::services::{Aggregator, DataLoaderService, RemoteOptions, RemoteSourceService};
 use crate::types::{CacheWarning, DailySummary, SourceUsage, StatsData, TotalSummary};
 
 use super::widgets::{
@@ -49,6 +49,7 @@ impl Default for ViewMode {
 pub struct TuiConfig {
     pub initial_view_mode: DailyViewMode,
     pub initial_tab: Option<Tab>,
+    pub remote_options: RemoteOptions,
 }
 
 /// Application state
@@ -783,8 +784,12 @@ pub fn run(config: TuiConfig) -> anyhow::Result<()> {
 
 /// Load data synchronously (extracted for background thread).
 /// Uses cache-first strategy via DataLoaderService.
-fn load_data_sync() -> Result<Box<AppData>, String> {
-    let result = DataLoaderService::new().load().map_err(|e| e.to_string())?;
+fn load_data_sync(remote_options: RemoteOptions) -> Result<Box<AppData>, String> {
+    let extra_sources =
+        RemoteSourceService::sync_and_build_sources(&remote_options).map_err(|e| e.to_string())?;
+    let result = DataLoaderService::with_extra_sources(extra_sources)
+        .load()
+        .map_err(|e| e.to_string())?;
 
     build_app_data_from_summaries(
         result.summaries,
@@ -858,13 +863,14 @@ fn build_app_data_from_summaries(
 }
 
 fn run_app(terminal: &mut DefaultTerminal, config: TuiConfig, theme: Theme) -> anyhow::Result<()> {
+    let remote_options = config.remote_options.clone();
     let mut app = App::new(config, theme);
     app.terminal_height = terminal.size()?.height;
 
     // Spawn background thread for data loading
     let (data_tx, data_rx) = mpsc::channel();
     thread::spawn(move || {
-        let result = load_data_sync();
+        let result = load_data_sync(remote_options);
         let _ = data_tx.send(result);
     });
 
@@ -1403,6 +1409,7 @@ mod tests {
         let config = TuiConfig {
             initial_view_mode: DailyViewMode::Weekly,
             initial_tab: None,
+            ..TuiConfig::default()
         };
         let app = App::new(config, Theme::Dark);
 
@@ -1750,6 +1757,7 @@ mod tests {
         let config = TuiConfig {
             initial_view_mode: DailyViewMode::Daily,
             initial_tab: Some(Tab::Stats),
+            ..TuiConfig::default()
         };
         let app = App::new(config, Theme::Dark);
         assert!(matches!(

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -23,8 +23,11 @@ pub enum ToktrackError {
 
     /// Configuration error
     #[error("config error: {0}")]
-    #[allow(dead_code)]
     Config(String),
+
+    /// Remote sync error
+    #[error("remote error: {0}")]
+    Remote(String),
 }
 
 /// Result type alias for toktrack


### PR DESCRIPTION
This pr adds support for tracking Codex usage from SSH remote environments. 

### Motivation: 
codex recently support use codex app in PC to work in ssh server, which is the same as vscode plugin in ssh mode. For me, most of tokens  is used and storaged in ssh server. Thus, toktrack cannot take this into account. That's why I add this feature. Becuase I don't use claude code and gemini code, I don't add them into this pr (I don't know how cc and gemini is logged in ssh server). This support can be added later.

This decription is writed with the assistance of AI.

It first refactors parser registration around explicit source instances, then uses that source identity layer to add configurable remote Codex sources. toktrack can now sync Codex JSONL session logs from configured SSH hosts, parse them with the existing Codex parser, and include them in normal commands such as `report`, `daily`, `stats`, and the TUI.

Remote Codex usage is tracked separately from local Codex usage with source ids like `codex@devbox`.

This PR makes that workflow first-class:

- local Codex usage remains tracked as before
- remote Codex usage can be synced over SSH
- each remote source has its own identity, cache, and source breakdown
- users can configure default remote hosts so normal report/stat commands include them automatically

## Changes

### Source instances

- Add `SourceInstance` with separate `id`, `label`, and parser `kind`.
- Update the parser registry to register source instances instead of assuming one source per parser kind.
- Preserve existing local source identities.
- Update data loading so cache files and source usage breakdowns use `source.id`.
- Allow additional source instances to be appended to the default registry.

### Remote Codex sources

- Add config loading from `~/.toktrack/config.toml`.
- Support configured remotes with `name`, `target`, and optional `paths.codex`.
- Sync remote Codex `*.jsonl` files via `rsync` over the user's existing SSH setup.
- Store remote snapshots under:

```text
~/.toktrack/remotes/<remote-name>/codex/sessions/
```

- Register remote Codex sources as:

```text
codex@<remote-name>
```

- Keep remote cache files separate, for example:

```text
~/.toktrack/cache/codex@devbox_daily.json
```

### CLI behavior

Normal commands now support remote selection:

```bash
toktrack report                         # local + default_remotes
toktrack --remote devbox report         # local + default_remotes + devbox
toktrack --all-remotes stats            # local + every configured remote
toktrack --local-only report            # local only
```

Conflicting options are rejected:

```bash
toktrack --remote devbox --local-only report
toktrack --all-remotes --local-only report
```

### Config management commands

Users can manage remote config without editing TOML manually:

```bash
toktrack remote add devbox ubuntu@devbox --default
toktrack remote add prod prod-alias --codex-path /home/codex/.codex/sessions
toktrack remote default add prod
toktrack remote default remove devbox
toktrack remote remove prod
toktrack remote list
```

Example config:

```toml
default_remotes = ["devbox"]

[[remotes]]
name = "devbox"
target = "ubuntu@devbox"

[remotes.paths]
codex = "~/.codex/sessions"
```

The target field is passed to SSH/rsync, so it can be either `user@host` or an SSH config alias.

## Compatibility

For users without `~/.toktrack/config.toml`, behavior remains local-only and unchanged.

Existing local Claude/Codex/Gemini/OpenCode parsing continues to work as before. Remote sources are additive unless configured as defaults.

## Test Plan

- `cargo fmt -- --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`

Current result:

```text
522 passed; 0 failed; 1 ignored
```


