### PR TITLE
fix: address 2.8.0 review findings (saturating add, snapshot warn)

### DIFF
--- a/src/parsers/gemini.rs
+++ b/src/parsers/gemini.rs
@@ -274,7 +274,10 @@ impl GeminiParser {
                 // input_tokens is billable non-cached input and cached isn't double-charged.
                 // `tokens.tool` (toolUsePromptTokenCount) is folded into input so totals
                 // match gemini-cli's own `total` (which sums it in).
-                input_tokens: tokens.input.saturating_sub(cached) + tokens.tool.unwrap_or(0),
+                input_tokens: tokens
+                    .input
+                    .saturating_sub(cached)
+                    .saturating_add(tokens.tool.unwrap_or(0)),
                 output_tokens: tokens.output,
                 cache_read_tokens: cached,
                 cache_creation_tokens: 0,

--- a/src/services/pricing.rs
+++ b/src/services/pricing.rs
@@ -348,8 +348,11 @@ impl PricingService {
     /// Vendored snapshot as a `PricingCache`. `fetched_at = 0` marks it stale so
     /// it is refreshed from the network at the next opportunity.
     fn snapshot_cache() -> PricingCache {
-        let models: HashMap<String, ModelPricing> =
-            serde_json::from_str(PRICING_SNAPSHOT_JSON).unwrap_or_default();
+        let models: HashMap<String, ModelPricing> = serde_json::from_str(PRICING_SNAPSHOT_JSON)
+            .unwrap_or_else(|e| {
+                eprintln!("[toktrack] BUG: bundled pricing snapshot failed to parse: {e}");
+                HashMap::new()
+            });
         PricingCache {
             fetched_at: 0,
             models,


### PR DESCRIPTION
Fixes from the full 2.8.0 review (verdict PASS): gemini tool-token fold uses saturating_add (P1); snapshot parse failure now warns instead of silent empty pricing (P3). 522 tests pass. Targets develop.