### PR TITLE
feat(services): label estimated (LiteLLM-calculated) source costs

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -149,7 +149,17 @@ fn run_report(_week: bool, month: bool, days: Option<u32>, svg: Option<PathBuf>)
     let end = today;
 
     let result = load_data_full()?;
-    let data = ReportData::from_summaries(&result.summaries, &result.source_summaries, start, end);
+    let mut data =
+        ReportData::from_summaries(&result.summaries, &result.source_summaries, start, end);
+    // Carry per-source "estimated" (LiteLLM-calculated cost) onto the report.
+    let estimated: std::collections::HashMap<&str, bool> = result
+        .source_usage
+        .iter()
+        .map(|s| (s.source.as_str(), s.estimated))
+        .collect();
+    for sr in &mut data.by_source {
+        sr.estimated = estimated.get(sr.name.as_str()).copied().unwrap_or(false);
+    }
 
     // Always print text report
     println!("{}", crate::report::text::render(&data));

--- a/src/report/data.rs
+++ b/src/report/data.rs
@@ -24,6 +24,8 @@ pub struct SourceReport {
     pub name: String,
     pub total_tokens: u64,
     pub cost_usd: f64,
+    /// True when this source's cost is a LiteLLM estimate (no upstream cost).
+    pub estimated: bool,
 }
 
 /// A single day's report
@@ -152,6 +154,7 @@ impl ReportData {
                     name: source_name.clone(),
                     total_tokens,
                     cost_usd: cost,
+                    estimated: false, // set by the caller from SourceUsage
                 })
             })
             .collect();

--- a/src/report/svg.rs
+++ b/src/report/svg.rs
@@ -377,6 +377,7 @@ mod tests {
                 name: "claude".to_string(),
                 total_tokens: 1_802_457,
                 cost_usd: 42.37,
+                estimated: false,
             }],
             daily: vec![DayReport {
                 date: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),

--- a/src/report/text.rs
+++ b/src/report/text.rs
@@ -122,13 +122,22 @@ pub fn render(data: &ReportData) -> String {
         out.push_str(&format!("\u{2502}{}\u{2502}\n", "\u{2508}".repeat(w)));
         boxed_line(&mut out, w, " BY SOURCE");
 
+        let mut any_estimated = false;
         for source in &data.by_source {
             let name = truncate(&source.name, 18);
-            let cost = format_cost(source.cost_usd);
+            let cost = if source.estimated {
+                any_estimated = true;
+                format!("~{}", format_cost(source.cost_usd))
+            } else {
+                format_cost(source.cost_usd)
+            };
             let tokens = format_tokens(source.total_tokens);
 
             let content = format!("   {:<18}  {:>9} {:>7}", name, cost, tokens);
             boxed_line(&mut out, w, &content);
+        }
+        if any_estimated {
+            boxed_line(&mut out, w, "   ~ = estimated cost (LiteLLM pricing)");
         }
     }
 
@@ -236,6 +245,7 @@ mod tests {
                 name: "claude".to_string(),
                 total_tokens: 1_802_457,
                 cost_usd: 42.37,
+                estimated: false,
             }],
             daily: vec![
                 DayReport {
@@ -360,6 +370,7 @@ mod tests {
                 name: "very-long-source-name".to_string(),
                 total_tokens: 999_999_999,
                 cost_usd: 99999.99,
+                estimated: false,
             }],
             daily: vec![DayReport {
                 date: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),

--- a/src/services/aggregator.rs
+++ b/src/services/aggregator.rs
@@ -368,6 +368,7 @@ impl Aggregator {
                 total_tokens,
                 total_cost_usd,
                 supported: true,
+                estimated: false,
             })
             .collect();
 

--- a/src/services/data_loader.rs
+++ b/src/services/data_loader.rs
@@ -118,6 +118,7 @@ impl DataLoaderService {
 
         let mut all_summaries = Vec::new();
         let mut source_stats: HashMap<String, (u64, f64)> = HashMap::new();
+        let mut source_estimated: HashMap<String, bool> = HashMap::new();
         let mut source_summaries: HashMap<String, Vec<DailySummary>> = HashMap::new();
         let mut cache_warning = None;
 
@@ -157,6 +158,11 @@ impl DataLoaderService {
                 }
             };
 
+            let est = Self::batch_estimated(&entries);
+            source_estimated
+                .entry(parser.name().to_string())
+                .and_modify(|e| *e |= est)
+                .or_insert(est);
             let entries = self.apply_pricing(entries);
 
             match cache_service.load_or_compute(parser.name(), &entries) {
@@ -182,7 +188,7 @@ impl DataLoaderService {
         }
 
         let all_summaries = Aggregator::merge_by_date(all_summaries);
-        let mut source_usage = Self::build_source_usage(source_stats);
+        let mut source_usage = Self::build_source_usage(source_stats, &source_estimated);
         source_usage.extend(Self::antigravity_notice());
 
         Ok(LoadResult {
@@ -207,6 +213,7 @@ impl DataLoaderService {
 
         let mut all_summaries = Vec::new();
         let mut source_stats: HashMap<String, (u64, f64)> = HashMap::new();
+        let mut source_estimated: HashMap<String, bool> = HashMap::new();
         let mut source_summaries: HashMap<String, Vec<DailySummary>> = HashMap::new();
         let mut cache_warning = None;
         let mut any_entries = false;
@@ -225,6 +232,11 @@ impl DataLoaderService {
             }
             any_entries = true;
 
+            let est = Self::batch_estimated(&entries);
+            source_estimated
+                .entry(parser.name().to_string())
+                .and_modify(|e| *e |= est)
+                .or_insert(est);
             let entries = self.apply_pricing_with_ref(entries, pricing_ref);
 
             // Try to use cache service
@@ -269,7 +281,7 @@ impl DataLoaderService {
         }
 
         let all_summaries = Aggregator::merge_by_date(all_summaries);
-        let mut source_usage = Self::build_source_usage(source_stats);
+        let mut source_usage = Self::build_source_usage(source_stats, &source_estimated);
         source_usage.extend(Self::antigravity_notice());
 
         Ok(LoadResult {
@@ -283,6 +295,14 @@ impl DataLoaderService {
     /// Apply pricing to entries using cached pricing service
     fn apply_pricing(&self, entries: Vec<UsageEntry>) -> Vec<UsageEntry> {
         self.apply_pricing_with_ref(entries, self.pricing.as_ref())
+    }
+
+    /// Whether a batch of entries is "estimated" — at least one non-Copilot entry
+    /// had no upstream cost, so its cost will be LiteLLM-calculated.
+    fn batch_estimated(entries: &[UsageEntry]) -> bool {
+        entries
+            .iter()
+            .any(|e| e.cost_usd.is_none() && !is_copilot_provider(e.provider.as_deref()))
     }
 
     /// Apply pricing to entries using the given pricing service reference
@@ -327,14 +347,18 @@ impl DataLoaderService {
     }
 
     /// Convert source stats map to sorted SourceUsage vector
-    fn build_source_usage(source_stats: HashMap<String, (u64, f64)>) -> Vec<SourceUsage> {
+    fn build_source_usage(
+        source_stats: HashMap<String, (u64, f64)>,
+        estimated: &HashMap<String, bool>,
+    ) -> Vec<SourceUsage> {
         let mut result: Vec<SourceUsage> = source_stats
             .into_iter()
             .map(|(source, (total_tokens, total_cost_usd))| SourceUsage {
+                supported: true,
+                estimated: estimated.get(&source).copied().unwrap_or(false),
                 source,
                 total_tokens,
                 total_cost_usd,
-                supported: true,
             })
             .collect();
         // Sort by total_tokens descending
@@ -363,6 +387,7 @@ impl DataLoaderService {
                 total_tokens: 0,
                 total_cost_usd: 0.0,
                 supported: false,
+                estimated: false,
             })
         } else {
             None
@@ -445,7 +470,7 @@ mod tests {
     #[test]
     fn test_build_source_usage_empty() {
         let stats = HashMap::new();
-        let result = DataLoaderService::build_source_usage(stats);
+        let result = DataLoaderService::build_source_usage(stats, &HashMap::new());
         assert!(result.is_empty());
     }
 
@@ -453,13 +478,51 @@ mod tests {
     fn test_build_source_usage_single_source() {
         let mut stats = HashMap::new();
         stats.insert("claude".to_string(), (1000u64, 0.05f64));
+        let estimated = HashMap::from([("claude".to_string(), true)]);
 
-        let result = DataLoaderService::build_source_usage(stats);
+        let result = DataLoaderService::build_source_usage(stats, &estimated);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].source, "claude");
         assert_eq!(result[0].total_tokens, 1000);
         assert!((result[0].total_cost_usd - 0.05).abs() < f64::EPSILON);
+        assert!(result[0].supported);
+        assert!(
+            result[0].estimated,
+            "estimated flag should flow from the map"
+        );
+    }
+
+    #[test]
+    fn test_batch_estimated() {
+        use chrono::Utc;
+        let mk = |cost: Option<f64>, provider: Option<&str>| UsageEntry {
+            timestamp: Utc::now(),
+            model: Some("m".into()),
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            reasoning_tokens: 0,
+            cache_creation_5m_tokens: 0,
+            cache_creation_1h_tokens: 0,
+            web_search_requests: 0,
+            reported_total_tokens: None,
+            cost_usd: cost,
+            message_id: None,
+            request_id: None,
+            source: None,
+            provider: provider.map(String::from),
+        };
+        // upstream cost present → not estimated
+        assert!(!DataLoaderService::batch_estimated(&[mk(Some(0.1), None)]));
+        // calculated (no upstream cost) → estimated
+        assert!(DataLoaderService::batch_estimated(&[mk(None, None)]));
+        // copilot without cost → free, not an estimate
+        assert!(!DataLoaderService::batch_estimated(&[mk(
+            None,
+            Some("github-copilot")
+        )]));
     }
 
     #[test]
@@ -469,7 +532,7 @@ mod tests {
         stats.insert("opencode".to_string(), (2000u64, 0.10f64));
         stats.insert("gemini".to_string(), (1000u64, 0.05f64));
 
-        let result = DataLoaderService::build_source_usage(stats);
+        let result = DataLoaderService::build_source_usage(stats, &HashMap::new());
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].source, "opencode");

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1013,6 +1013,7 @@ mod tests {
                     total_tokens: 3000,
                     total_cost_usd: 0.20,
                     supported: true,
+                    estimated: false,
                 }],
                 source_daily_data: HashMap::new(),
                 source_models_data: HashMap::new(),
@@ -1145,6 +1146,7 @@ mod tests {
                 total_tokens: 1000,
                 total_cost_usd: 0.05,
                 supported: true,
+                estimated: false,
             });
         }
 

--- a/src/tui/widgets/overview.rs
+++ b/src/tui/widgets/overview.rs
@@ -92,9 +92,17 @@ impl Widget for Overview<'_> {
         let sources_label_idx = constraints.len(); // 5
         constraints.push(Constraint::Length(if show_sources { 1 } else { 0 }));
 
+        // Reserve one extra line for the estimated-cost legend when any shown
+        // source is estimated.
+        let any_estimated = self
+            .data
+            .source_usage
+            .iter()
+            .take(4)
+            .any(|s| s.supported && s.estimated);
         let sources_bars_idx = constraints.len(); // 6
         constraints.push(Constraint::Length(if show_sources {
-            source_rows
+            source_rows + u16::from(any_estimated)
         } else {
             0
         }));
@@ -224,6 +232,7 @@ impl Overview<'_> {
         let full_width = 2 + TOTAL_LINE_WIDTH;
         let x_offset = area.width.saturating_sub(full_width as u16) / 2;
 
+        let mut any_estimated = false;
         for (i, source) in self.data.source_usage.iter().take(4).enumerate() {
             let y = area.y + i as u16;
             if y >= area.y + area.height {
@@ -289,7 +298,7 @@ impl Overview<'_> {
                 Style::default().fg(self.theme.text())
             };
 
-            let spans = vec![
+            let mut spans = vec![
                 Span::styled(marker, Style::default().fg(self.theme.accent())),
                 Span::styled(name_display, name_style),
                 Span::raw("  "),
@@ -297,10 +306,34 @@ impl Overview<'_> {
                 Span::raw("  "),
                 Span::styled(count_str, Style::default().fg(self.theme.text())),
             ];
+            // Estimated-cost marker: this source's cost is LiteLLM-calculated.
+            if source.estimated {
+                any_estimated = true;
+                spans.push(Span::styled(
+                    " ~",
+                    Style::default()
+                        .fg(self.theme.muted())
+                        .add_modifier(Modifier::DIM),
+                ));
+            }
 
             // Render centered
             let line = Line::from(spans);
             buf.set_line(area.x + x_offset, y, &line, area.width - x_offset);
+        }
+
+        // Legend for the estimated-cost marker (only when shown).
+        if any_estimated {
+            let y = area.y + self.data.source_usage.len().min(4) as u16;
+            if y < area.y + area.height {
+                let legend = Line::from(Span::styled(
+                    "  ~ = estimated cost (LiteLLM)",
+                    Style::default()
+                        .fg(self.theme.muted())
+                        .add_modifier(Modifier::DIM),
+                ));
+                buf.set_line(area.x + x_offset, y, &legend, area.width - x_offset);
+            }
         }
     }
 
@@ -399,12 +432,14 @@ mod tests {
                 total_tokens: 100,
                 total_cost_usd: 1.0,
                 supported: true,
+                estimated: false,
             },
             SourceUsage {
                 source: "antigravity".into(),
                 total_tokens: 0,
                 total_cost_usd: 0.0,
                 supported: false,
+                estimated: false,
             },
         ];
         let data = OverviewData {
@@ -432,6 +467,45 @@ mod tests {
         assert!(
             text.contains("unsupported"),
             "overview should render the unsupported notice for disabled sources"
+        );
+    }
+
+    #[test]
+    fn test_estimated_source_renders_marker_and_legend() {
+        let total = TotalSummary::default();
+        let daily: Vec<(NaiveDate, u64)> = vec![];
+        let sources = vec![SourceUsage {
+            source: "gemini".into(),
+            total_tokens: 500,
+            total_cost_usd: 0.10,
+            supported: true,
+            estimated: true,
+        }];
+        let data = OverviewData {
+            total: &total,
+            daily_tokens: &daily,
+            source_usage: &sources,
+            selected_source: None,
+            selected_tab: Tab::Overview,
+        };
+        let area = Rect::new(0, 0, 120, 30);
+        let mut buf = Buffer::empty(area);
+        Overview::new(
+            data,
+            NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+            Theme::Dark,
+        )
+        .render(area, &mut buf);
+
+        let mut text = String::new();
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                text.push_str(buf[(x, y)].symbol());
+            }
+        }
+        assert!(
+            text.contains("estimated cost"),
+            "overview should render the estimated-cost legend"
         );
     }
 }

--- a/src/types/usage.rs
+++ b/src/types/usage.rs
@@ -239,6 +239,10 @@ pub struct SourceUsage {
     /// not write file-readable token usage). Rendered as a disabled row.
     #[serde(default = "default_true")]
     pub supported: bool,
+    /// True when this source's cost was LiteLLM-calculated (the source did not
+    /// provide its own cost), i.e. an estimate. Rendered with a marker + legend.
+    #[serde(default)]
+    pub estimated: bool,
 }
 
 impl Default for SourceUsage {
@@ -248,6 +252,7 @@ impl Default for SourceUsage {
             total_tokens: 0,
             total_cost_usd: 0.0,
             supported: true,
+            estimated: false,
         }
     }
 }


### PR DESCRIPTION
Round 3 #6 (final). Marks sources whose cost is LiteLLM-calculated (Gemini/Codex/modern Claude) with a ~ marker + legend in both the text report and the TUI overview; OpenCode/PI (upstream cost) stay unmarked. The cost-priority policy already preferred upstream cost (data_loader); this adds the labeling. 515 tests pass. Targets develop; no main merge.