### PR TITLE
feat(parser): common data-dir discovery with env-var overrides

### DIFF
--- a/src/parsers/claude.rs
+++ b/src/parsers/claude.rs
@@ -54,16 +54,21 @@ pub struct ClaudeCodeParser {
 }
 
 impl ClaudeCodeParser {
-    /// Create a new parser with default data directory (~/.claude/projects/)
+    /// Create a new parser with default data directory.
+    ///
+    /// Honors `CLAUDE_CONFIG_DIR` (root; replaces `~/.claude`); projects live
+    /// under `<root>/projects`.
     pub fn new() -> Self {
-        let home = directories::BaseDirs::new()
-            .map(|d| d.home_dir().to_path_buf())
-            .unwrap_or_else(|| {
-                eprintln!("[toktrack] Warning: Could not determine home directory");
-                PathBuf::from(".")
-            });
+        let root = super::discovery::first_env_dir(&["CLAUDE_CONFIG_DIR"]).unwrap_or_else(|| {
+            directories::BaseDirs::new()
+                .map(|d| d.home_dir().join(".claude"))
+                .unwrap_or_else(|| {
+                    eprintln!("[toktrack] Warning: Could not determine home directory");
+                    PathBuf::from(".")
+                })
+        });
         Self {
-            data_dir: home.join(".claude").join("projects"),
+            data_dir: root.join("projects"),
         }
     }
 
@@ -316,6 +321,20 @@ mod tests {
     fn test_parser_file_pattern() {
         let parser = ClaudeCodeParser::new();
         assert_eq!(parser.file_pattern(), "**/*.jsonl");
+    }
+
+    #[test]
+    fn test_claude_config_dir_env_override() {
+        let saved = std::env::var("CLAUDE_CONFIG_DIR").ok();
+        std::env::set_var("CLAUDE_CONFIG_DIR", "/tmp/toktrack-claude-cfg");
+        assert_eq!(
+            ClaudeCodeParser::new().data_dir(),
+            Path::new("/tmp/toktrack-claude-cfg/projects")
+        );
+        match saved {
+            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+        }
     }
 
     #[test]

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -61,16 +61,21 @@ pub struct CodexParser {
 }
 
 impl CodexParser {
-    /// Create a new parser with default data directory (~/.codex/sessions/)
+    /// Create a new parser with default data directory.
+    ///
+    /// Honors `CODEX_HOME` (root; replaces `~/.codex`); sessions live under
+    /// `<root>/sessions`.
     pub fn new() -> Self {
-        let home = directories::BaseDirs::new()
-            .map(|d| d.home_dir().to_path_buf())
-            .unwrap_or_else(|| {
-                eprintln!("[toktrack] Warning: Could not determine home directory");
-                PathBuf::from(".")
-            });
+        let root = super::discovery::first_env_dir(&["CODEX_HOME"]).unwrap_or_else(|| {
+            directories::BaseDirs::new()
+                .map(|d| d.home_dir().join(".codex"))
+                .unwrap_or_else(|| {
+                    eprintln!("[toktrack] Warning: Could not determine home directory");
+                    PathBuf::from(".")
+                })
+        });
         Self {
-            data_dir: home.join(".codex").join("sessions"),
+            data_dir: root.join("sessions"),
         }
     }
 
@@ -400,6 +405,20 @@ mod tests {
     fn test_parser_file_pattern() {
         let parser = CodexParser::new();
         assert_eq!(parser.file_pattern(), "**/*.jsonl");
+    }
+
+    #[test]
+    fn test_codex_home_env_override() {
+        let saved = std::env::var("CODEX_HOME").ok();
+        std::env::set_var("CODEX_HOME", "/tmp/toktrack-codex-home");
+        assert_eq!(
+            CodexParser::new().data_dir(),
+            Path::new("/tmp/toktrack-codex-home/sessions")
+        );
+        match saved {
+            Some(v) => std::env::set_var("CODEX_HOME", v),
+            None => std::env::remove_var("CODEX_HOME"),
+        }
     }
 
     #[test]

--- a/src/parsers/discovery.rs
+++ b/src/parsers/discovery.rs
@@ -1,0 +1,73 @@
+//! Shared data-directory discovery for parsers.
+//!
+//! Centralizes environment-variable overrides so each parser doesn't reimplement
+//! the "first non-empty env var wins, empty means unset" rule. Confirmed upstream
+//! override variables:
+//! - Codex: `CODEX_HOME` (root; sessions live under `$CODEX_HOME/sessions`)
+//! - Claude: `CLAUDE_CONFIG_DIR` (root; projects under `$CLAUDE_CONFIG_DIR/projects`)
+//! - Gemini: `GEMINI_CLI_HOME` (home root; data under `$GEMINI_CLI_HOME/.gemini/tmp`)
+//! - OpenCode: `OPENCODE_DATA_DIR` (full data dir) / `XDG_DATA_HOME` (base)
+//! - PI Agent: `PI_CODING_AGENT_SESSION_DIR` (== `--session-dir`) then `PI_AGENT_DIR`
+
+use std::path::PathBuf;
+
+/// First usable directory among `env_vars`: the first variable that is set and
+/// non-empty. `CODEX_HOME`/`CLAUDE_CONFIG_DIR` may be comma-separated lists, so
+/// the first entry is taken. Empty/whitespace values are treated as unset.
+pub fn first_env_dir(env_vars: &[&str]) -> Option<PathBuf> {
+    for name in env_vars {
+        if let Ok(val) = std::env::var(name) {
+            let first = val.split(',').next().unwrap_or("").trim();
+            if !first.is_empty() {
+                return Some(PathBuf::from(first));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Each test uses a uniquely-named env var to avoid cross-test races
+    // (cargo runs tests in parallel; process env is global).
+    #[test]
+    fn test_returns_none_when_unset() {
+        assert_eq!(first_env_dir(&["TOKTRACK_DISCOVERY_UNSET_XYZ"]), None);
+    }
+
+    #[test]
+    fn test_returns_first_set_var() {
+        std::env::set_var("TOKTRACK_DISCOVERY_A1", "/tmp/a1");
+        let got = first_env_dir(&["TOKTRACK_DISCOVERY_A1"]);
+        std::env::remove_var("TOKTRACK_DISCOVERY_A1");
+        assert_eq!(got, Some(PathBuf::from("/tmp/a1")));
+    }
+
+    #[test]
+    fn test_empty_value_treated_as_unset() {
+        std::env::set_var("TOKTRACK_DISCOVERY_EMPTY", "   ");
+        let got = first_env_dir(&["TOKTRACK_DISCOVERY_EMPTY"]);
+        std::env::remove_var("TOKTRACK_DISCOVERY_EMPTY");
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn test_precedence_first_non_empty_wins() {
+        std::env::set_var("TOKTRACK_DISCOVERY_P1", "");
+        std::env::set_var("TOKTRACK_DISCOVERY_P2", "/tmp/p2");
+        let got = first_env_dir(&["TOKTRACK_DISCOVERY_P1", "TOKTRACK_DISCOVERY_P2"]);
+        std::env::remove_var("TOKTRACK_DISCOVERY_P1");
+        std::env::remove_var("TOKTRACK_DISCOVERY_P2");
+        assert_eq!(got, Some(PathBuf::from("/tmp/p2")));
+    }
+
+    #[test]
+    fn test_comma_list_takes_first_entry() {
+        std::env::set_var("TOKTRACK_DISCOVERY_LIST", "/tmp/first,/tmp/second");
+        let got = first_env_dir(&["TOKTRACK_DISCOVERY_LIST"]);
+        std::env::remove_var("TOKTRACK_DISCOVERY_LIST");
+        assert_eq!(got, Some(PathBuf::from("/tmp/first")));
+    }
+}

--- a/src/parsers/gemini.rs
+++ b/src/parsers/gemini.rs
@@ -96,10 +96,7 @@ impl GeminiParser {
     /// Honors `GEMINI_CLI_HOME` (matches gemini-cli's `paths.ts` behavior),
     /// falling back to the user's home directory.
     pub fn new() -> Self {
-        let home = std::env::var("GEMINI_CLI_HOME")
-            .ok()
-            .filter(|s| !s.is_empty())
-            .map(PathBuf::from)
+        let home = super::discovery::first_env_dir(&["GEMINI_CLI_HOME"])
             .or_else(|| directories::BaseDirs::new().map(|d| d.home_dir().to_path_buf()))
             .unwrap_or_else(|| {
                 eprintln!("[toktrack] Warning: Could not determine home directory");

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -2,6 +2,7 @@
 
 mod claude;
 mod codex;
+mod discovery;
 mod gemini;
 mod opencode;
 mod pi_agent;

--- a/src/parsers/opencode.rs
+++ b/src/parsers/opencode.rs
@@ -61,15 +61,22 @@ pub struct OpenCodeParser {
 
 impl OpenCodeParser {
     /// Default: `~/.local/share/opencode/{opencode.db, storage/message/}`.
-    /// OpenCode uses XDG layout on every platform.
+    ///
+    /// Honors `OPENCODE_DATA_DIR` (the full data dir) then `XDG_DATA_HOME`
+    /// (base; `<XDG_DATA_HOME>/opencode`), falling back to the XDG default.
     pub fn new() -> Self {
-        let base = directories::BaseDirs::new()
-            .map(|d| d.home_dir().join(".local").join("share"))
-            .unwrap_or_else(|| {
-                eprintln!("[toktrack] Warning: Could not determine home directory");
-                PathBuf::from(".")
+        let base = super::discovery::first_env_dir(&["OPENCODE_DATA_DIR"])
+            .or_else(|| {
+                super::discovery::first_env_dir(&["XDG_DATA_HOME"]).map(|x| x.join("opencode"))
             })
-            .join("opencode");
+            .unwrap_or_else(|| {
+                directories::BaseDirs::new()
+                    .map(|d| d.home_dir().join(".local").join("share").join("opencode"))
+                    .unwrap_or_else(|| {
+                        eprintln!("[toktrack] Warning: Could not determine home directory");
+                        PathBuf::from(".")
+                    })
+            });
         Self::with_base_dir(base)
     }
 
@@ -368,6 +375,22 @@ mod tests {
     fn parser_uses_msg_glob_pattern() {
         let parser = OpenCodeParser::new();
         assert_eq!(parser.file_pattern(), "**/msg_*.json");
+    }
+
+    #[test]
+    fn opencode_data_dir_env_override() {
+        // OPENCODE_DATA_DIR is the full data dir → json/db derive from it.
+        let saved = std::env::var("OPENCODE_DATA_DIR").ok();
+        std::env::set_var("OPENCODE_DATA_DIR", "/tmp/toktrack-oc-data");
+        let parser = OpenCodeParser::new();
+        assert_eq!(
+            parser.data_dir(),
+            Path::new("/tmp/toktrack-oc-data/storage/message")
+        );
+        match saved {
+            Some(v) => std::env::set_var("OPENCODE_DATA_DIR", v),
+            None => std::env::remove_var("OPENCODE_DATA_DIR"),
+        }
     }
 
     #[test]

--- a/src/parsers/pi_agent.rs
+++ b/src/parsers/pi_agent.rs
@@ -78,21 +78,21 @@ pub struct PiAgentParser {
 }
 
 impl PiAgentParser {
-    /// Create a new parser with default data directory (~/.pi/agent/sessions/)
-    /// or PI_AGENT_DIR if set.
+    /// Create a new parser with default data directory (~/.pi/agent/sessions/).
+    ///
+    /// Honors `PI_CODING_AGENT_SESSION_DIR` (== `--session-dir`, canonical since
+    /// v0.71.0) with precedence over the legacy `PI_AGENT_DIR`.
     pub fn new() -> Self {
-        let data_dir = std::env::var("PI_AGENT_DIR")
-            .ok()
-            .filter(|v| !v.trim().is_empty())
-            .map(PathBuf::from)
-            .or_else(|| {
-                directories::BaseDirs::new()
-                    .map(|d| d.home_dir().join(".pi").join("agent").join("sessions"))
-            })
-            .unwrap_or_else(|| {
-                eprintln!("[toktrack] Warning: Could not determine home directory");
-                PathBuf::from(".")
-            });
+        let data_dir =
+            super::discovery::first_env_dir(&["PI_CODING_AGENT_SESSION_DIR", "PI_AGENT_DIR"])
+                .or_else(|| {
+                    directories::BaseDirs::new()
+                        .map(|d| d.home_dir().join(".pi").join("agent").join("sessions"))
+                })
+                .unwrap_or_else(|| {
+                    eprintln!("[toktrack] Warning: Could not determine home directory");
+                    PathBuf::from(".")
+                });
 
         Self { data_dir }
     }
@@ -295,6 +295,27 @@ mod tests {
     fn test_parser_file_pattern() {
         let parser = PiAgentParser::new();
         assert_eq!(parser.file_pattern(), "**/*.jsonl");
+    }
+
+    #[test]
+    fn test_pi_session_dir_env_takes_precedence() {
+        // PI_CODING_AGENT_SESSION_DIR (== --session-dir) wins over legacy PI_AGENT_DIR.
+        let saved_s = std::env::var("PI_CODING_AGENT_SESSION_DIR").ok();
+        let saved_a = std::env::var("PI_AGENT_DIR").ok();
+        std::env::set_var("PI_AGENT_DIR", "/tmp/toktrack-pi-legacy");
+        std::env::set_var("PI_CODING_AGENT_SESSION_DIR", "/tmp/toktrack-pi-session");
+        assert_eq!(
+            PiAgentParser::new().data_dir(),
+            Path::new("/tmp/toktrack-pi-session")
+        );
+        match saved_s {
+            Some(v) => std::env::set_var("PI_CODING_AGENT_SESSION_DIR", v),
+            None => std::env::remove_var("PI_CODING_AGENT_SESSION_DIR"),
+        }
+        match saved_a {
+            Some(v) => std::env::set_var("PI_AGENT_DIR", v),
+            None => std::env::remove_var("PI_AGENT_DIR"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Round 3 #3. Centralizes path discovery so CODEX_HOME, CLAUDE_CONFIG_DIR, OPENCODE_DATA_DIR, XDG_DATA_HOME, and PI_CODING_AGENT_SESSION_DIR are honored consistently (previously only Gemini/PI had ad-hoc env handling). Env var names verified against upstream docs/repos. 509 tests pass. Targets develop; no main merge.