### PR TITLE
fix(services): Stop antigravity notice from bleeding over the TUI

### DIFF
--- a/src/services/data_loader.rs
+++ b/src/services/data_loader.rs
@@ -368,7 +368,8 @@ impl DataLoaderService {
 
     /// Detect an Antigravity CLI install (`<gemini home>/.gemini/antigravity-cli`).
     /// It is unsupported — Antigravity does not write file-readable token usage —
-    /// so surface a one-line notice and a disabled source row rather than silence.
+    /// so surface a disabled source row (shown in the Sources list) rather than
+    /// silence. No stderr notice: it would bleed over the TUI while it renders.
     fn antigravity_notice() -> Option<SourceUsage> {
         let base = crate::parsers::discovery::first_env_dir(&["GEMINI_CLI_HOME"])
             .or_else(|| directories::BaseDirs::new().map(|d| d.home_dir().to_path_buf()))?;
@@ -378,10 +379,6 @@ impl DataLoaderService {
     /// Detection split out for testing without touching the global `GEMINI_CLI_HOME`.
     fn antigravity_notice_at(home_base: &std::path::Path) -> Option<SourceUsage> {
         if home_base.join(".gemini").join("antigravity-cli").exists() {
-            eprintln!(
-                "[toktrack] Note: Antigravity CLI detected but unsupported — it does \
-                 not write file-readable token usage, so its usage cannot be tracked."
-            );
             Some(SourceUsage {
                 source: "antigravity".into(),
                 total_tokens: 0,


### PR DESCRIPTION
The antigravity detection emitted a stderr eprintln! note. In TUI mode data loads in a background thread after ratatui enters the alternate screen + raw mode, so the line wrote straight to the terminal, overlapped the heatmap, and persisted across tab switches (ratatui's diff buffer never repaints those externally-corrupted cells).

The unsupported status is already surfaced in the TUI as the dimmed "(unsupported — no local usage)" source row, so drop the redundant stderr note and keep returning the disabled SourceUsage entry.

Before:
<img width="781" height="268" alt="image" src="https://github.com/user-attachments/assets/42c44c41-f91a-4c5d-80c5-990568f144c9" />

After:
<img width="781" height="268" alt="image" src="https://github.com/user-attachments/assets/1c64ea56-f9b0-4234-9fe1-84c89dc8cd5c" />