### PR TITLE
feat(services): detect + surface unsupported Antigravity CLI

### DIFF
--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -2,7 +2,7 @@
 
 mod claude;
 mod codex;
-mod discovery;
+pub mod discovery;
 mod gemini;
 mod opencode;
 mod pi_agent;

--- a/src/services/aggregator.rs
+++ b/src/services/aggregator.rs
@@ -367,6 +367,7 @@ impl Aggregator {
                 source,
                 total_tokens,
                 total_cost_usd,
+                supported: true,
             })
             .collect();
 

--- a/src/services/data_loader.rs
+++ b/src/services/data_loader.rs
@@ -182,7 +182,8 @@ impl DataLoaderService {
         }
 
         let all_summaries = Aggregator::merge_by_date(all_summaries);
-        let source_usage = Self::build_source_usage(source_stats);
+        let mut source_usage = Self::build_source_usage(source_stats);
+        source_usage.extend(Self::antigravity_notice());
 
         Ok(LoadResult {
             summaries: all_summaries,
@@ -268,7 +269,8 @@ impl DataLoaderService {
         }
 
         let all_summaries = Aggregator::merge_by_date(all_summaries);
-        let source_usage = Self::build_source_usage(source_stats);
+        let mut source_usage = Self::build_source_usage(source_stats);
+        source_usage.extend(Self::antigravity_notice());
 
         Ok(LoadResult {
             summaries: all_summaries,
@@ -332,11 +334,39 @@ impl DataLoaderService {
                 source,
                 total_tokens,
                 total_cost_usd,
+                supported: true,
             })
             .collect();
         // Sort by total_tokens descending
         result.sort_by_key(|b| std::cmp::Reverse(b.total_tokens));
         result
+    }
+
+    /// Detect an Antigravity CLI install (`<gemini home>/.gemini/antigravity-cli`).
+    /// It is unsupported — Antigravity does not write file-readable token usage —
+    /// so surface a one-line notice and a disabled source row rather than silence.
+    fn antigravity_notice() -> Option<SourceUsage> {
+        let base = crate::parsers::discovery::first_env_dir(&["GEMINI_CLI_HOME"])
+            .or_else(|| directories::BaseDirs::new().map(|d| d.home_dir().to_path_buf()))?;
+        Self::antigravity_notice_at(&base)
+    }
+
+    /// Detection split out for testing without touching the global `GEMINI_CLI_HOME`.
+    fn antigravity_notice_at(home_base: &std::path::Path) -> Option<SourceUsage> {
+        if home_base.join(".gemini").join("antigravity-cli").exists() {
+            eprintln!(
+                "[toktrack] Note: Antigravity CLI detected but unsupported — it does \
+                 not write file-readable token usage, so its usage cannot be tracked."
+            );
+            Some(SourceUsage {
+                source: "antigravity".into(),
+                total_tokens: 0,
+                total_cost_usd: 0.0,
+                supported: false,
+            })
+        } else {
+            None
+        }
     }
 }
 
@@ -388,6 +418,26 @@ mod tests {
     #[test]
     fn test_is_copilot_provider_empty_string() {
         assert!(!is_copilot_provider(Some("")));
+    }
+
+    // ========== Antigravity detection ==========
+
+    #[test]
+    fn test_antigravity_notice_detected_as_unsupported() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".gemini").join("antigravity-cli")).unwrap();
+        let notice =
+            DataLoaderService::antigravity_notice_at(tmp.path()).expect("dir present → notice");
+        assert_eq!(notice.source, "antigravity");
+        assert!(!notice.supported);
+        assert_eq!(notice.total_tokens, 0);
+        assert_eq!(notice.total_cost_usd, 0.0);
+    }
+
+    #[test]
+    fn test_antigravity_notice_absent_when_no_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(DataLoaderService::antigravity_notice_at(tmp.path()).is_none());
     }
 
     // ========== build_source_usage tests ==========

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1012,6 +1012,7 @@ mod tests {
                     source: "claude".to_string(),
                     total_tokens: 3000,
                     total_cost_usd: 0.20,
+                    supported: true,
                 }],
                 source_daily_data: HashMap::new(),
                 source_models_data: HashMap::new(),
@@ -1143,6 +1144,7 @@ mod tests {
                 source: "opencode".to_string(),
                 total_tokens: 1000,
                 total_cost_usd: 0.05,
+                supported: true,
             });
         }
 

--- a/src/tui/widgets/overview.rs
+++ b/src/tui/widgets/overview.rs
@@ -263,6 +263,23 @@ impl Overview<'_> {
             // Token count
             let count_str = format_number(source.total_tokens);
 
+            // Unsupported sources (e.g. Antigravity) render as a dimmed, bar-less
+            // notice row instead of a usage bar.
+            if !source.supported {
+                let dim = Style::default()
+                    .fg(self.theme.muted())
+                    .add_modifier(Modifier::DIM);
+                let spans = vec![
+                    Span::raw(marker),
+                    Span::styled(name_display, dim),
+                    Span::raw("  "),
+                    Span::styled("(unsupported — no local usage)", dim),
+                ];
+                let line = Line::from(spans);
+                buf.set_line(area.x + x_offset, y, &line, area.width - x_offset);
+                continue;
+            }
+
             // Build the line
             let name_style = if is_selected {
                 Style::default()
@@ -370,5 +387,51 @@ mod tests {
     #[test]
     fn test_format_number_million() {
         assert_eq!(format_number(1000000), "1,000,000");
+    }
+
+    #[test]
+    fn test_unsupported_source_renders_disabled_row() {
+        let total = TotalSummary::default();
+        let daily: Vec<(NaiveDate, u64)> = vec![];
+        let sources = vec![
+            SourceUsage {
+                source: "claude".into(),
+                total_tokens: 100,
+                total_cost_usd: 1.0,
+                supported: true,
+            },
+            SourceUsage {
+                source: "antigravity".into(),
+                total_tokens: 0,
+                total_cost_usd: 0.0,
+                supported: false,
+            },
+        ];
+        let data = OverviewData {
+            total: &total,
+            daily_tokens: &daily,
+            source_usage: &sources,
+            selected_source: None,
+            selected_tab: Tab::Overview,
+        };
+        let area = Rect::new(0, 0, 120, 30);
+        let mut buf = Buffer::empty(area);
+        Overview::new(
+            data,
+            NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+            Theme::Dark,
+        )
+        .render(area, &mut buf);
+
+        let mut text = String::new();
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                text.push_str(buf[(x, y)].symbol());
+            }
+        }
+        assert!(
+            text.contains("unsupported"),
+            "overview should render the unsupported notice for disabled sources"
+        );
     }
 }

--- a/src/types/usage.rs
+++ b/src/types/usage.rs
@@ -225,12 +225,31 @@ pub struct TotalSummary {
     pub day_count: u64,
 }
 
+fn default_true() -> bool {
+    true
+}
+
 /// Usage aggregated by source CLI (claude, opencode, gemini, etc.)
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SourceUsage {
     pub source: String,
     pub total_tokens: u64,
     pub total_cost_usd: f64,
+    /// False for detected-but-unsupported sources (e.g. Antigravity, which does
+    /// not write file-readable token usage). Rendered as a disabled row.
+    #[serde(default = "default_true")]
+    pub supported: bool,
+}
+
+impl Default for SourceUsage {
+    fn default() -> Self {
+        Self {
+            source: String::new(),
+            total_tokens: 0,
+            total_cost_usd: 0.0,
+            supported: true,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Round 3 #5. Antigravity (Gemini CLI successor) writes no file-readable token usage. Detect ~/.gemini/antigravity-cli → stderr notice + a dimmed disabled source row in the TUI (SourceUsage gains supported: bool, serde-default true). 513 tests pass. Targets develop; no main merge.