### PR TITLE
feat: data-preservation audit (CLI + TUI)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -119,13 +119,17 @@ toktrack report              # 최근 7일 (텍스트)
 toktrack report --month      # 최근 30일
 toktrack report --days 14    # 최근 N일
 toktrack report --svg        # 텍스트 + SVG 파일
+
+# 데이터 보존 감사 (디스크에 살아있음 vs 캐시에만 있음)
+toktrack audit               # 소스별 커버리지 리포트
+toktrack audit --json        # 머신 리더블
 ```
 
 ### 키보드 단축키
 
 | 키 | 동작 |
 |-----|--------|
-| `1-3` | 탭 직접 전환 |
+| `1-4` | 탭 직접 전환 (Audit 포함) |
 | `Tab` / `Shift+Tab` | 다음 / 이전 탭 |
 | `j` / `k` 또는 `↑` / `↓` | 위 / 아래 스크롤 |
 | `Enter` | 모델 상세 팝업 열기 (Daily 탭) |
@@ -201,13 +205,37 @@ export CLAUDE_CONFIG_DIR="/path/to/.claude"
 ├── cache/
 │   ├── claude-code_daily.json   # 일별 비용 요약
 │   ├── codex_daily.json
+│   ├── codex@devbox_daily.json
 │   ├── gemini_daily.json
 │   ├── opencode_daily.json
 │   └── pi-agent_daily.json
+├── remotes/
+│   └── devbox/codex/sessions/   # 동기화된 원격 Codex JSONL 스냅샷
+├── config.toml                  # 선택: 원격 소스 설정
 └── pricing.json                 # LiteLLM 가격 정보 (1시간 TTL)
 ```
 
 각 `*_daily.json`의 지난 날짜 데이터는 **불변**입니다 — 한번 집계된 날의 결과는 수정되지 않습니다. 현재 날짜만 매 실행마다 재계산됩니다. 따라서 Claude Code가 30일 후 세션 파일을 삭제하더라도, 캐시에 비용 기록이 그대로 남습니다.
+
+### 무엇이 보존됐는지 직접 확인
+
+`toktrack audit`는 소스별·날짜별로 데이터가 아직 **live**(raw 세션 파일이 디스크에 존재)인지, **cache-only**(CLI가 raw를 삭제 — toktrack만 보유)인지, **missing**(데이터 없음 — 안 쓴 날이거나 toktrack이 보기 전에 사라진 날; 손실로 단정하지 않음)인지 보여줍니다.
+
+```
+$ toktrack audit
+
+Data preservation audit (2026-06-08)
+
+  claude-code   2025-12-22 → 2026-06-08
+    live (raw on disk):         79 days
+    preserved (CLI deleted):    83 days
+    no data (unused or lost):    7 days
+  ...
+
+  ► 100 days of cost history preserved that your CLIs already deleted.
+```
+
+전체 일별 내역은 `toktrack audit --json`, 또는 TUI에서 **Audit** 탭(`4` 키)으로 시각적 커버리지 맵을 확인하세요.
 
 ### Claude Code 자동 삭제 비활성화
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ toktrack report              # Last 7 days (text)
 toktrack report --month      # Last 30 days
 toktrack report --days 14    # Last N days
 toktrack report --svg        # Text + SVG file
+
+# Data-preservation audit (live on disk vs cache-only)
+toktrack audit               # Per-source coverage report
+toktrack audit --json        # Machine-readable
 ```
 
 ### Remote Codex Sources
@@ -186,7 +190,7 @@ existing snapshot/cache for that remote.
 
 | Key | Action |
 |-----|--------|
-| `1-3` | Switch tabs directly |
+| `1-4` | Switch tabs directly (incl. Audit) |
 | `Tab` / `Shift+Tab` | Next / Previous tab |
 | `j` / `k` or `↑` / `↓` | Scroll up / down |
 | `Enter` | Open model breakdown popup (Daily tab) |
@@ -274,6 +278,26 @@ Custom pricing (including `web_search` / `web_fetch` per-request rates) can be s
 ```
 
 Past dates in each `*_daily.json` are **immutable** — once a day is summarized, the cached result is never modified. Only the current day is recomputed on each run. This means even if Claude Code deletes session files after 30 days, your cost history remains intact in the cache.
+
+### See Exactly What's Preserved
+
+`toktrack audit` shows, per source and per day, whether the data is still **live** (raw session file on disk), **cache-only** (the CLI deleted the raw file — only toktrack still has it), or **missing** (no data — an unused day, or one lost before toktrack first saw it; never claimed as a loss).
+
+```
+$ toktrack audit
+
+Data preservation audit (2026-06-08)
+
+  claude-code   2025-12-22 → 2026-06-08
+    live (raw on disk):         79 days
+    preserved (CLI deleted):    83 days
+    no data (unused or lost):    7 days
+  ...
+
+  ► 100 days of cost history preserved that your CLIs already deleted.
+```
+
+Use `toktrack audit --json` for the full per-day breakdown, or open the **Audit** tab in the TUI (press `4`) for a visual coverage map.
 
 ### Disable Claude Code Auto-Deletion
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,9 +5,13 @@ use std::path::PathBuf;
 use chrono::Local;
 use clap::{Parser, Subcommand};
 
+use crate::parsers::ParserRegistry;
 use crate::report::data::ReportData;
 use crate::services::config::{ConfigService, RemoteConfig as StoredRemoteConfig};
-use crate::services::{Aggregator, DataLoaderService, RemoteOptions, RemoteSourceService};
+use crate::services::{
+    audit, Aggregator, DailySummaryCacheService, DataLoaderService, RemoteOptions,
+    RemoteSourceService,
+};
 use crate::tui::widgets::daily::DailyViewMode;
 use crate::tui::widgets::tabs::Tab;
 use crate::tui::TuiConfig;
@@ -84,6 +88,13 @@ enum Commands {
         /// Output SVG file (default: toktrack-report.svg)
         #[arg(long, num_args = 0..=1, default_missing_value = "toktrack-report.svg")]
         svg: Option<PathBuf>,
+    },
+
+    /// Audit data preservation: which days are live on disk vs cache-only
+    Audit {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Manage configured SSH remote sources
@@ -206,6 +217,7 @@ impl Cli {
                 days,
                 svg,
             }) => Ok(run_report(week, month, days, svg, &remote_options)?),
+            Some(Commands::Audit { json }) => Ok(run_audit(json, &remote_options)?),
             Some(Commands::Remote { command }) => Ok(run_remote_config(command)?),
         }
     }
@@ -341,6 +353,26 @@ fn run_report(
         println!("\nSVG saved to: {}", path.display());
     }
 
+    Ok(())
+}
+
+/// Audit data preservation across all sources (text, or JSON with --json).
+fn run_audit(json: bool, remote_options: &RemoteOptions) -> Result<()> {
+    let extra_sources = RemoteSourceService::sync_and_build_sources(remote_options)?;
+    let registry = ParserRegistry::with_extra_sources(extra_sources);
+    let cache = DailySummaryCacheService::new()?;
+    let today = Local::now().date_naive();
+    let report = audit::build_report(registry.sources(), &cache, today);
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .map_err(|e| ToktrackError::Parse(e.to_string()))?
+        );
+    } else {
+        print!("{}", crate::report::audit::render(&report));
+    }
     Ok(())
 }
 
@@ -550,6 +582,18 @@ mod tests {
     fn test_cli_parse_report_week_month_conflict() {
         let result = Cli::try_parse_from(["toktrack", "report", "--week", "--month"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parse_audit() {
+        let cli = Cli::try_parse_from(["toktrack", "audit"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Audit { json: false })));
+    }
+
+    #[test]
+    fn test_cli_parse_audit_json() {
+        let cli = Cli::try_parse_from(["toktrack", "audit", "--json"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Audit { json: true })));
     }
 
     #[test]

--- a/src/report/audit.rs
+++ b/src/report/audit.rs
@@ -1,0 +1,135 @@
+//! Human-readable rendering of the data-preservation audit.
+//!
+//! Leads each source with the headline-worthy figure — days preserved in cache
+//! after the upstream CLI deleted them — while labelling gap days honestly as
+//! "no data (unused or lost)" so the report never overstates a loss.
+
+use crate::services::audit::{AuditReport, SourceAudit};
+use std::fmt::Write as _;
+
+/// Render the audit report as plain text suitable for a terminal.
+pub fn render(report: &AuditReport) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "Data preservation audit ({})", report.generated_for);
+    let _ = writeln!(out);
+
+    for source in &report.sources {
+        render_source(&mut out, source);
+    }
+
+    if report.total_cache_only_days > 0 {
+        let _ = writeln!(
+            out,
+            "  \u{25ba} {} days of cost history preserved that your CLIs already deleted.",
+            report.total_cache_only_days
+        );
+    } else {
+        let _ = writeln!(
+            out,
+            "  \u{25ba} No cache-only history yet — all tracked data is still live on disk."
+        );
+    }
+
+    out
+}
+
+fn render_source(out: &mut String, source: &SourceAudit) {
+    match (source.start, source.end) {
+        (Some(start), Some(end)) => {
+            let _ = writeln!(out, "  {}   {} \u{2192} {}", source.label, start, end);
+            let _ = writeln!(
+                out,
+                "    live (raw on disk):       {:>4} days",
+                source.live_days
+            );
+            let _ = writeln!(
+                out,
+                "    preserved (CLI deleted):  {:>4} days",
+                source.cache_only_days
+            );
+            let _ = writeln!(
+                out,
+                "    no data (unused or lost): {:>4} days",
+                source.missing_days
+            );
+            let _ = writeln!(out);
+        }
+        _ => {
+            let _ = writeln!(out, "  {}   (no data)", source.label);
+            let _ = writeln!(out);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::audit::SourceAudit;
+    use chrono::NaiveDate;
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    fn report_with(sources: Vec<SourceAudit>, total_cache_only: u32) -> AuditReport {
+        AuditReport {
+            generated_for: date(2026, 6, 8),
+            total_cache_only_days: total_cache_only,
+            sources,
+        }
+    }
+
+    fn source(
+        label: &str,
+        start: Option<NaiveDate>,
+        live: u32,
+        cache_only: u32,
+        missing: u32,
+    ) -> SourceAudit {
+        SourceAudit {
+            id: label.to_string(),
+            label: label.to_string(),
+            start,
+            end: start,
+            total_days: live + cache_only + missing,
+            live_days: live,
+            cache_only_days: cache_only,
+            missing_days: missing,
+            days: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn render_includes_headline_count() {
+        let r = report_with(
+            vec![source("claude-code", Some(date(2026, 3, 1)), 72, 28, 0)],
+            28,
+        );
+        let text = render(&r);
+        assert!(
+            text.contains("28 days of cost history preserved"),
+            "got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn render_labels_missing_honestly() {
+        let r = report_with(vec![source("codex", Some(date(2026, 3, 1)), 1, 1, 1)], 1);
+        let text = render(&r);
+        assert!(text.contains("no data (unused or lost)"), "got:\n{text}");
+    }
+
+    #[test]
+    fn render_empty_source_shows_no_data() {
+        let r = report_with(vec![source("pi-agent", None, 0, 0, 0)], 0);
+        let text = render(&r);
+        assert!(text.contains("pi-agent   (no data)"), "got:\n{text}");
+    }
+
+    #[test]
+    fn render_zero_preserved_uses_live_headline() {
+        let r = report_with(vec![source("gemini", Some(date(2026, 3, 1)), 5, 0, 0)], 0);
+        let text = render(&r);
+        assert!(text.contains("still live on disk"), "got:\n{text}");
+    }
+}

--- a/src/report/audit.rs
+++ b/src/report/audit.rs
@@ -100,7 +100,7 @@ mod tests {
     }
 
     #[test]
-    fn render_includes_headline_count() {
+    fn test_render_includes_headline_count() {
         let r = report_with(
             vec![source("claude-code", Some(date(2026, 3, 1)), 72, 28, 0)],
             28,
@@ -113,21 +113,21 @@ mod tests {
     }
 
     #[test]
-    fn render_labels_missing_honestly() {
+    fn test_render_labels_missing_honestly() {
         let r = report_with(vec![source("codex", Some(date(2026, 3, 1)), 1, 1, 1)], 1);
         let text = render(&r);
         assert!(text.contains("no data (unused or lost)"), "got:\n{text}");
     }
 
     #[test]
-    fn render_empty_source_shows_no_data() {
+    fn test_render_empty_source_shows_no_data() {
         let r = report_with(vec![source("pi-agent", None, 0, 0, 0)], 0);
         let text = render(&r);
         assert!(text.contains("pi-agent   (no data)"), "got:\n{text}");
     }
 
     #[test]
-    fn render_zero_preserved_uses_live_headline() {
+    fn test_render_zero_preserved_uses_live_headline() {
         let r = report_with(vec![source("gemini", Some(date(2026, 3, 1)), 5, 0, 0)], 0);
         let text = render(&r);
         assert!(text.contains("still live on disk"), "got:\n{text}");

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,5 +1,6 @@
 //! Report generation for AI coding usage receipts
 
+pub mod audit;
 pub mod data;
 pub mod svg;
 pub mod text;

--- a/src/services/audit.rs
+++ b/src/services/audit.rs
@@ -98,9 +98,9 @@ pub fn audit_source(
             if date == end {
                 break;
             }
-            date = date
-                .succ_opt()
-                .expect("range end is reachable within representable dates");
+            // The `date == end` break above guarantees `date < end` here, so
+            // `date` is strictly below the max representable NaiveDate.
+            date = date.succ_opt().expect("date is strictly before end");
         }
     }
 
@@ -178,7 +178,7 @@ mod tests {
     }
 
     #[test]
-    fn live_takes_precedence_over_cache() {
+    fn test_live_takes_precedence_over_cache() {
         // A day present in BOTH live and cache is reported as live (recoverable).
         let day = d(2026, 3, 1);
         let audit = audit_source("claude-code", "claude-code", &set(&[day]), &set(&[day]));
@@ -190,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    fn cache_only_when_raw_gone() {
+    fn test_cache_only_when_raw_gone() {
         // In cache but not on disk → preserved-by-toktrack.
         let day = d(2026, 3, 1);
         let audit = audit_source("codex", "codex", &HashSet::new(), &set(&[day]));
@@ -201,7 +201,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_for_gap_days_inside_range() {
+    fn test_missing_for_gap_days_inside_range() {
         // Range is 03-01..=03-03; only the endpoints have data, the middle is a gap.
         let live = set(&[d(2026, 3, 1)]);
         let cache = set(&[d(2026, 3, 3)]);
@@ -218,7 +218,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_source_yields_none_range() {
+    fn test_empty_source_yields_none_range() {
         let audit = audit_source("pi-agent", "pi-agent", &HashSet::new(), &HashSet::new());
 
         assert_eq!(audit.start, None);
@@ -228,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn single_day_source() {
+    fn test_single_day_source() {
         let day = d(2026, 6, 8);
         let audit = audit_source("opencode", "opencode", &set(&[day]), &HashSet::new());
 
@@ -239,7 +239,7 @@ mod tests {
     }
 
     #[test]
-    fn counts_sum_to_total_days() {
+    fn test_counts_sum_to_total_days() {
         // 03-01 live, 03-02 missing, 03-03 cache_only, 03-04 missing, 03-05 live.
         let live = set(&[d(2026, 3, 1), d(2026, 3, 5)]);
         let cache = set(&[d(2026, 3, 3)]);
@@ -256,7 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn coverage_serializes_to_snake_case() {
+    fn test_coverage_serializes_to_snake_case() {
         let day = d(2026, 3, 1);
         let audit = audit_source("codex", "codex", &HashSet::new(), &set(&[day]));
         let json = serde_json::to_string(&audit.days[0]).unwrap();
@@ -264,7 +264,7 @@ mod tests {
     }
 
     #[test]
-    fn build_report_counts_cached_dates_as_cache_only_when_no_raw() {
+    fn test_build_report_counts_cached_dates_as_cache_only_when_no_raw() {
         use crate::parsers::ClaudeCodeParser;
         use crate::services::cache::DailySummaryCache;
         use crate::types::DailySummary;

--- a/src/services/audit.rs
+++ b/src/services/audit.rs
@@ -1,0 +1,323 @@
+//! Data-preservation audit: per-source, per-day coverage classification.
+//!
+//! For each source we compare the dates that still have raw session files on
+//! disk (`live`) against the dates kept in toktrack's persistent cache. A day
+//! that exists only in the cache (`cache_only`) is cost history the upstream CLI
+//! has already deleted — the concrete proof of toktrack's persistence wedge. A
+//! day inside the covered range with neither raw nor cached data is `missing`
+//! ("no data" — could be an unused day or one lost before toktrack saw it; we do
+//! not claim it as a loss).
+
+use crate::parsers::SourceInstance;
+use crate::services::DailySummaryCacheService;
+use chrono::NaiveDate;
+use serde::Serialize;
+use std::collections::{BTreeSet, HashSet};
+
+/// Coverage state for a single (source, day).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DayCoverage {
+    /// Raw session file for this day is still on disk.
+    Live,
+    /// Day is in the cache but the raw file is gone — preserved by toktrack.
+    CacheOnly,
+    /// Day inside the covered range with neither raw nor cached data.
+    Missing,
+}
+
+/// Coverage of one calendar day.
+#[derive(Debug, Clone, Serialize)]
+pub struct DayStatus {
+    pub date: NaiveDate,
+    pub coverage: DayCoverage,
+}
+
+/// Per-source audit result over the covered date range.
+#[derive(Debug, Clone, Serialize)]
+pub struct SourceAudit {
+    pub id: String,
+    pub label: String,
+    pub start: Option<NaiveDate>,
+    pub end: Option<NaiveDate>,
+    pub total_days: u32,
+    pub live_days: u32,
+    pub cache_only_days: u32,
+    pub missing_days: u32,
+    pub days: Vec<DayStatus>,
+}
+
+/// Full audit report across all sources.
+#[derive(Debug, Clone, Serialize)]
+pub struct AuditReport {
+    pub generated_for: NaiveDate,
+    /// Headline metric: total days preserved in cache after the CLI deleted them.
+    pub total_cache_only_days: u32,
+    pub sources: Vec<SourceAudit>,
+}
+
+/// Classify every day in `[min(live ∪ cache) ..= max(live ∪ cache)]`.
+///
+/// Pure: given the live and cached date sets it produces the per-day coverage
+/// and counts. `live` takes precedence over `cache` (a day with a raw file is
+/// still recoverable, so it is reported as `live` even if also cached).
+pub fn audit_source(
+    id: impl Into<String>,
+    label: impl Into<String>,
+    live: &HashSet<NaiveDate>,
+    cache: &HashSet<NaiveDate>,
+) -> SourceAudit {
+    let id = id.into();
+    let label = label.into();
+
+    // Union of all dates that carry data anywhere; bounds the covered range.
+    let all: BTreeSet<NaiveDate> = live.iter().chain(cache.iter()).copied().collect();
+    let start = all.iter().next().copied();
+    let end = all.iter().next_back().copied();
+
+    let mut days = Vec::new();
+    let mut live_days = 0u32;
+    let mut cache_only_days = 0u32;
+    let mut missing_days = 0u32;
+
+    if let (Some(start), Some(end)) = (start, end) {
+        let mut date = start;
+        loop {
+            let coverage = if live.contains(&date) {
+                live_days += 1;
+                DayCoverage::Live
+            } else if cache.contains(&date) {
+                cache_only_days += 1;
+                DayCoverage::CacheOnly
+            } else {
+                missing_days += 1;
+                DayCoverage::Missing
+            };
+            days.push(DayStatus { date, coverage });
+
+            if date == end {
+                break;
+            }
+            date = date
+                .succ_opt()
+                .expect("range end is reachable within representable dates");
+        }
+    }
+
+    SourceAudit {
+        id,
+        label,
+        start,
+        end,
+        total_days: days.len() as u32,
+        live_days,
+        cache_only_days,
+        missing_days,
+        days,
+    }
+}
+
+/// Build the full audit report across every source.
+///
+/// For each source `live` is the set of dates with raw session files still on
+/// disk, and `cache` is the set of dates kept in toktrack's persistent cache.
+/// Sources are processed independently; a source whose raw data fails to parse
+/// degrades to "no live data" rather than failing the whole report.
+pub fn build_report(
+    sources: &[SourceInstance],
+    cache: &DailySummaryCacheService,
+    today: NaiveDate,
+) -> AuditReport {
+    let sources: Vec<SourceAudit> = sources
+        .iter()
+        .map(|source| {
+            let live = collect_live_dates(source);
+            let cached = cache.cached_dates(&source.id);
+            audit_source(source.id.as_str(), source.label.as_str(), &live, &cached)
+        })
+        .collect();
+
+    let total_cache_only_days = sources.iter().map(|s| s.cache_only_days).sum();
+
+    AuditReport {
+        generated_for: today,
+        total_cache_only_days,
+        sources,
+    }
+}
+
+/// Collect the local dates that currently have raw session files for `source`.
+///
+/// Uses a full `parse_all` so multi-day session files are classified correctly
+/// (peeking a single line per file would misattribute files that span
+/// midnight). On parse failure we warn and return an empty set — the audit
+/// never hard-fails on one bad source.
+fn collect_live_dates(source: &SourceInstance) -> HashSet<NaiveDate> {
+    match source.parser.parse_all() {
+        Ok(entries) => entries.iter().map(|e| e.local_date()).collect(),
+        Err(e) => {
+            eprintln!(
+                "[toktrack] Warning: failed to read raw data for '{}': {}",
+                source.id, e
+            );
+            HashSet::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn d(y: i32, m: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, day).unwrap()
+    }
+
+    fn set(dates: &[NaiveDate]) -> HashSet<NaiveDate> {
+        dates.iter().copied().collect()
+    }
+
+    #[test]
+    fn live_takes_precedence_over_cache() {
+        // A day present in BOTH live and cache is reported as live (recoverable).
+        let day = d(2026, 3, 1);
+        let audit = audit_source("claude-code", "claude-code", &set(&[day]), &set(&[day]));
+
+        assert_eq!(audit.days.len(), 1);
+        assert_eq!(audit.days[0].coverage, DayCoverage::Live);
+        assert_eq!(audit.live_days, 1);
+        assert_eq!(audit.cache_only_days, 0);
+    }
+
+    #[test]
+    fn cache_only_when_raw_gone() {
+        // In cache but not on disk → preserved-by-toktrack.
+        let day = d(2026, 3, 1);
+        let audit = audit_source("codex", "codex", &HashSet::new(), &set(&[day]));
+
+        assert_eq!(audit.days[0].coverage, DayCoverage::CacheOnly);
+        assert_eq!(audit.cache_only_days, 1);
+        assert_eq!(audit.live_days, 0);
+    }
+
+    #[test]
+    fn missing_for_gap_days_inside_range() {
+        // Range is 03-01..=03-03; only the endpoints have data, the middle is a gap.
+        let live = set(&[d(2026, 3, 1)]);
+        let cache = set(&[d(2026, 3, 3)]);
+        let audit = audit_source("gemini", "gemini", &live, &cache);
+
+        assert_eq!(audit.start, Some(d(2026, 3, 1)));
+        assert_eq!(audit.end, Some(d(2026, 3, 3)));
+        assert_eq!(audit.total_days, 3);
+        assert_eq!(audit.days[1].date, d(2026, 3, 2));
+        assert_eq!(audit.days[1].coverage, DayCoverage::Missing);
+        assert_eq!(audit.live_days, 1);
+        assert_eq!(audit.cache_only_days, 1);
+        assert_eq!(audit.missing_days, 1);
+    }
+
+    #[test]
+    fn empty_source_yields_none_range() {
+        let audit = audit_source("pi-agent", "pi-agent", &HashSet::new(), &HashSet::new());
+
+        assert_eq!(audit.start, None);
+        assert_eq!(audit.end, None);
+        assert_eq!(audit.total_days, 0);
+        assert!(audit.days.is_empty());
+    }
+
+    #[test]
+    fn single_day_source() {
+        let day = d(2026, 6, 8);
+        let audit = audit_source("opencode", "opencode", &set(&[day]), &HashSet::new());
+
+        assert_eq!(audit.start, Some(day));
+        assert_eq!(audit.end, Some(day));
+        assert_eq!(audit.total_days, 1);
+        assert_eq!(audit.live_days, 1);
+    }
+
+    #[test]
+    fn counts_sum_to_total_days() {
+        // 03-01 live, 03-02 missing, 03-03 cache_only, 03-04 missing, 03-05 live.
+        let live = set(&[d(2026, 3, 1), d(2026, 3, 5)]);
+        let cache = set(&[d(2026, 3, 3)]);
+        let audit = audit_source("claude-code", "claude-code", &live, &cache);
+
+        assert_eq!(audit.total_days, 5);
+        assert_eq!(
+            audit.live_days + audit.cache_only_days + audit.missing_days,
+            audit.total_days
+        );
+        assert_eq!(audit.live_days, 2);
+        assert_eq!(audit.cache_only_days, 1);
+        assert_eq!(audit.missing_days, 2);
+    }
+
+    #[test]
+    fn coverage_serializes_to_snake_case() {
+        let day = d(2026, 3, 1);
+        let audit = audit_source("codex", "codex", &HashSet::new(), &set(&[day]));
+        let json = serde_json::to_string(&audit.days[0]).unwrap();
+        assert!(json.contains("\"cache_only\""), "got: {json}");
+    }
+
+    #[test]
+    fn build_report_counts_cached_dates_as_cache_only_when_no_raw() {
+        use crate::parsers::ClaudeCodeParser;
+        use crate::services::cache::DailySummaryCache;
+        use crate::types::DailySummary;
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().unwrap();
+        let cache = DailySummaryCacheService::with_cache_dir(temp.path().to_path_buf());
+
+        let summary_on = |date: NaiveDate| DailySummary {
+            date,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_reasoning_tokens: 0,
+            total_cache_creation_5m_tokens: 0,
+            total_cache_creation_1h_tokens: 0,
+            total_web_search_requests: 0,
+            total_cost_usd: 0.0,
+            models: HashMap::new(),
+        };
+        let cache_file = DailySummaryCache {
+            cli: "auditsrc".to_string(),
+            version: 0, // irrelevant for cached_dates
+            updated_at: 0,
+            summaries: vec![summary_on(d(2024, 1, 10)), summary_on(d(2024, 1, 12))],
+        };
+        std::fs::write(
+            cache.cache_path("auditsrc"),
+            serde_json::to_string(&cache_file).unwrap(),
+        )
+        .unwrap();
+
+        // Parser points at a nonexistent dir → no live dates, so every cached
+        // date must be classified cache_only.
+        let source = SourceInstance::new(
+            "auditsrc",
+            "auditsrc",
+            "claude-code",
+            Box::new(ClaudeCodeParser::with_data_dir(PathBuf::from(
+                "tests/fixtures/nonexistent",
+            ))),
+        );
+
+        let report = build_report(std::slice::from_ref(&source), &cache, d(2024, 6, 1));
+
+        assert_eq!(report.sources.len(), 1);
+        let audited = &report.sources[0];
+        assert_eq!(audited.live_days, 0);
+        assert_eq!(audited.cache_only_days, 2);
+        assert_eq!(report.total_cache_only_days, 2);
+        assert_eq!(report.generated_for, d(2024, 6, 1));
+    }
+}

--- a/src/services/cache.rs
+++ b/src/services/cache.rs
@@ -181,6 +181,20 @@ impl DailySummaryCacheService {
         cache.summaries.iter().map(|s| s.date).max()
     }
 
+    /// Return the set of dates present in the cached summaries.
+    /// Empty when the cache file is absent or unreadable (no panic) — the audit
+    /// treats an unreadable cache as "nothing preserved" rather than failing.
+    pub fn cached_dates(&self, cli: &str) -> HashSet<NaiveDate> {
+        let path = self.cache_path(cli);
+        let Ok(content) = fs::read_to_string(&path) else {
+            return HashSet::new();
+        };
+        match serde_json::from_str::<DailySummaryCache>(&content) {
+            Ok(cache) => cache.summaries.iter().map(|s| s.date).collect(),
+            Err(_) => HashSet::new(),
+        }
+    }
+
     /// Load cached summaries for past dates (excludes today).
     /// Uses shared file lock for concurrent read safety.
     fn load_past_summaries(
@@ -980,6 +994,59 @@ mod tests {
             service.latest_cached_date("claude-code"),
             Some(NaiveDate::from_ymd_opt(2026, 2, 27).unwrap())
         );
+    }
+
+    // Test: cached_dates is empty when no cache file exists
+    #[test]
+    fn test_cached_dates_empty_when_no_file() {
+        let (service, _temp) = create_test_service();
+        assert!(service.cached_dates("claude-code").is_empty());
+    }
+
+    // Test: cached_dates collects every date from the cached summaries
+    #[test]
+    fn test_cached_dates_collects_all_summary_dates() {
+        let (service, _temp) = create_test_service();
+        let summary_on = |date: NaiveDate| DailySummary {
+            date,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_reasoning_tokens: 0,
+            total_cache_creation_5m_tokens: 0,
+            total_cache_creation_1h_tokens: 0,
+            total_web_search_requests: 0,
+            total_cost_usd: 0.0,
+            models: HashMap::new(),
+        };
+        let cache = DailySummaryCache {
+            cli: "claude-code".to_string(),
+            version: CACHE_VERSION,
+            updated_at: chrono::Utc::now().timestamp(),
+            summaries: vec![
+                summary_on(NaiveDate::from_ymd_opt(2026, 3, 1).unwrap()),
+                summary_on(NaiveDate::from_ymd_opt(2026, 3, 3).unwrap()),
+            ],
+        };
+        let cache_path = service.cache_path("claude-code");
+        fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        fs::write(&cache_path, serde_json::to_string(&cache).unwrap()).unwrap();
+
+        let dates = service.cached_dates("claude-code");
+        assert_eq!(dates.len(), 2);
+        assert!(dates.contains(&NaiveDate::from_ymd_opt(2026, 3, 1).unwrap()));
+        assert!(dates.contains(&NaiveDate::from_ymd_opt(2026, 3, 3).unwrap()));
+    }
+
+    // Test: cached_dates returns empty on a corrupted cache file (no panic)
+    #[test]
+    fn test_cached_dates_empty_on_corrupted_file() {
+        let (service, _temp) = create_test_service();
+        let cache_path = service.cache_path("claude-code");
+        fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        fs::write(&cache_path, "not valid json {{{").unwrap();
+        assert!(service.cached_dates("claude-code").is_empty());
     }
 
     // Test 17: latest_cached_date returns None for empty summaries

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,6 +1,7 @@
 //! Services for data aggregation and processing
 
 pub mod aggregator;
+pub mod audit;
 pub mod cache;
 pub mod config;
 pub mod data_loader;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -289,14 +289,25 @@ impl App {
 
     /// Poll the background audit thread without blocking the event loop.
     fn poll_audit(&mut self) {
-        if let Some(rx) = &self.audit_rx {
-            if let Ok(result) = rx.try_recv() {
-                match result {
-                    Ok(report) => self.audit = Some(report),
-                    Err(e) => self.audit_error = Some(e),
-                }
+        let Some(rx) = &self.audit_rx else {
+            return;
+        };
+        match rx.try_recv() {
+            Ok(Ok(report)) => {
+                self.audit = Some(report);
                 self.audit_rx = None;
             }
+            Ok(Err(e)) => {
+                self.audit_error = Some(e);
+                self.audit_rx = None;
+            }
+            // Sender dropped without sending (e.g. the worker thread panicked) —
+            // surface an error instead of spinning on "Computing…" forever.
+            Err(mpsc::TryRecvError::Disconnected) => {
+                self.audit_error = Some("Audit computation failed unexpectedly".to_string());
+                self.audit_rx = None;
+            }
+            Err(mpsc::TryRecvError::Empty) => {}
         }
     }
 
@@ -1804,6 +1815,23 @@ mod tests {
             app.view_mode,
             ViewMode::Dashboard { tab: Tab::Audit }
         ));
+    }
+
+    #[test]
+    fn test_poll_audit_surfaces_disconnected_worker() {
+        // If the audit worker thread dies without sending (sender dropped),
+        // poll_audit must surface an error and clear the receiver instead of
+        // leaving the Audit tab stuck on "Computing…" forever.
+        let mut app = App::default();
+        let (tx, rx) = mpsc::channel::<std::result::Result<AuditReport, String>>();
+        drop(tx);
+        app.audit_rx = Some(rx);
+
+        app.poll_audit();
+
+        assert!(app.audit_error.is_some());
+        assert!(app.audit_rx.is_none());
+        assert!(app.audit.is_none());
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -13,8 +13,12 @@ use ratatui::{
 
 use super::theme::Theme;
 
+use crate::parsers::ParserRegistry;
+use crate::services::audit::{self, AuditReport};
 use crate::services::update_checker::{check_for_update, execute_update, UpdateCheckResult};
-use crate::services::{Aggregator, DataLoaderService, RemoteOptions, RemoteSourceService};
+use crate::services::{
+    Aggregator, DailySummaryCacheService, DataLoaderService, RemoteOptions, RemoteSourceService,
+};
 use crate::types::{CacheWarning, DailySummary, SourceUsage, StatsData, TotalSummary};
 
 use super::widgets::{
@@ -137,6 +141,14 @@ pub struct App {
     quit_confirm: Option<QuitConfirmState>,
     model_breakdown: Option<ModelBreakdownState>,
     terminal_height: u16,
+    /// Remote options retained for the on-demand audit computation.
+    remote_options: RemoteOptions,
+    /// Lazily-computed data-preservation audit (Audit tab).
+    audit: Option<AuditReport>,
+    /// Receiver for the background audit computation, if one is in flight.
+    audit_rx: Option<mpsc::Receiver<std::result::Result<AuditReport, String>>>,
+    /// Error from the audit computation, if it failed.
+    audit_error: Option<String>,
 }
 
 impl App {
@@ -167,6 +179,10 @@ impl App {
             quit_confirm: None,
             model_breakdown: None,
             terminal_height: 24,
+            remote_options: config.remote_options.clone(),
+            audit: None,
+            audit_rx: None,
+            audit_error: None,
         }
     }
 
@@ -250,6 +266,38 @@ impl App {
     /// Set the current dashboard tab
     fn set_tab(&mut self, tab: Tab) {
         self.view_mode = ViewMode::Dashboard { tab };
+        if tab == Tab::Audit {
+            self.ensure_audit_loading();
+        }
+    }
+
+    /// Kick off the background audit computation the first time the Audit tab
+    /// is opened. The audit needs a full raw parse, so it must never run on the
+    /// startup hot path — only on demand.
+    fn ensure_audit_loading(&mut self) {
+        if self.audit.is_some() || self.audit_rx.is_some() {
+            return;
+        }
+        self.audit_error = None;
+        let remote_options = self.remote_options.clone();
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let _ = tx.send(compute_audit(remote_options));
+        });
+        self.audit_rx = Some(rx);
+    }
+
+    /// Poll the background audit thread without blocking the event loop.
+    fn poll_audit(&mut self) {
+        if let Some(rx) = &self.audit_rx {
+            if let Ok(result) = rx.try_recv() {
+                match result {
+                    Ok(report) => self.audit = Some(report),
+                    Err(e) => self.audit_error = Some(e),
+                }
+                self.audit_rx = None;
+            }
+        }
     }
 
     /// Handle keyboard events in Dashboard mode
@@ -286,6 +334,12 @@ impl App {
             }
             KeyCode::Char('3') => {
                 if let Some(tab) = Tab::from_number(3) {
+                    self.set_tab(tab);
+                }
+                return;
+            }
+            KeyCode::Char('4') => {
+                if let Some(tab) = Tab::from_number(4) {
                     self.set_tab(tab);
                 }
                 return;
@@ -348,8 +402,8 @@ impl App {
                 }
                 _ => {}
             },
-            Tab::Stats | Tab::Models => {
-                // Stats/Models tabs have no additional keys beyond common ones
+            Tab::Stats | Tab::Models | Tab::Audit => {
+                // These tabs have no additional keys beyond the common ones.
             }
         }
     }
@@ -692,6 +746,14 @@ impl Widget for &App {
                             .with_tab(*tab);
                             models_view.render(area, buf);
                         }
+                        Tab::Audit => {
+                            super::widgets::audit::AuditView::new(
+                                self.audit.as_ref(),
+                                self.audit_error.as_deref(),
+                                self.theme,
+                            )
+                            .render(area, buf);
+                        }
                     },
                     ViewMode::SourceDetail { source } => {
                         let daily_data = data
@@ -780,6 +842,20 @@ pub fn run(config: TuiConfig) -> anyhow::Result<()> {
     let result = run_app(&mut terminal, config, theme);
     ratatui::restore();
     result
+}
+
+/// Compute the data-preservation audit (runs on a background thread when the
+/// Audit tab is first opened — never on the startup hot path).
+fn compute_audit(remote_options: RemoteOptions) -> Result<AuditReport, String> {
+    let extra_sources =
+        RemoteSourceService::sync_and_build_sources(&remote_options).map_err(|e| e.to_string())?;
+    let registry = ParserRegistry::with_extra_sources(extra_sources);
+    let cache = DailySummaryCacheService::new().map_err(|e| e.to_string())?;
+    Ok(audit::build_report(
+        registry.sources(),
+        &cache,
+        Local::now().date_naive(),
+    ))
 }
 
 /// Load data synchronously (extracted for background thread).
@@ -902,6 +978,9 @@ fn run_app(terminal: &mut DefaultTerminal, config: TuiConfig, theme: Theme) -> a
                 }
             }
         }
+
+        // Check for on-demand audit completion (non-blocking)
+        app.poll_audit();
 
         // Check for update check completion (non-blocking)
         if app.update_status == UpdateStatus::Checking {
@@ -1702,6 +1781,12 @@ mod tests {
         app.handle_event(Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)));
         assert!(matches!(
             app.view_mode,
+            ViewMode::Dashboard { tab: Tab::Audit }
+        ));
+
+        app.handle_event(Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)));
+        assert!(matches!(
+            app.view_mode,
             ViewMode::Dashboard { tab: Tab::Overview }
         ));
     }
@@ -1710,13 +1795,14 @@ mod tests {
     fn test_backtab_switches_tab() {
         let mut app = App::default();
 
+        // From Overview, BackTab wraps to the last tab (Audit).
         app.handle_event(Event::Key(KeyEvent::new(
             KeyCode::BackTab,
             KeyModifiers::SHIFT,
         )));
         assert!(matches!(
             app.view_mode,
-            ViewMode::Dashboard { tab: Tab::Models }
+            ViewMode::Dashboard { tab: Tab::Audit }
         ));
     }
 

--- a/src/tui/widgets/audit.rs
+++ b/src/tui/widgets/audit.rs
@@ -23,8 +23,10 @@ const MAX_CONTENT_WIDTH: u16 = 170;
 const BAR_WIDTH: usize = 48;
 
 /// Split a bar of `width` cells proportionally across the three coverage
-/// categories. Any non-zero category gets at least one cell (so a single
-/// preserved day is still visible), and `missing` absorbs the remainder.
+/// categories. `live` and `cache_only` are each bumped to at least one cell so
+/// a single preserved day stays visible; if the bar is too narrow to fit both,
+/// `cache_only` (the headline metric) is kept and `live` may fall to zero.
+/// `missing` absorbs the remainder.
 fn segment_widths(live: u32, cache_only: u32, missing: u32, width: usize) -> (usize, usize, usize) {
     let total = (live + cache_only + missing) as usize;
     if total == 0 || width == 0 {
@@ -72,12 +74,6 @@ impl<'a> AuditView<'a> {
             selected_tab: Tab::Audit,
             theme,
         }
-    }
-
-    #[allow(dead_code)] // Parity with the other views; selected tab is always Audit here.
-    pub fn with_tab(mut self, tab: Tab) -> Self {
-        self.selected_tab = tab;
-        self
     }
 }
 
@@ -316,7 +312,7 @@ mod tests {
     }
 
     #[test]
-    fn segment_widths_split_proportionally() {
+    fn test_segment_widths_split_proportionally() {
         // 50/50 live vs missing over 48 cells.
         let (l, c, m) = segment_widths(10, 0, 10, 48);
         assert_eq!(c, 0);
@@ -325,20 +321,20 @@ mod tests {
     }
 
     #[test]
-    fn segment_widths_keeps_single_preserved_day_visible() {
+    fn test_segment_widths_keeps_single_preserved_day_visible() {
         // 1 preserved day out of 1000 must still light at least one cell.
         let (_l, c, _m) = segment_widths(999, 1, 0, 48);
         assert!(c >= 1, "preserved segment vanished");
     }
 
     #[test]
-    fn segment_widths_never_exceed_width() {
+    fn test_segment_widths_never_exceed_width() {
         let (l, c, m) = segment_widths(1, 1, 0, 2);
         assert_eq!(l + c + m, 2);
     }
 
     #[test]
-    fn segment_widths_empty_is_zero() {
+    fn test_segment_widths_empty_is_zero() {
         assert_eq!(segment_widths(0, 0, 0, 48), (0, 0, 0));
     }
 
@@ -357,19 +353,19 @@ mod tests {
     }
 
     #[test]
-    fn renders_loading_state_without_panic() {
+    fn test_renders_loading_state_without_panic() {
         let text = render_to_string(AuditView::new(None, None, Theme::Dark));
         assert!(text.contains("Computing"), "got:\n{text}");
     }
 
     #[test]
-    fn renders_error_state_without_panic() {
+    fn test_renders_error_state_without_panic() {
         let text = render_to_string(AuditView::new(None, Some("boom"), Theme::Dark));
         assert!(text.contains("Audit failed"), "got:\n{text}");
     }
 
     #[test]
-    fn renders_report_with_headline() {
+    fn test_renders_report_with_headline() {
         let report = AuditReport {
             generated_for: date(2026, 6, 8),
             total_cache_only_days: 28,

--- a/src/tui/widgets/audit.rs
+++ b/src/tui/widgets/audit.rs
@@ -1,0 +1,382 @@
+//! Audit view widget — per-source data-preservation coverage.
+//!
+//! Renders one stacked bar per source (live / preserved / no-data) and a
+//! headline count of the days toktrack kept after the upstream CLI deleted
+//! them. While the audit is still computing (a background full parse) the view
+//! shows a "computing" message rather than blocking startup.
+
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Paragraph, Widget},
+};
+
+use super::tabs::{Tab, TabBar};
+use crate::services::audit::{AuditReport, SourceAudit};
+use crate::tui::theme::Theme;
+
+/// Maximum content width (consistent with the other views).
+const MAX_CONTENT_WIDTH: u16 = 170;
+/// Width of the per-source coverage bar, in cells.
+const BAR_WIDTH: usize = 48;
+
+/// Split a bar of `width` cells proportionally across the three coverage
+/// categories. Any non-zero category gets at least one cell (so a single
+/// preserved day is still visible), and `missing` absorbs the remainder.
+fn segment_widths(live: u32, cache_only: u32, missing: u32, width: usize) -> (usize, usize, usize) {
+    let total = (live + cache_only + missing) as usize;
+    if total == 0 || width == 0 {
+        return (0, 0, 0);
+    }
+
+    let mut l = live as usize * width / total;
+    let mut c = cache_only as usize * width / total;
+    if live > 0 {
+        l = l.max(1);
+    }
+    if cache_only > 0 {
+        c = c.max(1);
+    }
+    // Bumping to at least one cell can overshoot the bar; trim the larger of the
+    // two filled segments until they fit, keeping at least one cell each.
+    while l + c > width {
+        if l >= c && l > 1 {
+            l -= 1;
+        } else if c > 1 {
+            c -= 1;
+        } else if l > 0 {
+            l -= 1;
+        } else {
+            c -= 1;
+        }
+    }
+    let m = width - l - c;
+    (l, c, m)
+}
+
+/// Audit view widget.
+pub struct AuditView<'a> {
+    report: Option<&'a AuditReport>,
+    error: Option<&'a str>,
+    selected_tab: Tab,
+    theme: Theme,
+}
+
+impl<'a> AuditView<'a> {
+    pub fn new(report: Option<&'a AuditReport>, error: Option<&'a str>, theme: Theme) -> Self {
+        Self {
+            report,
+            error,
+            selected_tab: Tab::Audit,
+            theme,
+        }
+    }
+
+    #[allow(dead_code)] // Parity with the other views; selected tab is always Audit here.
+    pub fn with_tab(mut self, tab: Tab) -> Self {
+        self.selected_tab = tab;
+        self
+    }
+}
+
+impl Widget for AuditView<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let content_width = area.width.min(MAX_CONTENT_WIDTH);
+        let x_offset = (area.width.saturating_sub(content_width)) / 2;
+        let centered = Rect {
+            x: area.x + x_offset,
+            y: area.y,
+            width: content_width,
+            height: area.height,
+        };
+
+        let chunks = Layout::vertical([
+            Constraint::Length(1), // top padding
+            Constraint::Length(1), // tabs
+            Constraint::Length(1), // separator
+            Constraint::Length(1), // title
+            Constraint::Length(1), // blank
+            Constraint::Min(0),    // content
+            Constraint::Length(1), // separator
+            Constraint::Length(1), // keybindings
+        ])
+        .split(centered);
+
+        TabBar::new(self.selected_tab, self.theme).render(chunks[1], buf);
+        self.render_separator(chunks[2], buf);
+        self.render_title(chunks[3], buf);
+        self.render_content(chunks[5], buf);
+        self.render_separator(chunks[6], buf);
+        self.render_keybindings(chunks[7], buf);
+    }
+}
+
+impl AuditView<'_> {
+    fn render_separator(&self, area: Rect, buf: &mut Buffer) {
+        let line = "─".repeat(area.width as usize);
+        buf.set_string(
+            area.x,
+            area.y,
+            &line,
+            Style::default().fg(self.theme.muted()),
+        );
+    }
+
+    fn render_title(&self, area: Rect, buf: &mut Buffer) {
+        Paragraph::new(Line::from(Span::styled(
+            "Data Preservation Audit",
+            Style::default()
+                .fg(self.theme.text())
+                .add_modifier(Modifier::BOLD),
+        )))
+        .alignment(Alignment::Center)
+        .render(area, buf);
+    }
+
+    fn render_content(&self, area: Rect, buf: &mut Buffer) {
+        match (self.error, self.report) {
+            (Some(err), _) => self.render_message(
+                area,
+                buf,
+                &format!("Audit failed: {err}"),
+                self.theme.error(),
+            ),
+            (None, None) => self.render_message(
+                area,
+                buf,
+                "Computing data-preservation audit… (parsing raw session files)",
+                self.theme.muted(),
+            ),
+            (None, Some(report)) => self.render_report(area, buf, report),
+        }
+    }
+
+    fn render_message(
+        &self,
+        area: Rect,
+        buf: &mut Buffer,
+        msg: &str,
+        color: ratatui::style::Color,
+    ) {
+        Paragraph::new(Line::from(Span::styled(
+            msg.to_string(),
+            Style::default().fg(color),
+        )))
+        .alignment(Alignment::Center)
+        .render(area, buf);
+    }
+
+    fn render_report(&self, area: Rect, buf: &mut Buffer, report: &AuditReport) {
+        let mut lines: Vec<Line> = Vec::new();
+        lines.push(self.legend_line());
+        lines.push(Line::from(""));
+        for source in &report.sources {
+            self.push_source_lines(&mut lines, source);
+        }
+        lines.push(Line::from(""));
+        lines.push(self.headline_line(report));
+
+        Paragraph::new(lines).render(area, buf);
+    }
+
+    fn legend_line(&self) -> Line<'static> {
+        Line::from(vec![
+            Span::styled("█ live   ", Style::default().fg(self.theme.bar())),
+            Span::styled(
+                "█ preserved (CLI deleted)   ",
+                Style::default().fg(self.theme.cost()),
+            ),
+            Span::styled(
+                "░ no data (unused or lost)",
+                Style::default().fg(self.theme.muted()),
+            ),
+        ])
+    }
+
+    fn push_source_lines(&self, lines: &mut Vec<Line<'static>>, source: &SourceAudit) {
+        match (source.start, source.end) {
+            (Some(start), Some(end)) => {
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("{:<14}", source.label),
+                        Style::default().fg(self.theme.text()),
+                    ),
+                    Span::styled(
+                        format!("{start} → {end}   "),
+                        Style::default().fg(self.theme.muted()),
+                    ),
+                    Span::styled(
+                        format!("live {}", source.live_days),
+                        Style::default().fg(self.theme.bar()),
+                    ),
+                    Span::styled(" · ", Style::default().fg(self.theme.muted())),
+                    Span::styled(
+                        format!("preserved {}", source.cache_only_days),
+                        Style::default().fg(self.theme.cost()),
+                    ),
+                    Span::styled(" · ", Style::default().fg(self.theme.muted())),
+                    Span::styled(
+                        format!("missing {}", source.missing_days),
+                        Style::default().fg(self.theme.muted()),
+                    ),
+                ]));
+
+                let (l, c, m) = segment_widths(
+                    source.live_days,
+                    source.cache_only_days,
+                    source.missing_days,
+                    BAR_WIDTH,
+                );
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("█".repeat(l), Style::default().fg(self.theme.bar())),
+                    Span::styled("█".repeat(c), Style::default().fg(self.theme.cost())),
+                    Span::styled("░".repeat(m), Style::default().fg(self.theme.muted())),
+                ]));
+                lines.push(Line::from(""));
+            }
+            _ => {
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("{:<14}", source.label),
+                        Style::default().fg(self.theme.text()),
+                    ),
+                    Span::styled("(no data)", Style::default().fg(self.theme.muted())),
+                ]));
+                lines.push(Line::from(""));
+            }
+        }
+    }
+
+    fn headline_line(&self, report: &AuditReport) -> Line<'static> {
+        if report.total_cache_only_days > 0 {
+            Line::from(Span::styled(
+                format!(
+                    "► {} days of cost history preserved that your CLIs already deleted.",
+                    report.total_cache_only_days
+                ),
+                Style::default()
+                    .fg(self.theme.cost())
+                    .add_modifier(Modifier::BOLD),
+            ))
+        } else {
+            Line::from(Span::styled(
+                "► No cache-only history yet — all tracked data is still live on disk.",
+                Style::default().fg(self.theme.muted()),
+            ))
+        }
+    }
+
+    fn render_keybindings(&self, area: Rect, buf: &mut Buffer) {
+        Paragraph::new(Line::from(vec![
+            Span::styled("Ctrl+C", Style::default().fg(self.theme.accent())),
+            Span::styled(": Quit", Style::default().fg(self.theme.muted())),
+            Span::raw("  "),
+            Span::styled("Tab", Style::default().fg(self.theme.accent())),
+            Span::styled(": Switch view", Style::default().fg(self.theme.muted())),
+            Span::raw("  "),
+            Span::styled("?", Style::default().fg(self.theme.accent())),
+            Span::styled(": Help", Style::default().fg(self.theme.muted())),
+        ]))
+        .alignment(Alignment::Center)
+        .render(area, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::audit::{AuditReport, SourceAudit};
+    use chrono::NaiveDate;
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    fn source(
+        label: &str,
+        start: Option<NaiveDate>,
+        live: u32,
+        cache_only: u32,
+        missing: u32,
+    ) -> SourceAudit {
+        SourceAudit {
+            id: label.to_string(),
+            label: label.to_string(),
+            start,
+            end: start,
+            total_days: live + cache_only + missing,
+            live_days: live,
+            cache_only_days: cache_only,
+            missing_days: missing,
+            days: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn segment_widths_split_proportionally() {
+        // 50/50 live vs missing over 48 cells.
+        let (l, c, m) = segment_widths(10, 0, 10, 48);
+        assert_eq!(c, 0);
+        assert_eq!(l + c + m, 48);
+        assert_eq!(l, 24);
+    }
+
+    #[test]
+    fn segment_widths_keeps_single_preserved_day_visible() {
+        // 1 preserved day out of 1000 must still light at least one cell.
+        let (_l, c, _m) = segment_widths(999, 1, 0, 48);
+        assert!(c >= 1, "preserved segment vanished");
+    }
+
+    #[test]
+    fn segment_widths_never_exceed_width() {
+        let (l, c, m) = segment_widths(1, 1, 0, 2);
+        assert_eq!(l + c + m, 2);
+    }
+
+    #[test]
+    fn segment_widths_empty_is_zero() {
+        assert_eq!(segment_widths(0, 0, 0, 48), (0, 0, 0));
+    }
+
+    fn render_to_string(view: AuditView) -> String {
+        let area = Rect::new(0, 0, 90, 24);
+        let mut buf = Buffer::empty(area);
+        view.render(area, &mut buf);
+        let mut out = String::new();
+        for y in 0..area.height {
+            for x in 0..area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn renders_loading_state_without_panic() {
+        let text = render_to_string(AuditView::new(None, None, Theme::Dark));
+        assert!(text.contains("Computing"), "got:\n{text}");
+    }
+
+    #[test]
+    fn renders_error_state_without_panic() {
+        let text = render_to_string(AuditView::new(None, Some("boom"), Theme::Dark));
+        assert!(text.contains("Audit failed"), "got:\n{text}");
+    }
+
+    #[test]
+    fn renders_report_with_headline() {
+        let report = AuditReport {
+            generated_for: date(2026, 6, 8),
+            total_cache_only_days: 28,
+            sources: vec![source("claude-code", Some(date(2026, 3, 1)), 72, 28, 0)],
+        };
+        let text = render_to_string(AuditView::new(Some(&report), None, Theme::Dark));
+        assert!(text.contains("preserved"), "got:\n{text}");
+        assert!(text.contains("28 days"), "got:\n{text}");
+    }
+}

--- a/src/tui/widgets/help.rs
+++ b/src/tui/widgets/help.rs
@@ -68,7 +68,7 @@ impl Widget for HelpPopup {
             Constraint::Length(1), // [1] Navigation header
             Constraint::Length(1), // [2] Separator
             Constraint::Length(1), // [3] Tab/Shift+Tab
-            Constraint::Length(1), // [4] 1-3
+            Constraint::Length(1), // [4] 1-4
             Constraint::Length(1), // [5] Up/Down
             Constraint::Length(1), // [6] Enter
             Constraint::Length(1), // [7] Esc
@@ -107,7 +107,7 @@ impl Widget for HelpPopup {
 
         // Keybindings
         render_keybinding(chunks[3], buf, "Tab / Shift+Tab", "Switch view", self.theme);
-        render_keybinding(chunks[4], buf, "1 / 2 / 3", "Jump to tab", self.theme);
+        render_keybinding(chunks[4], buf, "1 / 2 / 3 / 4", "Jump to tab", self.theme);
         render_keybinding(chunks[5], buf, "Up/Down or j/k", "Navigate", self.theme);
         render_keybinding(chunks[6], buf, "Enter", "View source details", self.theme);
         render_keybinding(chunks[7], buf, "Esc", "Back to dashboard", self.theme);

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -1,5 +1,6 @@
 //! TUI widgets
 
+pub mod audit;
 pub mod daily;
 pub mod heatmap;
 pub mod help;

--- a/src/tui/widgets/tabs.rs
+++ b/src/tui/widgets/tabs.rs
@@ -16,6 +16,7 @@ pub enum Tab {
     Overview,
     Stats,
     Models,
+    Audit,
 }
 
 impl Tab {
@@ -25,12 +26,13 @@ impl Tab {
             Self::Overview => "Overview",
             Self::Stats => "Stats",
             Self::Models => "Models",
+            Self::Audit => "Audit",
         }
     }
 
     /// Get all tabs in order
     pub fn all() -> &'static [Tab] {
-        &[Tab::Overview, Tab::Stats, Tab::Models]
+        &[Tab::Overview, Tab::Stats, Tab::Models, Tab::Audit]
     }
 
     /// Get the next tab (wrapping)
@@ -38,25 +40,28 @@ impl Tab {
         match self {
             Self::Overview => Self::Stats,
             Self::Stats => Self::Models,
-            Self::Models => Self::Overview,
+            Self::Models => Self::Audit,
+            Self::Audit => Self::Overview,
         }
     }
 
     /// Get the previous tab (wrapping)
     pub fn prev(self) -> Self {
         match self {
-            Self::Overview => Self::Models,
+            Self::Overview => Self::Audit,
             Self::Stats => Self::Overview,
             Self::Models => Self::Stats,
+            Self::Audit => Self::Models,
         }
     }
 
-    /// Get tab from number key (1-3)
+    /// Get tab from number key (1-4)
     pub fn from_number(n: u8) -> Option<Self> {
         match n {
             1 => Some(Self::Overview),
             2 => Some(Self::Stats),
             3 => Some(Self::Models),
+            4 => Some(Self::Audit),
             _ => None,
         }
     }
@@ -139,29 +144,33 @@ mod tests {
         assert_eq!(Tab::Overview.label(), "Overview");
         assert_eq!(Tab::Stats.label(), "Stats");
         assert_eq!(Tab::Models.label(), "Models");
+        assert_eq!(Tab::Audit.label(), "Audit");
     }
 
     #[test]
     fn test_tab_all() {
         let all = Tab::all();
-        assert_eq!(all.len(), 3);
+        assert_eq!(all.len(), 4);
         assert_eq!(all[0], Tab::Overview);
         assert_eq!(all[1], Tab::Stats);
         assert_eq!(all[2], Tab::Models);
+        assert_eq!(all[3], Tab::Audit);
     }
 
     #[test]
     fn test_tab_next() {
         assert_eq!(Tab::Overview.next(), Tab::Stats);
         assert_eq!(Tab::Stats.next(), Tab::Models);
-        assert_eq!(Tab::Models.next(), Tab::Overview);
+        assert_eq!(Tab::Models.next(), Tab::Audit);
+        assert_eq!(Tab::Audit.next(), Tab::Overview);
     }
 
     #[test]
     fn test_tab_prev() {
-        assert_eq!(Tab::Overview.prev(), Tab::Models);
+        assert_eq!(Tab::Overview.prev(), Tab::Audit);
         assert_eq!(Tab::Stats.prev(), Tab::Overview);
         assert_eq!(Tab::Models.prev(), Tab::Stats);
+        assert_eq!(Tab::Audit.prev(), Tab::Models);
     }
 
     #[test]
@@ -174,7 +183,8 @@ mod tests {
         assert_eq!(Tab::from_number(1), Some(Tab::Overview));
         assert_eq!(Tab::from_number(2), Some(Tab::Stats));
         assert_eq!(Tab::from_number(3), Some(Tab::Models));
+        assert_eq!(Tab::from_number(4), Some(Tab::Audit));
         assert_eq!(Tab::from_number(0), None);
-        assert_eq!(Tab::from_number(4), None);
+        assert_eq!(Tab::from_number(5), None);
     }
 }


### PR DESCRIPTION
## What
Adds `toktrack audit` — a per-source, per-day data-preservation report that makes the persistent-cache wedge visible: it shows which days are still **live** (raw session file on disk), **cache_only** (the CLI deleted the raw file — only toktrack still has it), or **missing** (no data — labelled "unused or lost", never claimed as a loss).

On the author's own machine: **100 days of cost history preserved that the CLIs already deleted** (claude-code 83, codex 13, gemini 3, opencode 1).

## Surfaces
- **CLI**: `toktrack audit` (text table + headline) and `toktrack audit --json` (full per-day breakdown). Honours the existing `--remote/--all-remotes/--local-only` flags.
- **TUI**: a fourth **Audit** tab (key `4` / Tab cycle) with a stacked coverage bar per source + headline. Computed **lazily on a background thread** the first time the tab is opened, so it never slows TUI startup (live-date detection needs a full raw parse).

## Design notes
- `live` dates come from a full `parse_all` (correct for session files spanning midnight, unlike a first-line peek).
- A source that fails to parse degrades to "no live data" rather than failing the whole audit (matches the project's graceful-degradation rule).
- Headline metric = total `cache_only` days. Gap days are never presented as a loss (honesty over hype).

## Tests
Pure classification logic, cache date enumeration, CLI parsing, text rendering, TUI widget rendering + tab cycling — all under `make check` (fmt + clippy + test), 583 passing.

## Commits
1. `feat(cli): add audit subcommand for data-preservation coverage`
2. `feat(tui): add Audit tab with lazy data-preservation view`
3. `docs: document audit subcommand and sync Korean cache structure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)