### PR TITLE
feat(parser): add Qwen Code support (Gemini-format fork)

### DIFF
--- a/src/parsers/gemini.rs
+++ b/src/parsers/gemini.rs
@@ -88,6 +88,9 @@ struct GeminiTokensJsonl {
 /// Parser for Gemini CLI usage data
 pub struct GeminiParser {
     data_dir: PathBuf,
+    /// Source label ("gemini" or "qwen"). Qwen Code is a Gemini CLI fork with an
+    /// identical on-disk token format, so it reuses this parser verbatim.
+    source: &'static str,
 }
 
 impl GeminiParser {
@@ -104,13 +107,41 @@ impl GeminiParser {
             });
         Self {
             data_dir: home.join(".gemini").join("tmp"),
+            source: "gemini",
         }
     }
 
-    /// Create a parser with a custom data directory (for testing)
+    /// Create a parser for Qwen Code (Gemini CLI fork, identical format).
+    ///
+    /// Honors `QWEN_HOME` (overrides `~/.qwen`); sessions live under `<root>/tmp`.
+    pub fn new_qwen() -> Self {
+        let root = super::discovery::first_env_dir(&["QWEN_HOME"]).unwrap_or_else(|| {
+            directories::BaseDirs::new()
+                .map(|d| d.home_dir().join(".qwen"))
+                .unwrap_or_else(|| {
+                    eprintln!("[toktrack] Warning: Could not determine home directory");
+                    PathBuf::from(".")
+                })
+        });
+        Self {
+            data_dir: root.join("tmp"),
+            source: "qwen",
+        }
+    }
+
+    /// Create a parser with a custom data directory (for testing), source "gemini".
     #[allow(dead_code)]
     pub fn with_data_dir(data_dir: PathBuf) -> Self {
-        Self { data_dir }
+        Self {
+            data_dir,
+            source: "gemini",
+        }
+    }
+
+    /// Create a parser with a custom data directory and source label (for testing).
+    #[allow(dead_code)]
+    pub fn with_data_dir_source(data_dir: PathBuf, source: &'static str) -> Self {
+        Self { data_dir, source }
     }
 
     /// Parse a legacy `.json` (single-object) session file.
@@ -163,7 +194,7 @@ impl GeminiParser {
                 cost_usd: None,
                 message_id: Some(msg.id),
                 request_id: Some(session.session_id.clone()),
-                source: Some("gemini".into()),
+                source: Some(self.source.into()),
                 provider: None,
             });
         }
@@ -256,7 +287,7 @@ impl GeminiParser {
                 cost_usd: None,
                 message_id: parsed.id.map(String::from),
                 request_id: Some(request_id),
-                source: Some("gemini".into()),
+                source: Some(self.source.into()),
                 provider: None,
             });
         }
@@ -273,7 +304,7 @@ impl Default for GeminiParser {
 
 impl CLIParser for GeminiParser {
     fn name(&self) -> &str {
-        "gemini"
+        self.source
     }
 
     fn data_dir(&self) -> &Path {
@@ -426,6 +457,32 @@ mod tests {
     fn test_parser_name() {
         let parser = GeminiParser::new();
         assert_eq!(parser.name(), "gemini");
+    }
+
+    #[test]
+    fn test_qwen_parser_name_and_default_dir() {
+        let parser = GeminiParser::new_qwen();
+        assert_eq!(parser.name(), "qwen");
+        assert!(parser.data_dir().ends_with(".qwen/tmp"));
+    }
+
+    #[test]
+    fn test_qwen_parses_with_gemini_semantics() {
+        // Qwen Code reuses the Gemini format: input includes cached, total reconciles.
+        let parser =
+            GeminiParser::with_data_dir_source(PathBuf::from("tests/fixtures/qwen"), "qwen");
+        let entries = parser.parse_all().unwrap();
+        assert_eq!(entries.len(), 1);
+        let e = &entries[0];
+        assert_eq!(e.source, Some("qwen".into()));
+        assert_eq!(e.model, Some("qwen3-coder".to_string()));
+        // input 200 includes cached 40 → billable non-cached = 160
+        assert_eq!(e.input_tokens, 160);
+        assert_eq!(e.cache_read_tokens, 40);
+        assert_eq!(e.output_tokens, 80);
+        assert_eq!(e.reasoning_tokens, 20);
+        assert_eq!(e.reported_total_tokens, Some(300));
+        assert_eq!(e.total_tokens(), 300); // reconciles with upstream total
     }
 
     #[test]

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -110,6 +110,7 @@ impl ParserRegistry {
                 Box::new(ClaudeCodeParser::new()),
                 Box::new(CodexParser::new()),
                 Box::new(GeminiParser::new()),
+                Box::new(GeminiParser::new_qwen()),
                 Box::new(OpenCodeParser::new()),
                 Box::new(PiAgentParser::new()),
             ],
@@ -144,10 +145,11 @@ mod tests {
     #[test]
     fn test_registry_default_parsers() {
         let registry = ParserRegistry::new();
-        assert_eq!(registry.parsers().len(), 5);
+        assert_eq!(registry.parsers().len(), 6);
         assert!(registry.get("claude-code").is_some());
         assert!(registry.get("codex").is_some());
         assert!(registry.get("gemini").is_some());
+        assert!(registry.get("qwen").is_some());
         assert!(registry.get("opencode").is_some());
         assert!(registry.get("pi-agent").is_some());
     }
@@ -233,7 +235,8 @@ mod tests {
         // gemini/tmp_jsonl_malformed/chats/session-bad.jsonl,
         // gemini/tmp_jsonl_no_meta/chats/session-*.jsonl
         // claude/real-shape-session.jsonl
-        // (claude parser uses `**/*.jsonl`; gemini-format files parse to 0 entries.)
-        assert_eq!(files.len(), 14);
+        // qwen/proj/chats/session-*.jsonl
+        // (claude parser uses `**/*.jsonl`; gemini/qwen-format files parse to 0 entries.)
+        assert_eq!(files.len(), 15);
     }
 }

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -31,6 +31,7 @@ structure is preserved.
 | Claude | `claude-sample.jsonl`, `claude/real-shape-session.jsonl` | real-shape from `~/.claude/projects` (sanitized); covers cache TTL 5m/1h, web_search, and fields toktrack ignores (`web_fetch_requests`, `service_tier`, `iterations`) |
 | Codex | `codex/*.jsonl` | token_count delta sessions, session_meta provider |
 | Gemini | `gemini/tmp*/chats/*` | legacy `.json` + streaming `.jsonl`; `total` reconciles with `total_tokens()` (input excludes cached) |
+| Qwen | `qwen/proj/chats/*.jsonl` | Gemini CLI fork — identical format; parsed by the same parser with source "qwen" |
 | OpenCode | `opencode/...`, in-test SQLite | message rows with reasoning + cache + cost |
 | PI Agent | `pi_agent/*.jsonl` | assistant usage; nested `cost.total` |
 

--- a/tests/fixtures/qwen/proj/chats/session-2026-06-01T10-00-00-qwen0001.jsonl
+++ b/tests/fixtures/qwen/proj/chats/session-2026-06-01T10-00-00-qwen0001.jsonl
@@ -1,0 +1,3 @@
+{"sessionId":"qwen-sess-0001","projectHash":"deadbeef","startTime":"2026-06-01T10:00:00Z","lastUpdated":"2026-06-01T10:00:00Z","kind":"main"}
+{"id":"q1","timestamp":"2026-06-01T10:00:00Z","type":"user","content":"redacted"}
+{"id":"q2","timestamp":"2026-06-01T10:00:01Z","type":"gemini","model":"qwen3-coder","content":"redacted","tokens":{"input":200,"output":80,"cached":40,"thoughts":20,"tool":0,"total":300}}


### PR DESCRIPTION
Round 4 #A (final). Qwen Code is a Gemini CLI fork with an identical token format, so GeminiParser is parameterized (source + dir) and registered as a 'qwen' source (honors QWEN_HOME, default ~/.qwen/tmp). The round-2 cached-subtraction fix + total reconciliation apply verbatim. Registry: 6 parsers. 522 tests pass. Targets develop; no main merge.