### PR TITLE
docs: lead with data-preservation wedge, demote speed messaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "toktrack"
 version = "2.9.0"
 edition = "2021"
-description = "Ultra-fast token & cost tracker for Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, and PI Agent"
+description = "Never lose your AI coding cost history — fast token & cost tracker for Claude Code, Codex, Gemini, Qwen Code, OpenCode & PI Agent with a persistent cache"
 license = "MIT"
 repository = "https://github.com/mag123c/toktrack"
 keywords = ["claude-code", "token-tracker", "ai-cost", "tui", "llm"]

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,9 +8,9 @@
 
 > **⚠️ 알고 계셨나요?** Claude Code는 **기본적으로 30일 후 세션 데이터를 삭제**합니다. 삭제되면 토큰 사용량과 비용 기록은 영원히 사라집니다 — 보존하지 않는 한.
 
-**모든 AI 코딩 CLI**의 토큰 사용량과 비용을 한 곳에서 — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent 통합 대시보드.
+**비용 기록을 절대 잃지 않는 토큰 & 비용 트래커.** 대부분의 도구는 매 실행마다 CLI 세션 파일을 다시 읽습니다 — 그래서 Claude Code가 30일 후 파일을 삭제하면 비용 기록도 함께 사라집니다. toktrack은 **영구 캐시**를 유지해 기록이 살아남습니다.
 
-Rust 기반 초고속 성능 (simd-json + rayon 병렬 처리).
+**모든 AI 코딩 CLI**의 사용량을 한 곳에서 — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent 통합 대시보드. Rust 기반이라 대용량 기록에서도 빠릅니다 (simd-json + rayon).
 
 ![toktrack overview](assets/demo.gif)
 
@@ -18,30 +18,18 @@ Rust 기반 초고속 성능 (simd-json + rayon 병렬 처리).
 
 | 문제 | 해결책 |
 |------|--------|
-| 🐌 **기존 도구가 느림** — 대용량에서 40초 이상 | ⚡ **1000배 빠름** — 캐시 시 ~0.04초 |
-| 🗑️ **Claude Code 30일 후 데이터 삭제** — 비용 기록 사라짐 | 💾 **영구 캐시** — CLI가 파일 삭제해도 기록 유지 |
+| 🗑️ **Claude Code 30일 후 데이터 삭제** — 비용 기록 사라짐 | 💾 **영구 캐시** — CLI가 파일을 삭제해도 기록 유지 |
 | 📊 **통합 뷰 없음** — CLI별로 데이터 분산 | 🎯 **원 대시보드** — Claude Code, Codex, Gemini, Qwen, OpenCode, PI Agent 통합 |
-
-### 성능 비교
-
-```
-데이터셋: 2,000+ JSONL 파일, 3.4 GB
-
-기존 도구:            ████████████████████████████████████████ 40초+
-toktrack (콜드):      █ ~1초 (첫 실행)
-toktrack (캐시):      ▏ ~0.04초 (일상 사용)
-
-                      └── 최대 1000배 빠름
-```
+| 🐌 **대용량 기록 재스캔이 느림** | ⚡ **캐시 시 ~0.04초** — 매 실행 즉시 |
 
 ## 주요 기능
 
-- **초고속 파싱** — simd-json + rayon 병렬 처리 (~3 GiB/s 처리량)
+- **데이터 보존** — 영구 캐시로 CLI가 세션 파일을 삭제한 뒤에도 비용 기록 유지
+- **멀티 CLI 지원** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent 한 곳에서
 - **TUI 대시보드** — 3개 탭 (Overview, Stats, Models), 일별/주별/월별 뷰
 - **CLI 명령어** — `daily`, `weekly`, `monthly`, `stats` (JSON 출력 지원)
 - **사용량 리포트** — 공유 가능한 텍스트 & SVG 영수증 (`toktrack report`)
-- **멀티 CLI 지원** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent 한 곳에서
-- **데이터 보존** — CLI 데이터 삭제 후에도 비용 기록 유지
+- **대용량에서도 빠름** — simd-json + rayon 병렬 파싱 (~3 GiB/s), 캐시 시 ~0.04초
 
 ## 설치
 
@@ -170,15 +158,14 @@ export CLAUDE_CONFIG_DIR="/path/to/.claude"
 
 ## 성능
 
-| 도구 | 시간 | 속도 향상 |
-|------|------|-----------|
-| 기존 도구 | 40초+ | 기준 |
-| **toktrack** (콜드) | **~1.0초** | **40배 빠름** |
-| **toktrack** (캐시) | **~0.04초** | **1000배 빠름** |
+| 실행 | 시간 |
+|------|------|
+| 첫 실행 (콜드) | **~1.0초** |
+| 일상 사용 (캐시) | **~0.04초** |
 
-> Apple Silicon 기준, 2,000+ JSONL 파일 (3.4 GB).
+> Apple Silicon 기준, 2,000+ JSONL 파일 (3.4 GB). 영구 캐시 덕분에 매 실행 시 현재 날짜만 재계산하고 지난 날짜는 캐시에서 바로 읽으므로, 기록이 아무리 커져도 일상 사용은 즉시 끝납니다.
 >
-> **왜 이렇게 빠른가?** SIMD JSON 파싱 ([simd-json](https://github.com/simd-lite/simd-json)) + 병렬 처리 ([rayon](https://github.com/rayon-rs/rayon)) = ~3 GiB/s 처리량.
+> **왜 빠른가?** SIMD JSON 파싱 ([simd-json](https://github.com/simd-lite/simd-json)) + 병렬 처리 ([rayon](https://github.com/rayon-rs/rayon)) = 콜드 경로에서 ~3 GiB/s 처리량.
 
 ## 데이터 보존
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 > **⚠️ Did you know?** Claude Code **deletes your session data after 30 days** by default. Once deleted, your token usage and cost history are gone forever — unless you preserve them.
 
-Track token usage and costs across **all your AI coding CLIs** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, and PI Agent — in one dashboard.
+**The token & cost tracker that never loses your history.** Most tools re-read your CLI's session files on every run — so when Claude Code deletes them after 30 days, your cost history goes with them. toktrack keeps a **persistent cache**, so your history survives.
 
-Built with Rust for ultra-fast performance (simd-json + rayon parallel processing).
+Track usage across **all your AI coding CLIs** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, and PI Agent — in one dashboard. Built in Rust, so it stays fast even on huge histories (simd-json + rayon).
 
 ![toktrack overview](assets/demo.gif)
 
@@ -22,30 +22,18 @@ Built with Rust for ultra-fast performance (simd-json + rayon parallel processin
 
 | Problem | Solution |
 |---------|----------|
-| 🐌 **Existing tools are slow** — 40+ seconds on large datasets | ⚡ **1000x faster** — cached queries in ~0.04s |
-| 🗑️ **Claude Code deletes data after 30 days** — your cost history disappears | 💾 **Persistent cache** — history survives even after CLI deletes files |
-| 📊 **No unified view** — each CLI has separate data | 🎯 **One dashboard** — Claude Code, Codex, Gemini, Qwen, OpenCode, PI Agent in one place |
-
-### Performance Comparison
-
-```
-Dataset: 2,000+ JSONL files, 3.4 GB total
-
-Existing tools:     ████████████████████████████████████████ 40s+
-toktrack (cold):    █ ~1s (first run)
-toktrack (cached):  ▏ ~0.04s (daily use)
-
-                    └── up to 1000x faster
-```
+| 🗑️ **Claude Code deletes data after 30 days** — your cost history disappears | 💾 **Persistent cache** — history survives even after the CLI deletes its files |
+| 📊 **No unified view** — each CLI keeps its own separate data | 🎯 **One dashboard** — Claude Code, Codex, Gemini, Qwen, OpenCode, PI Agent in one place |
+| 🐌 **Re-scanning big histories is slow** | ⚡ **Cached queries in ~0.04s** — instant on every run |
 
 ## Features
 
-- **Ultra-Fast Parsing** — simd-json + rayon parallel processing (~3 GiB/s throughput)
+- **Data Preservation** — Persistent cache keeps your cost history even after a CLI deletes its own session files
+- **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent in one place
 - **TUI Dashboard** — 3 tabs (Overview, Stats, Models) with daily/weekly/monthly views
 - **CLI Commands** — `daily`, `weekly`, `monthly`, `stats` with JSON output support
 - **Usage Reports** — Shareable text & SVG receipts via `toktrack report`
-- **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent in one place
-- **Data Preservation** — Cached daily summaries survive CLI data deletion
+- **Fast on huge histories** — simd-json + rayon parallel parsing (~3 GiB/s); cached runs in ~0.04s
 
 ## Installation
 
@@ -232,15 +220,14 @@ Custom pricing (including `web_search` / `web_fetch` per-request rates) can be s
 
 ## Performance
 
-| Tool | Time | Speedup |
-|------|------|---------|
-| Existing tools | 40s+ | baseline |
-| **toktrack** (cold) | **~1.0s** | **40x faster** |
-| **toktrack** (cached) | **~0.04s** | **1000x faster** |
+| Run | Time |
+|-----|------|
+| First run (cold) | **~1.0s** |
+| Daily use (cached) | **~0.04s** |
 
-> Measured on Apple Silicon with 2,000+ JSONL files (3.4 GB).
+> Measured on Apple Silicon with 2,000+ JSONL files (3.4 GB). The persistent cache means only the current day is recomputed on each run — past days are read straight from cache, so daily use stays instant no matter how large your history grows.
 >
-> **Why so fast?** SIMD JSON parsing ([simd-json](https://github.com/simd-lite/simd-json)) + parallel processing ([rayon](https://github.com/rayon-rs/rayon)) = ~3 GiB/s throughput.
+> **Why it's fast:** SIMD JSON parsing ([simd-json](https://github.com/simd-lite/simd-json)) + parallel processing ([rayon](https://github.com/rayon-rs/rayon)) = ~3 GiB/s throughput on the cold path.
 
 ## Data Preservation
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toktrack",
   "version": "2.9.0",
-  "description": "Ultra-fast token & cost tracker for Claude Code, Codex CLI, and Gemini CLI",
+  "description": "Never lose your AI coding cost history — token & cost tracker for Claude Code, Codex, Gemini, Qwen Code, OpenCode & PI Agent, with a persistent cache that survives CLI data deletion.",
   "bin": {
     "toktrack": "./bin/run.js"
   },


### PR DESCRIPTION
## Why
Speed ("1000x faster") is no longer a defensible lead now that the main alternative (ccusage) is also a native Rust binary. Repositions messaging around the one structural advantage competitors can't trivially copy: a **persistent cache that survives a CLI deleting its own session files**.

## Changes
- **README.md / README.ko.md**: new lead sentence naming the wedge + the mechanism competitors lack (per-run re-parsing → history lost on CLI deletion). Comparison table reordered (preservation > unified > speed). Removed the stale top-of-readme "vs existing tools 40s / 1000x" speed flex. Reframed the Performance section as toktrack's own cold/warm numbers tied to the cache. Data Preservation moved to top of the feature list.
- **npm/package.json**: description was outdated (3 CLIs) → now leads with preservation and lists all six supported CLIs.
- **Cargo.toml**: description aligned to the same preservation lead.

## Notes
Docs-only — no version bump (release-please ignores `docs:`). The new npm/crates descriptions will publish with the next feature release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)