### PR TITLE
feat(tui): add Projects tab with per-project token breakdown

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -26,7 +26,8 @@
 
 - **데이터 보존** — 영구 캐시로 CLI가 세션 파일을 삭제한 뒤에도 비용 기록 유지
 - **멀티 CLI 지원** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent 한 곳에서
-- **TUI 대시보드** — 3개 탭 (Overview, Stats, Models), 일별/주별/월별 뷰
+- **TUI 대시보드** — 5개 탭 (Overview, Stats, Models, Projects, Audit), 일별/주별/월별 뷰
+- **프로젝트별 분석** — Projects 탭에서 프로젝트(세션 작업 디렉토리)별 토큰/비용 표시 (기록하는 CLI: Claude Code, Codex, OpenCode, PI Agent, Gemini CLI). 프로젝트를 열면 일별·모델별 분석으로 드릴다운. 프로젝트를 기록하지 않는 CLI는 `(no project)`로 묶임. 프로젝트 상세는 캐시되므로 CLI의 30일 삭제 후에도 유지
 - **CLI 명령어** — `daily`, `weekly`, `monthly`, `stats` (JSON 출력 지원)
 - **사용량 리포트** — 공유 가능한 텍스트 & SVG 영수증 (`toktrack report`)
 - **대용량에서도 빠름** — simd-json + rayon 병렬 파싱 (~3 GiB/s), 캐시 시 ~0.04초
@@ -128,7 +129,7 @@ zsh/bash/fish 몇 줄이면 됩니다 — **[셸 통합 가이드](docs/shell-in
 
 | 키 | 동작 |
 |-----|--------|
-| `1-4` | 탭 직접 전환 (Audit 포함) |
+| `1-5` | 탭 직접 전환 (Projects, Audit 포함) |
 | `Tab` / `Shift+Tab` | 다음 / 이전 탭 |
 | `j` / `k` 또는 `↑` / `↓` | 위 / 아래 스크롤 |
 | `Enter` | 모델 상세 팝업 열기 (Daily 탭) |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Track usage across **all your AI coding CLIs** — Claude Code, Codex CLI, Gemin
 - **Data Preservation** — Persistent cache keeps your cost history even after a CLI deletes its own session files
 - **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent in one place
 - **TUI Dashboard** — 5 tabs (Overview, Stats, Models, Projects, Audit) with daily/weekly/monthly views
-- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one — currently Claude Code, Codex, and PI Agent. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
+- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one — currently Claude Code, Codex, OpenCode, and PI Agent. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
 - **CLI Commands** — `daily`, `weekly`, `monthly`, `stats` with JSON output support
 - **Usage Reports** — Shareable text & SVG receipts via `toktrack report`
 - **Fast on huge histories** — simd-json + rayon parallel parsing (~3 GiB/s); cached runs in ~0.04s

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Track usage across **all your AI coding CLIs** — Claude Code, Codex CLI, Gemin
 - **Data Preservation** — Persistent cache keeps your cost history even after a CLI deletes its own session files
 - **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent in one place
 - **TUI Dashboard** — 5 tabs (Overview, Stats, Models, Projects, Audit) with daily/weekly/monthly views
-- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one — currently Claude Code and PI Agent. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
+- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one — currently Claude Code, Codex, and PI Agent. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
 - **CLI Commands** — `daily`, `weekly`, `monthly`, `stats` with JSON output support
 - **Usage Reports** — Shareable text & SVG receipts via `toktrack report`
 - **Fast on huge histories** — simd-json + rayon parallel parsing (~3 GiB/s); cached runs in ~0.04s

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Track usage across **all your AI coding CLIs** — Claude Code, Codex CLI, Gemin
 - **Data Preservation** — Persistent cache keeps your cost history even after a CLI deletes its own session files
 - **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent in one place
 - **TUI Dashboard** — 5 tabs (Overview, Stats, Models, Projects, Audit) with daily/weekly/monthly views
-- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the Claude Code working directory); drill into any project for its day-by-day, per-model breakdown. Project details are cached, so they survive past the CLI's 30-day deletion
+- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one — currently Claude Code and PI Agent. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
 - **CLI Commands** — `daily`, `weekly`, `monthly`, `stats` with JSON output support
 - **Usage Reports** — Shareable text & SVG receipts via `toktrack report`
 - **Fast on huge histories** — simd-json + rayon parallel parsing (~3 GiB/s); cached runs in ~0.04s

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Track usage across **all your AI coding CLIs** — Claude Code, Codex CLI, Gemin
 - **Data Preservation** — Persistent cache keeps your cost history even after a CLI deletes its own session files
 - **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent in one place
 - **TUI Dashboard** — 5 tabs (Overview, Stats, Models, Projects, Audit) with daily/weekly/monthly views
-- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one — currently Claude Code, Codex, OpenCode, and PI Agent. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
+- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one — currently Claude Code, Codex, OpenCode, PI Agent, and Gemini CLI. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
 - **CLI Commands** — `daily`, `weekly`, `monthly`, `stats` with JSON output support
 - **Usage Reports** — Shareable text & SVG receipts via `toktrack report`
 - **Fast on huge histories** — simd-json + rayon parallel parsing (~3 GiB/s); cached runs in ~0.04s

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Track usage across **all your AI coding CLIs** — Claude Code, Codex CLI, Gemin
 
 - **Data Preservation** — Persistent cache keeps your cost history even after a CLI deletes its own session files
 - **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent in one place
-- **TUI Dashboard** — 3 tabs (Overview, Stats, Models) with daily/weekly/monthly views
+- **TUI Dashboard** — 5 tabs (Overview, Stats, Models, Projects, Audit) with daily/weekly/monthly views
+- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the Claude Code working directory); drill into any project for its day-by-day, per-model breakdown. Project details are cached, so they survive past the CLI's 30-day deletion
 - **CLI Commands** — `daily`, `weekly`, `monthly`, `stats` with JSON output support
 - **Usage Reports** — Shareable text & SVG receipts via `toktrack report`
 - **Fast on huge histories** — simd-json + rayon parallel parsing (~3 GiB/s); cached runs in ~0.04s

--- a/npm/README.md
+++ b/npm/README.md
@@ -38,8 +38,9 @@ brew install toktrack
 ## Features
 
 - **Ultra-Fast Parsing** — simd-json + rayon parallel processing (~3 GiB/s throughput)
-- **TUI Dashboard** — 3 tabs (Overview, Stats, Models) with daily/weekly/monthly views
-- **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, OpenCode, PI Agent
+- **TUI Dashboard** — 5 tabs (Overview, Stats, Models, Projects, Audit) with daily/weekly/monthly views
+- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one — currently Claude Code, Codex, OpenCode, PI Agent, and Gemini CLI. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
+- **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent
 - **CLI Commands** — `daily`, `weekly`, `monthly`, `stats` with JSON output
 - **Data Preservation** — Cached daily summaries survive CLI data deletion
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -376,10 +376,24 @@ fn run_audit(json: bool, remote_options: &RemoteOptions) -> Result<()> {
     Ok(())
 }
 
+/// Remove the per-project breakdown before emitting `--json`.
+///
+/// `DailySummary.projects` is keyed by raw working-directory paths, which often
+/// include the OS username — exposing them in the shareable/pipeable JSON output
+/// would be a privacy surprise and an output-schema change. The breakdown stays
+/// in the (local, private) cache and the TUI; it is intentionally kept out of
+/// the public `--json` surface, consistent with the `report` receipt.
+fn redact_project_paths(summaries: &mut [DailySummary]) {
+    for summary in summaries {
+        summary.projects.clear();
+    }
+}
+
 /// Output daily summaries as JSON
 fn run_daily_json(remote_options: &RemoteOptions) -> Result<()> {
     let mut summaries = load_data(remote_options)?;
     summaries.sort_by_key(|b| std::cmp::Reverse(b.date));
+    redact_project_paths(&mut summaries);
     println!(
         "{}",
         serde_json::to_string_pretty(&summaries)
@@ -393,6 +407,7 @@ fn run_weekly_json(remote_options: &RemoteOptions) -> Result<()> {
     let summaries = load_data(remote_options)?;
     let mut weekly = Aggregator::weekly(&summaries);
     weekly.sort_by_key(|b| std::cmp::Reverse(b.date));
+    redact_project_paths(&mut weekly);
     println!(
         "{}",
         serde_json::to_string_pretty(&weekly).map_err(|e| ToktrackError::Parse(e.to_string()))?
@@ -405,6 +420,7 @@ fn run_monthly_json(remote_options: &RemoteOptions) -> Result<()> {
     let summaries = load_data(remote_options)?;
     let mut monthly = Aggregator::monthly(&summaries);
     monthly.sort_by_key(|b| std::cmp::Reverse(b.date));
+    redact_project_paths(&mut monthly);
     println!(
         "{}",
         serde_json::to_string_pretty(&monthly).map_err(|e| ToktrackError::Parse(e.to_string()))?
@@ -426,6 +442,44 @@ fn run_stats_json(remote_options: &RemoteOptions) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_redact_project_paths_removes_paths_from_json() {
+        use crate::types::ProjectUsage;
+        use std::collections::HashMap;
+
+        let mut projects = HashMap::new();
+        projects.insert(
+            "/work/secret-dir".to_string(),
+            ProjectUsage {
+                input_tokens: 100,
+                ..Default::default()
+            },
+        );
+        let mut summaries = vec![DailySummary {
+            date: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            total_input_tokens: 100,
+            total_output_tokens: 50,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_reasoning_tokens: 0,
+            total_cache_creation_5m_tokens: 0,
+            total_cache_creation_1h_tokens: 0,
+            total_web_search_requests: 0,
+            total_cost_usd: 1.0,
+            models: HashMap::new(),
+            projects,
+        }];
+
+        redact_project_paths(&mut summaries);
+        assert!(summaries[0].projects.is_empty());
+
+        // With projects cleared + skip_serializing_if, the JSON must not contain
+        // the `projects` key nor any raw path.
+        let json = serde_json::to_string(&summaries).unwrap();
+        assert!(!json.contains("projects"), "projects key leaked: {json}");
+        assert!(!json.contains("secret-dir"), "raw path leaked: {json}");
+    }
 
     #[test]
     fn test_cli_parse_no_args() {

--- a/src/parsers/claude.rs
+++ b/src/parsers/claude.rs
@@ -416,10 +416,10 @@ mod tests {
     #[test]
     fn test_parse_line_extracts_cwd_as_project() {
         let parser = ClaudeCodeParser::with_data_dir(PathBuf::from("tests/fixtures"));
-        let line = r#"{"type":"assistant","timestamp":"2026-01-15T10:00:01.500Z","cwd":"/home/me/Scripts/toktrack","message":{"model":"claude-sonnet-4","id":"msg-x","usage":{"input_tokens":100,"output_tokens":50}}}"#;
+        let line = r#"{"type":"assistant","timestamp":"2026-01-15T10:00:01.500Z","cwd":"/work/demo","message":{"model":"claude-sonnet-4","id":"msg-x","usage":{"input_tokens":100,"output_tokens":50}}}"#;
         let mut bytes = line.as_bytes().to_vec();
         let entry = parser.parse_line(&mut bytes).expect("entry parsed");
-        assert_eq!(entry.project.as_deref(), Some("/home/me/Scripts/toktrack"));
+        assert_eq!(entry.project.as_deref(), Some("/work/demo"));
     }
 
     #[test]

--- a/src/parsers/claude.rs
+++ b/src/parsers/claude.rs
@@ -18,6 +18,8 @@ struct ClaudeJsonLine<'a> {
     message: Option<ClaudeMessage<'a>>,
     #[serde(rename = "costUSD")]
     cost_usd: Option<f64>,
+    /// Working directory of the session — used as the project identifier.
+    cwd: Option<&'a str>,
 }
 
 #[derive(Deserialize)]
@@ -132,6 +134,7 @@ impl ClaudeCodeParser {
             request_id: data.request_id.map(String::from),
             source: Some("claude".into()),
             provider: None,
+            project: data.cwd.map(String::from),
         })
     }
 }
@@ -408,5 +411,23 @@ mod tests {
         assert_eq!(first.cache_creation_5m_tokens, 0);
         assert_eq!(first.cache_creation_1h_tokens, 0);
         assert_eq!(first.web_search_requests, 0);
+    }
+
+    #[test]
+    fn test_parse_line_extracts_cwd_as_project() {
+        let parser = ClaudeCodeParser::with_data_dir(PathBuf::from("tests/fixtures"));
+        let line = r#"{"type":"assistant","timestamp":"2026-01-15T10:00:01.500Z","cwd":"/home/me/Scripts/toktrack","message":{"model":"claude-sonnet-4","id":"msg-x","usage":{"input_tokens":100,"output_tokens":50}}}"#;
+        let mut bytes = line.as_bytes().to_vec();
+        let entry = parser.parse_line(&mut bytes).expect("entry parsed");
+        assert_eq!(entry.project.as_deref(), Some("/home/me/Scripts/toktrack"));
+    }
+
+    #[test]
+    fn test_parse_line_without_cwd_has_no_project() {
+        let parser = ClaudeCodeParser::with_data_dir(PathBuf::from("tests/fixtures"));
+        let line = r#"{"type":"assistant","timestamp":"2026-01-15T10:00:01.500Z","message":{"model":"claude-sonnet-4","id":"msg-y","usage":{"input_tokens":100,"output_tokens":50}}}"#;
+        let mut bytes = line.as_bytes().to_vec();
+        let entry = parser.parse_line(&mut bytes).expect("entry parsed");
+        assert_eq!(entry.project, None);
     }
 }

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -430,10 +430,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(entries.len(), 1);
-        assert_eq!(
-            entries[0].project.as_deref(),
-            Some("/home/user/code/myrepo")
-        );
+        assert_eq!(entries[0].project.as_deref(), Some("/work/myrepo"));
         assert_eq!(entries[0].model, Some("gpt-5.5".to_string()));
     }
 

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -277,6 +277,7 @@ impl CLIParser for CodexParser {
                         request_id: None,
                         source: Some("codex".into()),
                         provider: current_provider.clone(),
+                        project: None,
                     });
                 }
             }

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -31,6 +31,10 @@ struct CodexPayload {
     id: Option<String>,
     #[serde(default)]
     model_provider: Option<String>,
+    /// Working directory — present on `turn_context` (and sometimes
+    /// `session_meta`) payloads; used as the project identifier.
+    #[serde(default)]
+    cwd: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -102,19 +106,23 @@ impl CodexParser {
         };
 
         if data.line_type == "turn_context" {
-            if let Some(ref model) = payload.model {
-                return ParseResult::Model(model.clone());
+            if payload.model.is_none() && payload.cwd.is_none() {
+                return ParseResult::Skip;
             }
-            return ParseResult::Skip;
+            return ParseResult::TurnContext {
+                model: payload.model.clone(),
+                cwd: payload.cwd.clone(),
+            };
         }
 
         if data.line_type == "session_meta" {
-            if payload.id.is_none() && payload.model_provider.is_none() {
+            if payload.id.is_none() && payload.model_provider.is_none() && payload.cwd.is_none() {
                 return ParseResult::Skip;
             }
             return ParseResult::SessionMeta {
                 id: payload.id.clone(),
                 provider: payload.model_provider.clone(),
+                cwd: payload.cwd.clone(),
             };
         }
 
@@ -163,10 +171,14 @@ impl CodexParser {
 /// Result of parsing a single line
 enum ParseResult {
     Skip,
-    Model(String),
+    TurnContext {
+        model: Option<String>,
+        cwd: Option<String>,
+    },
     SessionMeta {
         id: Option<String>,
         provider: Option<String>,
+        cwd: Option<String>,
     },
     TokenCount(TokenCountData),
 }
@@ -197,6 +209,7 @@ impl CLIParser for CodexParser {
         let mut current_model: Option<String> = None;
         let mut session_id: Option<String> = None;
         let mut current_provider: Option<String> = None;
+        let mut current_project: Option<String> = None;
         let mut prev_totals = CodexTokenUsage {
             input_tokens: 0,
             output_tokens: 0,
@@ -216,8 +229,15 @@ impl CLIParser for CodexParser {
             let mut line_bytes = line.into_bytes();
             match self.parse_line(&mut line_bytes) {
                 ParseResult::Skip => {}
-                ParseResult::Model(m) => current_model = Some(m),
-                ParseResult::SessionMeta { id, provider } => {
+                ParseResult::TurnContext { model, cwd } => {
+                    if model.is_some() {
+                        current_model = model;
+                    }
+                    if cwd.is_some() {
+                        current_project = cwd;
+                    }
+                }
+                ParseResult::SessionMeta { id, provider, cwd } => {
                     if let Some(id) = id {
                         session_id = Some(id);
                     }
@@ -225,6 +245,9 @@ impl CLIParser for CodexParser {
                     // model_provider_id, the previous provider must NOT stick —
                     // sticking would silently misattribute billing.
                     current_provider = provider;
+                    if cwd.is_some() {
+                        current_project = cwd;
+                    }
                 }
                 ParseResult::TokenCount(data) => {
                     // Compute delta: prefer last_token_usage, fallback to diff
@@ -277,7 +300,7 @@ impl CLIParser for CodexParser {
                         request_id: None,
                         source: Some("codex".into()),
                         provider: current_provider.clone(),
-                        project: None,
+                        project: current_project.clone(),
                     });
                 }
             }
@@ -394,6 +417,36 @@ mod tests {
         for entry in &entries {
             assert_eq!(entry.source, Some("codex".into()));
             assert_eq!(entry.message_id, Some("session-001".to_string()));
+        }
+    }
+
+    #[test]
+    fn test_project_extracted_from_turn_context_cwd() {
+        // Real Codex `turn_context.payload` carries `cwd` (and workspace_roots);
+        // it must be attached to that session's usage as the project.
+        let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
+        let entries = parser
+            .parse_file(&fixture_path("cwd-session.jsonl"))
+            .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].project.as_deref(),
+            Some("/home/user/code/myrepo")
+        );
+        assert_eq!(entries[0].model, Some("gpt-5.5".to_string()));
+    }
+
+    #[test]
+    fn test_project_none_when_no_cwd() {
+        // Legacy fixtures without cwd must keep project=None.
+        let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
+        let entries = parser
+            .parse_file(&fixture_path("sample-session.jsonl"))
+            .unwrap();
+        assert!(!entries.is_empty());
+        for entry in &entries {
+            assert_eq!(entry.project, None);
         }
     }
 

--- a/src/parsers/gemini.rs
+++ b/src/parsers/gemini.rs
@@ -152,6 +152,7 @@ impl GeminiParser {
             simd_json::from_str(&mut content).map_err(|e| ToktrackError::Parse(e.to_string()))?
         };
 
+        let project = project_root_for(path);
         let mut entries = Vec::new();
 
         for msg in session.messages {
@@ -196,7 +197,7 @@ impl GeminiParser {
                 request_id: Some(session.session_id.clone()),
                 source: Some(self.source.into()),
                 provider: None,
-                project: None,
+                project: project.clone(),
             });
         }
 
@@ -214,6 +215,7 @@ impl GeminiParser {
             .unwrap_or("")
             .to_string();
         let mut session_id: Option<String> = None;
+        let project = project_root_for(path);
         let mut entries = Vec::new();
 
         for line_result in reader.lines() {
@@ -293,12 +295,32 @@ impl GeminiParser {
                 request_id: Some(request_id),
                 source: Some(self.source.into()),
                 provider: None,
-                project: None,
+                project: project.clone(),
             });
         }
 
         Ok(entries)
     }
+}
+
+/// Resolve a session's working directory from the `.project_root` sidecar that
+/// gemini-cli / qwen-code write in each tmp project dir
+/// (`<root>/tmp/<dir>/.project_root`). The chat file may sit one level (main
+/// session) or two (subagent) below that dir, so walk up a few parents. Returns
+/// the raw path string, used as the project identifier.
+fn project_root_for(path: &Path) -> Option<String> {
+    let mut dir = path.parent();
+    for _ in 0..4 {
+        let d = dir?;
+        if let Ok(contents) = fs::read_to_string(d.join(".project_root")) {
+            let trimmed = contents.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+        dir = d.parent();
+    }
+    None
 }
 
 impl Default for GeminiParser {
@@ -512,6 +534,48 @@ mod tests {
         // e0: 80 + 50 + 20 + 30 = 180 ; e1: 200 + 150 + 50 + 100 = 500
         assert_eq!(entries[0].total_tokens(), 180);
         assert_eq!(entries[1].total_tokens(), 500);
+    }
+
+    #[test]
+    fn test_project_extracted_from_project_root_sidecar() {
+        // gemini-cli / qwen-code store the cwd in a `.project_root` file next to
+        // the session's `chats/` dir; it must be attached to that file's entries.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let proj = tmp.path().join("tmp").join("myproj");
+        let chats = proj.join("chats");
+        std::fs::create_dir_all(&chats).unwrap();
+        std::fs::write(proj.join(".project_root"), "/work/demo\n").unwrap();
+        let session = chats.join("session-2026-06-19T10-00-00-abcd1234.jsonl");
+        std::fs::write(
+            &session,
+            "{\"sessionId\":\"s1\",\"projectHash\":\"h\",\"kind\":\"main\"}\n\
+             {\"type\":\"gemini\",\"timestamp\":\"2026-06-19T10:00:01Z\",\"model\":\"gemini-3\",\"tokens\":{\"input\":100,\"output\":50}}\n",
+        )
+        .unwrap();
+
+        let parser = GeminiParser::with_data_dir(tmp.path().join("tmp"));
+        let entries = parser.parse_file(&session).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].project.as_deref(), Some("/work/demo"));
+    }
+
+    #[test]
+    fn test_project_none_when_no_project_root() {
+        // Without a `.project_root` sidecar, project stays None (→ no-project bucket).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let chats = tmp.path().join("tmp").join("p").join("chats");
+        std::fs::create_dir_all(&chats).unwrap();
+        let session = chats.join("session-2026-06-19T10-00-00-abcd1234.jsonl");
+        std::fs::write(
+            &session,
+            "{\"type\":\"gemini\",\"timestamp\":\"2026-06-19T10:00:01Z\",\"model\":\"gemini-3\",\"tokens\":{\"input\":100,\"output\":50}}\n",
+        )
+        .unwrap();
+
+        let parser = GeminiParser::with_data_dir(tmp.path().join("tmp"));
+        let entries = parser.parse_file(&session).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].project, None);
     }
 
     fn fixture_no_session_model_path() -> PathBuf {

--- a/src/parsers/gemini.rs
+++ b/src/parsers/gemini.rs
@@ -196,6 +196,7 @@ impl GeminiParser {
                 request_id: Some(session.session_id.clone()),
                 source: Some(self.source.into()),
                 provider: None,
+                project: None,
             });
         }
 
@@ -292,6 +293,7 @@ impl GeminiParser {
                 request_id: Some(request_id),
                 source: Some(self.source.into()),
                 provider: None,
+                project: None,
             });
         }
 

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -343,6 +343,7 @@ mod tests {
         // claude-sample.jsonl, empty.jsonl, multi/file1.jsonl, multi/file2.jsonl,
         // codex/sample-session.jsonl, codex/multi-turn-session.jsonl,
         // codex/openai-session.jsonl, codex/multi-session-meta.jsonl,
+        // codex/cwd-session.jsonl,
         // pi_agent/sample-session.jsonl,
         // gemini/tmp_jsonl/chats/session-*.jsonl,
         // gemini/tmp_jsonl/chats/parent-session-xyz/sub-abc.jsonl,
@@ -351,6 +352,6 @@ mod tests {
         // claude/real-shape-session.jsonl
         // qwen/proj/chats/session-*.jsonl
         // (claude parser uses `**/*.jsonl`; gemini/qwen-format files parse to 0 entries.)
-        assert_eq!(files.len(), 15);
+        assert_eq!(files.len(), 16);
     }
 }

--- a/src/parsers/opencode.rs
+++ b/src/parsers/opencode.rs
@@ -202,6 +202,7 @@ fn to_usage_entry(id: String, session_id: String, msg: OpenCodeMessageData) -> O
         request_id: Some(session_id),
         source: Some("opencode".into()),
         provider: msg.provider_id,
+        project: None,
     })
 }
 

--- a/src/parsers/opencode.rs
+++ b/src/parsers/opencode.rs
@@ -675,7 +675,7 @@ mod tests {
         let conn = Connection::open(&db).unwrap();
         conn.execute_batch(
             "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL);\n\
-             INSERT INTO session (id, directory) VALUES ('ses_x', '/home/me/proj');",
+             INSERT INTO session (id, directory) VALUES ('ses_x', '/work/proj');",
         )
         .unwrap();
         drop(conn);
@@ -684,7 +684,7 @@ mod tests {
         let entries = parser.parse_all().unwrap();
 
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].project.as_deref(), Some("/home/me/proj"));
+        assert_eq!(entries[0].project.as_deref(), Some("/work/proj"));
     }
 
     #[test]

--- a/src/parsers/opencode.rs
+++ b/src/parsers/opencode.rs
@@ -113,6 +113,7 @@ impl OpenCodeParser {
             id,
             session_id,
             mut data_json,
+            directory,
         } in rows
         {
             // SAFETY: `data_json` is exclusively owned and not aliased; safe for simd_json in-place mutation.
@@ -126,7 +127,9 @@ impl OpenCodeParser {
                     continue;
                 }
             };
-            if let Some(entry) = to_usage_entry(id, session_id, data) {
+            if let Some(mut entry) = to_usage_entry(id, session_id, data) {
+                // Attribute to the session's working directory (empty → no project).
+                entry.project = directory.filter(|d| !d.is_empty());
                 entries.push(entry);
             }
         }
@@ -138,23 +141,52 @@ impl OpenCodeParser {
         // need URI percent-encoding. SQLITE_OPEN_READ_ONLY alone gives read-only access.
         let conn = Connection::open_with_flags(&self.db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
 
-        let base_sql = "SELECT id, session_id, data \
-             FROM message \
-             WHERE json_extract(data, '$.role') = 'assistant' \
-               AND COALESCE(json_extract(data, '$.tokens.input'), 0) \
-                 + COALESCE(json_extract(data, '$.tokens.output'), 0) > 0";
+        // Prefer the directory-aware query (joins `session.directory` so each
+        // message can be attributed to a project). Older OpenCode schemas may
+        // lack the `session` table/column, so fall back to a directory-less
+        // query that yields `project = None`.
+        Self::run_message_query(&conn, since_ms, true)
+            .or_else(|_| Self::run_message_query(&conn, since_ms, false))
+    }
 
-        let map_row = |r: &rusqlite::Row<'_>| -> rusqlite::Result<SqliteMessageRow> {
+    fn run_message_query(
+        conn: &Connection,
+        since_ms: Option<i64>,
+        with_directory: bool,
+    ) -> rusqlite::Result<Vec<SqliteMessageRow>> {
+        let (base_sql, time_col) = if with_directory {
+            (
+                "SELECT m.id, m.session_id, m.data, s.directory \
+                 FROM message m \
+                 LEFT JOIN session s ON s.id = m.session_id \
+                 WHERE json_extract(m.data, '$.role') = 'assistant' \
+                   AND COALESCE(json_extract(m.data, '$.tokens.input'), 0) \
+                     + COALESCE(json_extract(m.data, '$.tokens.output'), 0) > 0",
+                "m.time_created",
+            )
+        } else {
+            (
+                "SELECT id, session_id, data, NULL \
+                 FROM message \
+                 WHERE json_extract(data, '$.role') = 'assistant' \
+                   AND COALESCE(json_extract(data, '$.tokens.input'), 0) \
+                     + COALESCE(json_extract(data, '$.tokens.output'), 0) > 0",
+                "time_created",
+            )
+        };
+
+        fn map_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<SqliteMessageRow> {
             Ok(SqliteMessageRow {
                 id: r.get(0)?,
                 session_id: r.get(1)?,
                 data_json: r.get(2)?,
+                directory: r.get(3)?,
             })
-        };
+        }
 
         match since_ms {
             Some(ms) => {
-                let sql = format!("{} AND time_created >= ?", base_sql);
+                let sql = format!("{} AND {} >= ?", base_sql, time_col);
                 let mut stmt = conn.prepare(&sql)?;
                 stmt.query_map([ms], map_row).and_then(Iterator::collect)
             }
@@ -170,6 +202,9 @@ struct SqliteMessageRow {
     id: String,
     session_id: String,
     data_json: String,
+    /// `session.directory` (the session's working directory) when available —
+    /// used as the project identifier.
+    directory: Option<String>,
 }
 
 fn to_usage_entry(id: String, session_id: String, msg: OpenCodeMessageData) -> Option<UsageEntry> {
@@ -620,6 +655,59 @@ mod tests {
         let parser = OpenCodeParser::with_base_dir(base);
         let entries = parser.parse_all().unwrap();
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn sqlite_attributes_project_from_session_directory() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path().to_path_buf();
+        let db = base.join("opencode.db");
+        create_test_db(
+            &db,
+            &[(
+                "m1",
+                "ses_x",
+                1_700_000_000_000,
+                &assistant_data("opus-4", 1_700_000_000_000, 100, 50),
+            )],
+        );
+        // Add the `session` table (new OpenCode schema) with a directory.
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL);\n\
+             INSERT INTO session (id, directory) VALUES ('ses_x', '/home/me/proj');",
+        )
+        .unwrap();
+        drop(conn);
+
+        let parser = OpenCodeParser::with_base_dir(base);
+        let entries = parser.parse_all().unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].project.as_deref(), Some("/home/me/proj"));
+    }
+
+    #[test]
+    fn sqlite_project_none_when_no_session_table() {
+        // Older schema without a `session` table must fall back gracefully and
+        // leave project = None (no error).
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path().to_path_buf();
+        create_test_db(
+            &base.join("opencode.db"),
+            &[(
+                "m1",
+                "ses_x",
+                1_700_000_000_000,
+                &assistant_data("opus-4", 1_700_000_000_000, 100, 50),
+            )],
+        );
+
+        let parser = OpenCodeParser::with_base_dir(base);
+        let entries = parser.parse_all().unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].project, None);
     }
 
     #[test]

--- a/src/parsers/pi_agent.rs
+++ b/src/parsers/pi_agent.rs
@@ -221,6 +221,7 @@ impl CLIParser for PiAgentParser {
                         request_id: current_session.clone(),
                         source: Some("pi-agent".into()),
                         provider: event.provider,
+                        project: None,
                     });
                 }
             }

--- a/src/parsers/pi_agent.rs
+++ b/src/parsers/pi_agent.rs
@@ -29,6 +29,14 @@ struct PiAgentLine<'a> {
     id: Option<&'a str>,
     timestamp: Option<&'a str>,
     message: Option<PiAgentMessage<'a>>,
+    /// Working directory of the session (present on the `session` line) — used
+    /// as the project identifier.
+    ///
+    /// NOTE: this was implemented against the `pi_agent` test fixture, which has
+    /// `cwd` on the leading `session` line. It has NOT yet been verified against
+    /// a live PI Agent session directory, so the real-world field name/placement
+    /// may differ.
+    cwd: Option<&'a str>,
 }
 
 #[derive(Deserialize)]
@@ -68,7 +76,10 @@ struct PiAgentEvent {
 
 enum ParseResult {
     Skip,
-    Session(String),
+    Session {
+        id: Option<String>,
+        cwd: Option<String>,
+    },
     Usage(PiAgentEvent),
 }
 
@@ -116,10 +127,16 @@ impl PiAgentParser {
 
         match line_data.line_type {
             "session" => {
-                if let Some(id) = line_data.id {
-                    return ParseResult::Session(id.to_string());
+                // Capture the session id (used as request_id) and the cwd (used
+                // as the project). Emit even if id is absent so the project still
+                // gets recorded for this file's entries.
+                if line_data.id.is_none() && line_data.cwd.is_none() {
+                    return ParseResult::Skip;
                 }
-                ParseResult::Skip
+                ParseResult::Session {
+                    id: line_data.id.map(String::from),
+                    cwd: line_data.cwd.map(String::from),
+                }
             }
             "message" => {
                 let message = match line_data.message {
@@ -189,6 +206,7 @@ impl CLIParser for PiAgentParser {
         let reader = BufReader::new(file);
         let mut entries = Vec::new();
         let mut current_session: Option<String> = None;
+        let mut current_project: Option<String> = None;
 
         for line_result in reader.lines() {
             let line = match line_result {
@@ -199,8 +217,13 @@ impl CLIParser for PiAgentParser {
             let mut line_bytes = line.into_bytes();
             match self.parse_line(&mut line_bytes) {
                 ParseResult::Skip => {}
-                ParseResult::Session(session_id) => {
-                    current_session = Some(session_id);
+                ParseResult::Session { id, cwd } => {
+                    if id.is_some() {
+                        current_session = id;
+                    }
+                    if cwd.is_some() {
+                        current_project = cwd;
+                    }
                 }
                 ParseResult::Usage(event) => {
                     entries.push(UsageEntry {
@@ -221,7 +244,7 @@ impl CLIParser for PiAgentParser {
                         request_id: current_session.clone(),
                         source: Some("pi-agent".into()),
                         provider: event.provider,
-                        project: None,
+                        project: current_project.clone(),
                     });
                 }
             }
@@ -273,6 +296,18 @@ mod tests {
             Some("00000000-0000-0000-0000-000000000001".to_string())
         );
         assert_eq!(entry.cost_usd, Some(0.004788));
+    }
+
+    #[test]
+    fn test_parse_pi_agent_extracts_project_from_session_cwd() {
+        let parser = PiAgentParser::with_data_dir(PathBuf::from("tests/fixtures"));
+        let entries = parser
+            .parse_file(&fixture_path("sample-session.jsonl"))
+            .unwrap();
+
+        // The leading `session` line carries cwd="/tmp/example-project"; it must
+        // be attached to the file's usage entries as the project.
+        assert_eq!(entries[0].project.as_deref(), Some("/tmp/example-project"));
     }
 
     #[test]

--- a/src/parsers/pi_agent.rs
+++ b/src/parsers/pi_agent.rs
@@ -29,13 +29,9 @@ struct PiAgentLine<'a> {
     id: Option<&'a str>,
     timestamp: Option<&'a str>,
     message: Option<PiAgentMessage<'a>>,
-    /// Working directory of the session (present on the `session` line) — used
-    /// as the project identifier.
-    ///
-    /// NOTE: this was implemented against the `pi_agent` test fixture, which has
-    /// `cwd` on the leading `session` line. It has NOT yet been verified against
-    /// a live PI Agent session directory, so the real-world field name/placement
-    /// may differ.
+    /// Working directory of the session (present on the leading `session` line)
+    /// — used as the project identifier. Verified against live PI Agent v3
+    /// session files (top-level `"cwd"` on the `session` line).
     cwd: Option<&'a str>,
 }
 

--- a/src/report/data.rs
+++ b/src/report/data.rs
@@ -205,6 +205,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: cost,
             models,
+            projects: HashMap::new(),
         }
     }
 
@@ -319,6 +320,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 2.50,
             models,
+            projects: HashMap::new(),
         }];
         let data = ReportData::from_summaries(
             &summaries,

--- a/src/services/aggregator.rs
+++ b/src/services/aggregator.rs
@@ -1,7 +1,9 @@
 //! Aggregator service for computing usage statistics
 
 use super::normalize_model_name;
-use crate::types::{DailySummary, ModelUsage, SourceUsage, TotalSummary, UsageEntry};
+use crate::types::{
+    DailySummary, ModelUsage, ProjectUsage, SourceUsage, TotalSummary, UsageEntry, NO_PROJECT,
+};
 use chrono::Datelike;
 use std::collections::{HashMap, HashSet};
 
@@ -52,6 +54,14 @@ fn accumulate_summary(target: &mut DailySummary, source: &DailySummary) {
     for (model_name, model_usage) in &source.models {
         let t = target.models.entry(model_name.clone()).or_default();
         merge_model_usage(t, model_usage);
+    }
+
+    for (project_name, project_usage) in &source.projects {
+        target
+            .projects
+            .entry(project_name.clone())
+            .or_default()
+            .merge(project_usage);
     }
 }
 
@@ -110,6 +120,7 @@ impl Aggregator {
                 total_web_search_requests: 0,
                 total_cost_usd: 0.0,
                 models: HashMap::new(),
+                projects: HashMap::new(),
             });
 
             summary.total_input_tokens = summary
@@ -139,8 +150,17 @@ impl Aggregator {
             summary.total_cost_usd += cost;
 
             // Update model breakdown
-            let model_usage = summary.models.entry(model_name).or_default();
+            let model_usage = summary.models.entry(model_name.clone()).or_default();
             model_usage.add(entry, cost);
+
+            // Update per-project breakdown (nested per-model). Entries without a
+            // recorded project (Codex, Gemini, etc.) fall into the NO_PROJECT bucket.
+            let project_key = entry.project.as_deref().unwrap_or(NO_PROJECT);
+            summary
+                .projects
+                .entry(project_key.to_string())
+                .or_default()
+                .add(entry, cost, &model_name);
         }
 
         // Sort by date ascending
@@ -177,6 +197,7 @@ impl Aggregator {
                 total_web_search_requests: 0,
                 total_cost_usd: 0.0,
                 models: HashMap::new(),
+                projects: HashMap::new(),
             });
 
             accumulate_summary(week_summary, summary);
@@ -212,6 +233,7 @@ impl Aggregator {
                 total_web_search_requests: 0,
                 total_cost_usd: 0.0,
                 models: HashMap::new(),
+                projects: HashMap::new(),
             });
 
             accumulate_summary(month_summary, summary);
@@ -296,6 +318,64 @@ impl Aggregator {
         }
 
         model_map
+    }
+
+    /// Compute per-project breakdown (rolled up across all days) from a
+    /// DailySummary slice. Used to build the Projects tab's high-level list.
+    pub fn by_project_from_daily(summaries: &[DailySummary]) -> HashMap<String, ProjectUsage> {
+        let mut project_map: HashMap<String, ProjectUsage> = HashMap::new();
+
+        for s in summaries {
+            for (project_name, usage) in &s.projects {
+                project_map
+                    .entry(project_name.clone())
+                    .or_default()
+                    .merge(usage);
+            }
+        }
+
+        project_map
+    }
+
+    /// Explode a DailySummary slice into per-project daily summaries.
+    ///
+    /// Returns a map from project identifier to that project's own daily
+    /// summaries (each carrying only that project's tokens and per-model
+    /// breakdown). This lets the Projects drill-down reuse the same daily/
+    /// weekly/monthly rendering and model-breakdown popup as the source view.
+    pub fn project_daily_summaries(
+        summaries: &[DailySummary],
+    ) -> HashMap<String, Vec<DailySummary>> {
+        let mut per_project: HashMap<String, Vec<DailySummary>> = HashMap::new();
+
+        for s in summaries {
+            for (project_name, usage) in &s.projects {
+                let day = DailySummary {
+                    date: s.date,
+                    total_input_tokens: usage.input_tokens,
+                    total_output_tokens: usage.output_tokens,
+                    total_cache_read_tokens: usage.cache_read_tokens,
+                    total_cache_creation_tokens: usage.cache_creation_tokens,
+                    total_reasoning_tokens: usage.reasoning_tokens,
+                    total_cache_creation_5m_tokens: usage.cache_creation_5m_tokens,
+                    total_cache_creation_1h_tokens: usage.cache_creation_1h_tokens,
+                    total_web_search_requests: usage.web_search_requests,
+                    total_cost_usd: usage.cost_usd,
+                    models: usage.models.clone(),
+                    projects: HashMap::new(),
+                };
+                per_project
+                    .entry(project_name.clone())
+                    .or_default()
+                    .push(day);
+            }
+        }
+
+        for days in per_project.values_mut() {
+            days.sort_by_key(|s| s.date);
+        }
+
+        per_project
     }
 
     #[allow(dead_code)]
@@ -401,6 +481,7 @@ impl Aggregator {
                     total_web_search_requests: 0,
                     total_cost_usd: 0.0,
                     models: HashMap::new(),
+                    projects: HashMap::new(),
                 });
             accumulate_summary(target, &summary);
         }
@@ -443,7 +524,198 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         }
+    }
+
+    fn make_entry_with_project(
+        year: i32,
+        month: u32,
+        day: u32,
+        model: Option<&str>,
+        input: u64,
+        cost: Option<f64>,
+        project: Option<&str>,
+    ) -> UsageEntry {
+        let mut e = make_entry(year, month, day, model, input, 0, cost);
+        e.project = project.map(String::from);
+        e
+    }
+
+    #[test]
+    fn test_daily_populates_project_breakdown() {
+        let entries = vec![
+            make_entry_with_project(
+                2026,
+                1,
+                1,
+                Some("claude-opus"),
+                100,
+                Some(1.0),
+                Some("/proj/a"),
+            ),
+            make_entry_with_project(
+                2026,
+                1,
+                1,
+                Some("claude-haiku"),
+                50,
+                Some(0.5),
+                Some("/proj/a"),
+            ),
+            make_entry_with_project(
+                2026,
+                1,
+                1,
+                Some("claude-opus"),
+                30,
+                Some(0.3),
+                Some("/proj/b"),
+            ),
+            // No project -> bucketed under NO_PROJECT
+            make_entry_with_project(2026, 1, 1, Some("gpt-4o"), 10, Some(0.1), None),
+        ];
+
+        let daily = Aggregator::daily(&entries);
+        assert_eq!(daily.len(), 1);
+        let day = &daily[0];
+
+        // Three project buckets: /proj/a, /proj/b, NO_PROJECT
+        assert_eq!(day.projects.len(), 3);
+
+        let a = day.projects.get("/proj/a").expect("project a present");
+        assert_eq!(a.input_tokens, 150);
+        assert_eq!(a.count, 2);
+        // Nested per-model breakdown within the project.
+        assert_eq!(a.models.len(), 2);
+
+        let b = day.projects.get("/proj/b").expect("project b present");
+        assert_eq!(b.input_tokens, 30);
+
+        let none = day.projects.get(NO_PROJECT).expect("no-project bucket");
+        assert_eq!(none.input_tokens, 10);
+
+        // Project totals reconcile with the day total.
+        let proj_sum: u64 = day.projects.values().map(|p| p.input_tokens).sum();
+        assert_eq!(proj_sum, day.total_input_tokens);
+    }
+
+    #[test]
+    fn test_by_project_from_daily_rolls_up_across_days() {
+        let entries = vec![
+            make_entry_with_project(
+                2026,
+                1,
+                1,
+                Some("claude-opus"),
+                100,
+                Some(1.0),
+                Some("/proj/a"),
+            ),
+            make_entry_with_project(
+                2026,
+                1,
+                2,
+                Some("claude-opus"),
+                200,
+                Some(2.0),
+                Some("/proj/a"),
+            ),
+            make_entry_with_project(
+                2026,
+                1,
+                2,
+                Some("claude-opus"),
+                40,
+                Some(0.4),
+                Some("/proj/b"),
+            ),
+        ];
+        let daily = Aggregator::daily(&entries);
+        let by_project = Aggregator::by_project_from_daily(&daily);
+
+        assert_eq!(by_project.len(), 2);
+        assert_eq!(by_project.get("/proj/a").unwrap().input_tokens, 300);
+        assert_eq!(by_project.get("/proj/a").unwrap().count, 2);
+        assert_eq!(by_project.get("/proj/b").unwrap().input_tokens, 40);
+    }
+
+    #[test]
+    fn test_project_daily_summaries_explodes_per_project() {
+        let entries = vec![
+            make_entry_with_project(
+                2026,
+                1,
+                1,
+                Some("claude-opus"),
+                100,
+                Some(1.0),
+                Some("/proj/a"),
+            ),
+            make_entry_with_project(
+                2026,
+                1,
+                2,
+                Some("claude-opus"),
+                200,
+                Some(2.0),
+                Some("/proj/a"),
+            ),
+            make_entry_with_project(
+                2026,
+                1,
+                2,
+                Some("claude-opus"),
+                40,
+                Some(0.4),
+                Some("/proj/b"),
+            ),
+        ];
+        let daily = Aggregator::daily(&entries);
+        let per_project = Aggregator::project_daily_summaries(&daily);
+
+        // Project a spans two days; project b only one.
+        let a_days = per_project.get("/proj/a").unwrap();
+        assert_eq!(a_days.len(), 2);
+        assert_eq!(a_days[0].total_input_tokens, 100); // sorted ascending by date
+        assert_eq!(a_days[1].total_input_tokens, 200);
+        // Each exploded day carries the project's per-model breakdown.
+        assert!(!a_days[0].models.is_empty());
+
+        let b_days = per_project.get("/proj/b").unwrap();
+        assert_eq!(b_days.len(), 1);
+        assert_eq!(b_days[0].total_input_tokens, 40);
+    }
+
+    #[test]
+    fn test_weekly_merges_project_breakdown() {
+        let entries = vec![
+            make_entry_with_project(
+                2026,
+                1,
+                5,
+                Some("claude-opus"),
+                100,
+                Some(1.0),
+                Some("/proj/a"),
+            ),
+            make_entry_with_project(
+                2026,
+                1,
+                6,
+                Some("claude-opus"),
+                200,
+                Some(2.0),
+                Some("/proj/a"),
+            ),
+        ];
+        let daily = Aggregator::daily(&entries);
+        let weekly = Aggregator::weekly(&daily);
+
+        // Both days fall in the same week; the project breakdown must be merged.
+        assert_eq!(weekly.len(), 1);
+        let week = &weekly[0];
+        assert_eq!(week.projects.get("/proj/a").unwrap().input_tokens, 300);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -476,6 +748,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         }
     }
 
@@ -749,6 +1022,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: cost,
             models: HashMap::new(),
+            projects: HashMap::new(),
         }
     }
 
@@ -773,6 +1047,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: cost,
             models,
+            projects: HashMap::new(),
         }
     }
 
@@ -1144,6 +1419,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.01,
             models: HashMap::new(),
+            projects: HashMap::new(),
         };
         let source = DailySummary {
             date: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
@@ -1157,6 +1433,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.02,
             models: HashMap::new(),
+            projects: HashMap::new(),
         };
 
         accumulate_summary(&mut target, &source);
@@ -1264,6 +1541,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.01,
             models: models_target,
+            projects: HashMap::new(),
         };
 
         let mut models_source = HashMap::new();
@@ -1299,6 +1577,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.025,
             models: models_source,
+            projects: HashMap::new(),
         };
 
         accumulate_summary(&mut target, &source);
@@ -1344,6 +1623,7 @@ mod tests {
             request_id: None,
             source: source.map(String::from),
             provider: None,
+            project: None,
         }
     }
 
@@ -1375,6 +1655,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         };
         let entry_early = UsageEntry {
             timestamp: early_utc,
@@ -1394,6 +1675,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         };
 
         let result = Aggregator::daily(&[entry_late.clone(), entry_early.clone()]);
@@ -1449,6 +1731,7 @@ mod tests {
                 request_id: None,
                 source: None,
                 provider: None,
+                project: None,
             },
             UsageEntry {
                 timestamp: ts2,
@@ -1468,6 +1751,7 @@ mod tests {
                 request_id: None,
                 source: None,
                 provider: None,
+                project: None,
             },
         ];
 
@@ -1703,6 +1987,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: provider.map(String::from),
+            project: None,
         }
     }
 

--- a/src/services/audit.rs
+++ b/src/services/audit.rs
@@ -287,6 +287,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.0,
             models: HashMap::new(),
+            projects: HashMap::new(),
         };
         let cache_file = DailySummaryCache {
             cli: "auditsrc".to_string(),

--- a/src/services/cache.rs
+++ b/src/services/cache.rs
@@ -62,8 +62,11 @@ fn normalize_model_keys(models: HashMap<String, ModelUsage>) -> HashMap<String, 
 }
 
 /// Bump when aggregation logic changes (e.g., timezone fix).
-/// Mismatched version → full cache invalidation.
-const CACHE_VERSION: u32 = 13;
+/// Mismatched version → past summaries are kept (history is preserved) but a
+/// warning is surfaced, and every date whose raw files still exist is recomputed
+/// so the new shape is populated. v14 added per-project breakdown
+/// (`DailySummary.projects`).
+const CACHE_VERSION: u32 = 14;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DailySummaryCache {
@@ -357,6 +360,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         }
     }
 
@@ -405,6 +409,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 9.99,
             models: HashMap::new(),
+            projects: HashMap::new(),
         };
         let cache = DailySummaryCache {
             cli: "claude-code".to_string(),
@@ -436,6 +441,7 @@ mod tests {
                 request_id: None,
                 source: None,
                 provider: None,
+                project: None,
             },
             UsageEntry {
                 timestamp: today.and_hms_opt(12, 0, 0).unwrap().and_utc(),
@@ -455,6 +461,7 @@ mod tests {
                 request_id: None,
                 source: None,
                 provider: None,
+                project: None,
             },
         ];
 
@@ -521,6 +528,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 9.99,
             models: HashMap::new(),
+            projects: HashMap::new(),
         };
         let cache = DailySummaryCache {
             cli: "claude-code".to_string(),
@@ -551,6 +559,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         }];
 
         let (result, _warning) = service.load_or_compute("claude-code", &entries).unwrap();
@@ -598,6 +607,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.005,
             models: HashMap::new(),
+            projects: HashMap::new(),
         };
         let cache = DailySummaryCache {
             cli: "claude-code".to_string(),
@@ -628,6 +638,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         }];
 
         let (result, _warning) = service.load_or_compute("claude-code", &entries).unwrap();
@@ -748,6 +759,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.30,
             models,
+            projects: HashMap::new(),
         };
         let cache = DailySummaryCache {
             cli: "claude-code".to_string(),
@@ -840,6 +852,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.50,
             models: HashMap::new(),
+            projects: HashMap::new(),
         };
         let cache = DailySummaryCache {
             cli: "claude-code".to_string(),
@@ -957,6 +970,7 @@ mod tests {
                     total_web_search_requests: 0,
                     total_cost_usd: 0.01,
                     models: HashMap::new(),
+                    projects: HashMap::new(),
                 },
                 DailySummary {
                     date: NaiveDate::from_ymd_opt(2026, 2, 27).unwrap(),
@@ -970,6 +984,7 @@ mod tests {
                     total_web_search_requests: 0,
                     total_cost_usd: 0.02,
                     models: HashMap::new(),
+                    projects: HashMap::new(),
                 },
                 DailySummary {
                     date: NaiveDate::from_ymd_opt(2026, 2, 26).unwrap(),
@@ -983,6 +998,7 @@ mod tests {
                     total_web_search_requests: 0,
                     total_cost_usd: 0.015,
                     models: HashMap::new(),
+                    projects: HashMap::new(),
                 },
             ],
         };
@@ -1019,6 +1035,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.0,
             models: HashMap::new(),
+            projects: HashMap::new(),
         };
         let cache = DailySummaryCache {
             cli: "claude-code".to_string(),
@@ -1142,6 +1159,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.05,
             models,
+            projects: HashMap::new(),
         };
         let cache = DailySummaryCache {
             cli: "codex".to_string(),
@@ -1194,6 +1212,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.0,
             models,
+            projects: HashMap::new(),
         };
         // version=0 triggers the mismatch path which runs normalize_model_keys.
         let cache = serde_json::json!({

--- a/src/services/data_loader.rs
+++ b/src/services/data_loader.rs
@@ -538,6 +538,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: provider.map(String::from),
+            project: None,
         };
         // upstream cost present → not estimated
         assert!(!DataLoaderService::batch_estimated(&[mk(Some(0.1), None)]));
@@ -705,6 +706,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: provider.map(|s| s.to_string()),
+            project: None,
         }
     }
 
@@ -772,6 +774,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         };
         let yesterday_entry = UsageEntry {
             timestamp: yesterday.and_hms_opt(12, 0, 0).unwrap().and_utc(),
@@ -791,6 +794,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         };
         let today_entry = UsageEntry {
             timestamp: today.and_hms_opt(10, 0, 0).unwrap().and_utc(),
@@ -810,6 +814,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         };
 
         let all_entries = vec![old_entry, yesterday_entry, today_entry];

--- a/src/services/data_loader.rs
+++ b/src/services/data_loader.rs
@@ -134,7 +134,16 @@ impl DataLoaderService {
         for source in self.registry.sources() {
             let parser = source.parser.as_ref();
             debug_assert_eq!(source.kind, parser.name());
-            let has_source_cache = cache_service.cache_path(&source.id).exists();
+            // A cache is only usable on the warm (recent-only) path when it both
+            // exists AND matches the current CACHE_VERSION. A stale-version cache
+            // must be fully re-parsed so schema changes (e.g. the per-project
+            // breakdown) are backfilled for every date whose raw files still
+            // exist — `load_or_compute` still merges in older cache-only days, so
+            // preserved >30-day history is kept. Without this, a stale source is
+            // never refreshed as long as any *other* source has a current cache
+            // (which keeps the global warm path active).
+            let has_source_cache = cache_service.cache_path(&source.id).exists()
+                && cache_service.is_version_current(&source.id);
 
             let entries = if has_source_cache {
                 let latest = cache_service.latest_cached_date(&source.id);
@@ -683,6 +692,97 @@ mod tests {
             .collect();
         assert!(sources.contains("codex"));
         assert!(sources.contains("codex@testbox"));
+    }
+
+    #[test]
+    fn test_stale_version_source_is_reparsed_and_preserves_history() {
+        // A source whose cache is STALE-versioned must be fully re-parsed (so
+        // schema changes like the per-project breakdown are backfilled), while
+        // older cache-only days are preserved — even when another source keeps
+        // the global warm path active. The stale cache's latest date is recent
+        // (no date gap), so the ONLY thing that can trigger the reparse is the
+        // version check added to the warm path.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cache_dir = temp_dir.path().join("cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let pricing_path = temp_dir.path().join("pricing.json");
+        let fetched_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        std::fs::write(
+            &pricing_path,
+            format!(r#"{{"fetched_at":{},"models":{{}}}}"#, fetched_at),
+        )
+        .unwrap();
+
+        let cache_service = DailySummaryCacheService::with_cache_dir(cache_dir.clone());
+
+        // Seed a CURRENT-version cache for a second source so has_valid_cache()
+        // is true and load() takes the warm path.
+        let today = Local::now().date_naive();
+        let mut keepwarm_entry = make_entry(Some(0.01), Some("openai"));
+        keepwarm_entry.timestamp = today.and_hms_opt(12, 0, 0).unwrap().and_utc();
+        cache_service
+            .load_or_compute("keepwarm", &[keepwarm_entry])
+            .unwrap();
+
+        // Seed a STALE (version 0) codex cache: an ancient cache-only day (no raw
+        // backing → preserved history) + a recent day so latest_cached_date is
+        // recent (no gap).
+        let yesterday = today - chrono::Duration::days(1);
+        let stale = format!(
+            r#"{{"cli":"codex","version":0,"updated_at":0,"summaries":[
+                {{"date":"2020-01-01","total_input_tokens":111,"total_output_tokens":0,
+                  "total_cache_read_tokens":0,"total_cache_creation_tokens":0,
+                  "total_cost_usd":0.0,"models":{{}},"projects":{{}}}},
+                {{"date":"{}","total_input_tokens":5,"total_output_tokens":5,
+                  "total_cache_read_tokens":0,"total_cache_creation_tokens":0,
+                  "total_cost_usd":0.0,"models":{{}},"projects":{{}}}}
+            ]}}"#,
+            yesterday
+        );
+        std::fs::write(cache_dir.join("codex_daily.json"), stale).unwrap();
+
+        let service = DataLoaderService {
+            registry: ParserRegistry::with_sources(vec![
+                SourceInstance::new(
+                    "codex",
+                    "codex",
+                    "codex",
+                    Box::new(CodexParser::with_data_dir(PathBuf::from(
+                        "tests/fixtures/codex",
+                    ))),
+                ),
+                SourceInstance::new(
+                    "keepwarm",
+                    "keepwarm",
+                    "codex",
+                    Box::new(CodexParser::with_data_dir(temp_dir.path().to_path_buf())),
+                ),
+            ]),
+            cache_service: Some(DailySummaryCacheService::with_cache_dir(cache_dir.clone())),
+            pricing: PricingService::from_cache_only_with_path(&pricing_path),
+        };
+
+        let result = service.load().unwrap();
+        let codex = result
+            .source_summaries
+            .get("codex")
+            .expect("codex summaries present");
+        let dates: Vec<String> = codex.iter().map(|s| s.date.to_string()).collect();
+
+        // Ancient cache-only day preserved across the reparse.
+        assert!(
+            dates.iter().any(|d| d == "2020-01-01"),
+            "preserved >30-day history was dropped: {dates:?}"
+        );
+        // Fixture dates re-parsed — proves the stale source was fully re-parsed
+        // rather than served recent-only.
+        assert!(
+            dates.iter().any(|d| d.starts_with("2026-01")),
+            "stale-version source was not re-parsed (no backfill): {dates:?}"
+        );
     }
 
     // ========== apply_pricing tests ==========

--- a/src/services/pricing.rs
+++ b/src/services/pricing.rs
@@ -657,6 +657,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         }
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2099,7 +2099,7 @@ mod tests {
 
     #[test]
     fn test_projects_tab_enter_drills_into_project_detail() {
-        let key = "/home/me/Scripts/toktrack";
+        let key = "/srv/work/alpha/beta";
         let mut app = ready_app_with_one_project(key);
 
         // Jump to the Projects tab (key '4').

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -27,6 +27,7 @@ use super::widgets::{
     model_breakdown::{ModelBreakdownPopup, ModelBreakdownState},
     models::ModelsData,
     overview::{Overview, OverviewData},
+    projects::{project_display_name, ProjectsData, ProjectsView},
     quit_confirm::{QuitConfirmPopup, QuitConfirmState},
     source_detail::SourceDetailView,
     spinner::{LoadingStage, Spinner},
@@ -38,8 +39,17 @@ use super::widgets::{
 /// Current view mode
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ViewMode {
-    Dashboard { tab: Tab },
-    SourceDetail { source: String },
+    Dashboard {
+        tab: Tab,
+    },
+    SourceDetail {
+        source: String,
+    },
+    /// Drill-down into a single project's per-day breakdown. `project` holds the
+    /// raw project identifier (working directory) used to look up its data.
+    ProjectDetail {
+        project: String,
+    },
 }
 
 impl Default for ViewMode {
@@ -85,6 +95,12 @@ pub struct AppData {
     pub source_models_data: HashMap<String, ModelsData>,
     /// Per-source stats data
     pub source_stats_data: HashMap<String, StatsData>,
+    /// High-level per-project usage list (Projects tab).
+    pub projects_data: ProjectsData,
+    /// Per-project daily data, keyed by raw project identifier (drill-down).
+    pub project_daily_data: HashMap<String, DailyData>,
+    /// Per-project stats data, keyed by raw project identifier (drill-down).
+    pub project_stats_data: HashMap<String, StatsData>,
     /// Cache warning indicator for display in TUI
     #[allow(dead_code)] // Reserved for warning indicator feature
     pub cache_warning: Option<CacheWarning>,
@@ -126,6 +142,8 @@ pub struct App {
     should_quit: bool,
     view_mode: ViewMode,
     source_selected: usize,
+    /// Selected row in the Projects tab list.
+    project_selected: usize,
     daily_scroll: usize,
     weekly_scroll: usize,
     monthly_scroll: usize,
@@ -164,6 +182,7 @@ impl App {
                 tab: config.initial_tab.unwrap_or_default(),
             },
             source_selected: 0,
+            project_selected: 0,
             daily_scroll: 0,
             weekly_scroll: 0,
             monthly_scroll: 0,
@@ -191,7 +210,7 @@ impl App {
     /// Dashboard fixed overhead: padding(1) + tabs(1) + sep(1) + mode(1) + header(1) + sep(1) + keybindings(1) = 7
     fn effective_visible_rows(&self) -> usize {
         let overhead: u16 = match &self.view_mode {
-            ViewMode::SourceDetail { .. } => 8,
+            ViewMode::SourceDetail { .. } | ViewMode::ProjectDetail { .. } => 8,
             ViewMode::Dashboard { .. } => 7,
         };
         self.terminal_height.saturating_sub(overhead) as usize
@@ -249,7 +268,9 @@ impl App {
 
                 match &self.view_mode {
                     ViewMode::Dashboard { .. } => self.handle_dashboard_event(key.code),
-                    ViewMode::SourceDetail { .. } => self.handle_source_detail_event(key.code),
+                    ViewMode::SourceDetail { .. } | ViewMode::ProjectDetail { .. } => {
+                        self.handle_detail_event(key.code)
+                    }
                 }
             }
         }
@@ -355,6 +376,12 @@ impl App {
                 }
                 return;
             }
+            KeyCode::Char('5') => {
+                if let Some(tab) = Tab::from_number(5) {
+                    self.set_tab(tab);
+                }
+                return;
+            }
             KeyCode::Char('?') => {
                 self.show_help = !self.show_help;
                 return;
@@ -413,20 +440,72 @@ impl App {
                 }
                 _ => {}
             },
+            Tab::Projects => match code {
+                KeyCode::Up | KeyCode::Char('k') if self.project_selected > 0 => {
+                    self.project_selected -= 1;
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if let AppState::Ready { data } = &self.state {
+                        let max = data.projects_data.projects.len().saturating_sub(1);
+                        if self.project_selected < max {
+                            self.project_selected += 1;
+                        }
+                    }
+                }
+                KeyCode::Enter => self.open_project_detail(),
+                _ => {}
+            },
             Tab::Stats | Tab::Models | Tab::Audit => {
                 // These tabs have no additional keys beyond the common ones.
             }
         }
     }
 
-    /// Handle keyboard events in SourceDetail mode
-    fn handle_source_detail_event(&mut self, code: KeyCode) {
+    /// Enter the per-project drill-down for the currently selected project.
+    fn open_project_detail(&mut self) {
+        let AppState::Ready { data } = &self.state else {
+            return;
+        };
+        let Some(project) = data.projects_data.projects.get(self.project_selected) else {
+            return;
+        };
+        let key = project.key.clone();
+
+        self.view_mode = ViewMode::ProjectDetail {
+            project: key.clone(),
+        };
+        // Reset scroll/selection, then jump to the latest day for this project.
+        self.daily_scroll = 0;
+        self.weekly_scroll = 0;
+        self.monthly_scroll = 0;
+        self.daily_selected = None;
+        self.weekly_selected = None;
+        self.monthly_selected = None;
+        if let Some(project_daily) = data.project_daily_data.get(&key) {
+            let vr = self.effective_visible_rows();
+            self.daily_scroll =
+                DailyView::max_scroll_offset(project_daily, DailyViewMode::Daily, vr);
+            self.weekly_scroll =
+                DailyView::max_scroll_offset(project_daily, DailyViewMode::Weekly, vr);
+            self.monthly_scroll =
+                DailyView::max_scroll_offset(project_daily, DailyViewMode::Monthly, vr);
+        }
+    }
+
+    /// Handle keyboard events in a drill-down detail view (SourceDetail or
+    /// ProjectDetail). Both share the same daily-table interaction.
+    fn handle_detail_event(&mut self, code: KeyCode) {
         match code {
             KeyCode::Esc => {
                 if self.show_help {
                     self.show_help = false;
                 } else {
-                    self.view_mode = ViewMode::Dashboard { tab: Tab::Overview };
+                    // Return to the tab the drill-down was entered from.
+                    let tab = match &self.view_mode {
+                        ViewMode::ProjectDetail { .. } => Tab::Projects,
+                        _ => Tab::Overview,
+                    };
+                    self.view_mode = ViewMode::Dashboard { tab };
                 }
             }
             KeyCode::Up | KeyCode::Char('k') => {
@@ -572,13 +651,25 @@ impl App {
                 .source_daily_data
                 .get(source)
                 .unwrap_or(&data.daily_data),
+            ViewMode::ProjectDetail { project } => data
+                .project_daily_data
+                .get(project)
+                .unwrap_or(&data.daily_data),
             ViewMode::Dashboard { .. } => &data.daily_data,
         }
     }
 
-    /// Select previous row (move up) in SourceDetail
+    /// Whether the current view is a drill-down detail (source or project).
+    fn is_detail_view(&self) -> bool {
+        matches!(
+            self.view_mode,
+            ViewMode::SourceDetail { .. } | ViewMode::ProjectDetail { .. }
+        )
+    }
+
+    /// Select previous row (move up) in a detail view
     fn select_prev(&mut self) {
-        if !matches!(self.view_mode, ViewMode::SourceDetail { .. }) {
+        if !self.is_detail_view() {
             return;
         }
 
@@ -606,9 +697,9 @@ impl App {
         self.adjust_scroll_for_selection();
     }
 
-    /// Select next row (move down) in SourceDetail
+    /// Select next row (move down) in a detail view
     fn select_next(&mut self) {
-        if !matches!(self.view_mode, ViewMode::SourceDetail { .. }) {
+        if !self.is_detail_view() {
             return;
         }
 
@@ -658,7 +749,7 @@ impl App {
 
     /// Open model breakdown popup for the currently selected row
     fn open_model_breakdown(&mut self) {
-        if !matches!(self.view_mode, ViewMode::SourceDetail { .. }) {
+        if !self.is_detail_view() {
             return;
         }
         let selected = match self.active_selected() {
@@ -757,6 +848,15 @@ impl Widget for &App {
                             .with_tab(*tab);
                             models_view.render(area, buf);
                         }
+                        Tab::Projects => {
+                            ProjectsView::new(
+                                &data.projects_data,
+                                Some(self.project_selected),
+                                self.theme,
+                            )
+                            .with_tab(*tab)
+                            .render(area, buf);
+                        }
                         Tab::Audit => {
                             super::widgets::audit::AuditView::new(
                                 self.audit.as_ref(),
@@ -785,6 +885,27 @@ impl Widget for &App {
                             self.theme,
                         );
                         source_detail.render(area, buf);
+                    }
+                    ViewMode::ProjectDetail { project } => {
+                        let daily_data = data
+                            .project_daily_data
+                            .get(project)
+                            .unwrap_or(&data.daily_data);
+                        let stats_data = data
+                            .project_stats_data
+                            .get(project)
+                            .unwrap_or(&data.stats_data);
+                        let label = project_display_name(project);
+                        let project_detail = SourceDetailView::new(
+                            &label,
+                            daily_data,
+                            stats_data,
+                            self.active_scroll(),
+                            self.daily_view_mode,
+                            self.active_selected(),
+                            self.theme,
+                        );
+                        project_detail.render(area, buf);
                     }
                 }
 
@@ -912,6 +1033,22 @@ fn build_app_data_from_summaries(
     let model_map = Aggregator::by_model_from_daily(&summaries);
     let models_data = ModelsData::from_model_usage(&model_map);
     let stats_data = StatsData::from_daily_summaries(&summaries);
+
+    // Build per-project data (high-level list + per-project drill-down) before
+    // `summaries` is moved into the daily view below.
+    let project_map = Aggregator::by_project_from_daily(&summaries);
+    let projects_data = ProjectsData::from_project_usage(&project_map);
+    let project_summaries = Aggregator::project_daily_summaries(&summaries);
+    let mut project_daily_data = HashMap::new();
+    let mut project_stats_data = HashMap::new();
+    for (project, summ) in &project_summaries {
+        project_daily_data.insert(
+            project.clone(),
+            DailyData::from_daily_summaries(summ.clone()),
+        );
+        project_stats_data.insert(project.clone(), StatsData::from_daily_summaries(summ));
+    }
+
     let daily_data = DailyData::from_daily_summaries(summaries);
 
     // Build per-source data
@@ -945,6 +1082,9 @@ fn build_app_data_from_summaries(
         source_daily_data,
         source_models_data,
         source_stats_data,
+        projects_data,
+        project_daily_data,
+        project_stats_data,
         cache_warning,
     }))
 }
@@ -1082,6 +1222,7 @@ mod tests {
                 total_web_search_requests: 0,
                 total_cost_usd: 0.01,
                 models: HashMap::new(),
+                projects: HashMap::new(),
             })
             .collect();
 
@@ -1114,6 +1255,9 @@ mod tests {
                 source_daily_data: HashMap::new(),
                 source_models_data: HashMap::new(),
                 source_stats_data: HashMap::new(),
+                projects_data: Default::default(),
+                project_daily_data: HashMap::new(),
+                project_stats_data: HashMap::new(),
                 cache_warning: None,
             }),
         };
@@ -1407,6 +1551,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 0.01,
             models: HashMap::new(),
+            projects: HashMap::new(),
         }];
         let daily_tokens: Vec<(NaiveDate, u64)> = vec![(summaries[0].date, 150)];
         let daily_data = DailyData::from_daily_summaries(summaries.clone());
@@ -1423,6 +1568,9 @@ mod tests {
             source_daily_data: HashMap::new(),
             source_models_data: HashMap::new(),
             source_stats_data: HashMap::new(),
+            projects_data: Default::default(),
+            project_daily_data: HashMap::new(),
+            project_stats_data: HashMap::new(),
             cache_warning: None,
         })));
 
@@ -1792,6 +1940,12 @@ mod tests {
         app.handle_event(Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)));
         assert!(matches!(
             app.view_mode,
+            ViewMode::Dashboard { tab: Tab::Projects }
+        ));
+
+        app.handle_event(Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)));
+        assert!(matches!(
+            app.view_mode,
             ViewMode::Dashboard { tab: Tab::Audit }
         ));
 
@@ -1877,6 +2031,115 @@ mod tests {
         assert!(matches!(
             app.view_mode,
             ViewMode::Dashboard { tab: Tab::Stats }
+        ));
+    }
+
+    /// Build a Ready app holding a single project so the Projects drill-down can
+    /// be exercised end-to-end.
+    fn ready_app_with_one_project(key: &str) -> App {
+        let mut summary = DailySummary {
+            date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            total_input_tokens: 100,
+            total_output_tokens: 50,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_reasoning_tokens: 0,
+            total_cache_creation_5m_tokens: 0,
+            total_cache_creation_1h_tokens: 0,
+            total_web_search_requests: 0,
+            total_cost_usd: 1.0,
+            models: HashMap::new(),
+            projects: HashMap::new(),
+        };
+        let mut pu = crate::types::ProjectUsage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cost_usd: 1.0,
+            count: 1,
+            ..Default::default()
+        };
+        pu.models
+            .insert("claude-opus".to_string(), Default::default());
+        summary.projects.insert(key.to_string(), pu.clone());
+
+        let summaries = vec![summary];
+        let projects_data =
+            ProjectsData::from_project_usage(&Aggregator::by_project_from_daily(&summaries));
+        let project_summaries = Aggregator::project_daily_summaries(&summaries);
+        let mut project_daily_data = HashMap::new();
+        let mut project_stats_data = HashMap::new();
+        for (p, s) in &project_summaries {
+            project_daily_data.insert(p.clone(), DailyData::from_daily_summaries(s.clone()));
+            project_stats_data.insert(p.clone(), StatsData::from_daily_summaries(s));
+        }
+
+        let data = AppData {
+            total: crate::types::TotalSummary::default(),
+            daily_tokens: vec![],
+            models_data: ModelsData::from_model_usage(&HashMap::new()),
+            daily_data: DailyData::from_daily_summaries(summaries.clone()),
+            stats_data: StatsData::from_daily_summaries(&summaries),
+            source_usage: vec![],
+            source_daily_data: HashMap::new(),
+            source_models_data: HashMap::new(),
+            source_stats_data: HashMap::new(),
+            projects_data,
+            project_daily_data,
+            project_stats_data,
+            cache_warning: None,
+        };
+
+        App {
+            state: AppState::Ready {
+                data: Box::new(data),
+            },
+            ..App::default()
+        }
+    }
+
+    #[test]
+    fn test_projects_tab_enter_drills_into_project_detail() {
+        let key = "/home/me/Scripts/toktrack";
+        let mut app = ready_app_with_one_project(key);
+
+        // Jump to the Projects tab (key '4').
+        app.handle_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('4'),
+            KeyModifiers::NONE,
+        )));
+        assert!(matches!(
+            app.view_mode,
+            ViewMode::Dashboard { tab: Tab::Projects }
+        ));
+
+        // Enter drills into the selected project.
+        app.handle_event(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )));
+        match &app.view_mode {
+            ViewMode::ProjectDetail { project } => assert_eq!(project, key),
+            other => panic!("expected ProjectDetail, got {:?}", other),
+        }
+
+        // Esc returns to the Projects tab (not Overview).
+        app.handle_event(Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
+        assert!(matches!(
+            app.view_mode,
+            ViewMode::Dashboard { tab: Tab::Projects }
+        ));
+    }
+
+    #[test]
+    fn test_key_5_switches_to_audit() {
+        let mut app = App::default();
+        app.handle_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('5'),
+            KeyModifiers::NONE,
+        )));
+        assert!(matches!(
+            app.view_mode,
+            ViewMode::Dashboard { tab: Tab::Audit }
         ));
     }
 }

--- a/src/tui/widgets/daily.rs
+++ b/src/tui/widgets/daily.rs
@@ -636,6 +636,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: cost,
             models: HashMap::new(),
+            projects: HashMap::new(),
         }
     }
 

--- a/src/tui/widgets/help.rs
+++ b/src/tui/widgets/help.rs
@@ -107,7 +107,13 @@ impl Widget for HelpPopup {
 
         // Keybindings
         render_keybinding(chunks[3], buf, "Tab / Shift+Tab", "Switch view", self.theme);
-        render_keybinding(chunks[4], buf, "1 / 2 / 3 / 4", "Jump to tab", self.theme);
+        render_keybinding(
+            chunks[4],
+            buf,
+            "1 / 2 / 3 / 4 / 5",
+            "Jump to tab",
+            self.theme,
+        );
         render_keybinding(chunks[5], buf, "Up/Down or j/k", "Navigate", self.theme);
         render_keybinding(chunks[6], buf, "Enter", "View source details", self.theme);
         render_keybinding(chunks[7], buf, "Esc", "Back to dashboard", self.theme);

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -8,6 +8,7 @@ pub mod legend;
 pub mod model_breakdown;
 pub mod models;
 pub mod overview;
+pub mod projects;
 pub mod quit_confirm;
 pub mod source_detail;
 pub mod spinner;

--- a/src/tui/widgets/projects.rs
+++ b/src/tui/widgets/projects.rs
@@ -188,7 +188,7 @@ impl ProjectsView<'_> {
         if height == 0 || self.data.projects.is_empty() {
             if self.data.projects.is_empty() {
                 let msg = Paragraph::new(Line::from(Span::styled(
-                    "No project data yet — usage from Claude Code populates this view.",
+                    "No project data yet — usage from supported CLIs populates this view.",
                     Style::default().fg(self.theme.muted()),
                 )))
                 .alignment(Alignment::Center);

--- a/src/tui/widgets/projects.rs
+++ b/src/tui/widgets/projects.rs
@@ -301,20 +301,16 @@ mod tests {
 
     #[test]
     fn test_project_display_name_two_segments() {
-        assert_eq!(
-            project_display_name("/home/me/Scripts/toktrack"),
-            "Scripts/toktrack"
-        );
-        assert_eq!(
-            project_display_name("G:\\Scripts\\toktrack"),
-            "Scripts/toktrack"
-        );
+        // Forward slashes (POSIX-style).
+        assert_eq!(project_display_name("/srv/work/alpha/beta"), "alpha/beta");
+        // Backslashes (Windows-style) — synthetic placeholder, not a real path.
+        assert_eq!(project_display_name("Z:\\work\\alpha\\beta"), "alpha/beta");
     }
 
     #[test]
     fn test_project_display_name_single_segment() {
-        assert_eq!(project_display_name("/toktrack"), "toktrack");
-        assert_eq!(project_display_name("toktrack"), "toktrack");
+        assert_eq!(project_display_name("/solo"), "solo");
+        assert_eq!(project_display_name("solo"), "solo");
     }
 
     #[test]
@@ -351,7 +347,7 @@ mod tests {
     #[test]
     fn test_projects_view_renders_without_panic() {
         let mut map: HashMap<String, ProjectUsage> = HashMap::new();
-        map.insert("/home/me/Scripts/toktrack".to_string(), usage(1.0, 1000));
+        map.insert("/srv/work/alpha/beta".to_string(), usage(1.0, 1000));
         let data = ProjectsData::from_project_usage(&map);
         let view = ProjectsView::new(&data, Some(0), Theme::Dark);
         let area = Rect::new(0, 0, 120, 20);
@@ -364,7 +360,7 @@ mod tests {
                 content.push_str(buf[(x, y)].symbol());
             }
         }
-        assert!(content.contains("Scripts/toktrack"));
+        assert!(content.contains("alpha/beta"));
         assert!(content.contains("Project"));
     }
 

--- a/src/tui/widgets/projects.rs
+++ b/src/tui/widgets/projects.rs
@@ -1,0 +1,387 @@
+//! Projects view widget - displays per-project usage statistics with a
+//! selectable list that drills down into a per-day breakdown.
+
+use std::collections::HashMap;
+
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Paragraph, Widget},
+};
+
+use super::models::format_percentage_bar;
+use super::overview::format_number;
+use super::tabs::{Tab, TabBar};
+use crate::tui::theme::Theme;
+use crate::types::{ProjectUsage, NO_PROJECT};
+
+/// Turn a raw project identifier (the session working directory for Claude
+/// Code) into a compact display label: the last two path segments, e.g.
+/// `Scripts/toktrack`. The `(no project)` sentinel is shown verbatim.
+pub fn project_display_name(key: &str) -> String {
+    if key == NO_PROJECT {
+        return key.to_string();
+    }
+    let parts: Vec<&str> = key.split(['/', '\\']).filter(|s| !s.is_empty()).collect();
+    match parts.as_slice() {
+        [] => key.to_string(),
+        [only] => (*only).to_string(),
+        [.., parent, leaf] => format!("{}/{}", parent, leaf),
+    }
+}
+
+/// A single project's rolled-up usage for display (pre-sorted).
+#[derive(Debug, Clone)]
+pub struct ProjectSummary {
+    /// Raw project identifier (working directory), used to look up drill-down data.
+    pub key: String,
+    /// Compact label shown to the user.
+    pub display: String,
+    pub total_tokens: u64,
+    pub cost_usd: f64,
+}
+
+/// Data for the projects view.
+#[derive(Debug, Default)]
+pub struct ProjectsData {
+    /// Projects sorted by cost descending.
+    pub projects: Vec<ProjectSummary>,
+    /// Total cost across all projects (for the usage bar).
+    pub total_cost: f64,
+}
+
+impl ProjectsData {
+    /// Build from `Aggregator::by_project_from_daily()` output.
+    pub fn from_project_usage(project_map: &HashMap<String, ProjectUsage>) -> Self {
+        let total_cost: f64 = project_map.values().map(|p| p.cost_usd).sum();
+
+        let mut projects: Vec<ProjectSummary> = project_map
+            .iter()
+            .map(|(key, usage)| ProjectSummary {
+                key: key.clone(),
+                display: project_display_name(key),
+                total_tokens: usage.total_tokens(),
+                cost_usd: usage.cost_usd,
+            })
+            .filter(|p| p.total_tokens > 0)
+            .collect();
+
+        // Sort by cost descending (NaN-safe), tie-break by tokens.
+        projects.sort_by(|a, b| {
+            b.cost_usd
+                .partial_cmp(&a.cost_usd)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(b.total_tokens.cmp(&a.total_tokens))
+        });
+
+        Self {
+            projects,
+            total_cost,
+        }
+    }
+}
+
+/// Maximum content width (consistent with the Models view).
+const MAX_CONTENT_WIDTH: u16 = 170;
+
+/// Table width: marker(2) + Project(34) + Tokens(18) + Cost(12) + Usage(16) = 82
+const TABLE_WIDTH: u16 = 82;
+
+/// Projects view widget.
+pub struct ProjectsView<'a> {
+    data: &'a ProjectsData,
+    selected: Option<usize>,
+    theme: Theme,
+    tab: Tab,
+}
+
+impl<'a> ProjectsView<'a> {
+    pub fn new(data: &'a ProjectsData, selected: Option<usize>, theme: Theme) -> Self {
+        Self {
+            data,
+            selected,
+            theme,
+            tab: Tab::Projects,
+        }
+    }
+
+    pub fn with_tab(mut self, tab: Tab) -> Self {
+        self.tab = tab;
+        self
+    }
+}
+
+impl Widget for ProjectsView<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let content_width = area.width.min(MAX_CONTENT_WIDTH);
+        let x_offset = (area.width.saturating_sub(content_width)) / 2;
+        let centered_area = Rect {
+            x: area.x + x_offset,
+            y: area.y,
+            width: content_width,
+            height: area.height,
+        };
+
+        let chunks = Layout::vertical([
+            Constraint::Length(1), // 0: Top padding
+            Constraint::Length(1), // 1: Tabs
+            Constraint::Length(1), // 2: Separator
+            Constraint::Length(1), // 3: Header
+            Constraint::Fill(1),   // 4: Project rows
+            Constraint::Length(1), // 5: Separator
+            Constraint::Length(1), // 6: Keybindings
+        ])
+        .split(centered_area);
+
+        TabBar::new(self.tab, self.theme).render(chunks[1], buf);
+        self.render_separator(chunks[2], buf);
+        self.render_header(chunks[3], buf);
+        self.render_projects(chunks[4], buf);
+        self.render_separator(chunks[5], buf);
+        self.render_keybindings(chunks[6], buf);
+    }
+}
+
+impl ProjectsView<'_> {
+    fn table_offset(&self, area_width: u16) -> u16 {
+        area_width.saturating_sub(TABLE_WIDTH) / 2
+    }
+
+    fn render_separator(&self, area: Rect, buf: &mut Buffer) {
+        let line = "─".repeat(area.width as usize);
+        buf.set_string(
+            area.x,
+            area.y,
+            &line,
+            Style::default().fg(self.theme.muted()),
+        );
+    }
+
+    fn render_header(&self, area: Rect, buf: &mut Buffer) {
+        let offset = self.table_offset(area.width);
+        let bold = Style::default()
+            .fg(self.theme.text())
+            .add_modifier(Modifier::BOLD);
+        let header = Line::from(vec![
+            Span::styled(format!("{:<2}", ""), bold),
+            Span::styled(format!("{:<34}", "Project"), bold),
+            Span::styled(format!("{:>18}", "Tokens"), bold),
+            Span::styled(format!("{:>12}", "Cost"), bold),
+            Span::styled(format!("{:>16}", "Usage"), bold),
+        ]);
+        Paragraph::new(header).alignment(Alignment::Left).render(
+            Rect {
+                x: area.x + offset,
+                y: area.y,
+                width: TABLE_WIDTH.min(area.width),
+                height: area.height,
+            },
+            buf,
+        );
+    }
+
+    fn render_projects(&self, area: Rect, buf: &mut Buffer) {
+        let offset = self.table_offset(area.width);
+        let height = area.height as usize;
+        if height == 0 || self.data.projects.is_empty() {
+            if self.data.projects.is_empty() {
+                let msg = Paragraph::new(Line::from(Span::styled(
+                    "No project data yet — usage from Claude Code populates this view.",
+                    Style::default().fg(self.theme.muted()),
+                )))
+                .alignment(Alignment::Center);
+                msg.render(area, buf);
+            }
+            return;
+        }
+
+        // Auto-scroll so the selected row stays visible.
+        let selected = self.selected.unwrap_or(0);
+        let scroll = if selected >= height {
+            selected + 1 - height
+        } else {
+            0
+        };
+
+        for (row, project) in self
+            .data
+            .projects
+            .iter()
+            .enumerate()
+            .skip(scroll)
+            .take(height)
+        {
+            let y = area.y + (row - scroll) as u16;
+            let is_selected = self.selected == Some(row);
+
+            let percent = if self.data.total_cost > 0.0 {
+                (project.cost_usd / self.data.total_cost) * 100.0
+            } else {
+                0.0
+            };
+            let bar = format_percentage_bar(percent, 12);
+
+            let name = if project.display.chars().count() > 32 {
+                format!("{}…", project.display.chars().take(31).collect::<String>())
+            } else {
+                project.display.clone()
+            };
+
+            let marker = if is_selected { "▸ " } else { "  " };
+            let name_style = if is_selected {
+                Style::default()
+                    .fg(self.theme.accent())
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(self.theme.accent())
+            };
+
+            let row_line = Line::from(vec![
+                Span::styled(marker.to_string(), Style::default().fg(self.theme.accent())),
+                Span::styled(format!("{:<34}", name), name_style),
+                Span::styled(
+                    format!("{:>18}", format_number(project.total_tokens)),
+                    Style::default().fg(self.theme.text()),
+                ),
+                Span::styled(
+                    format!("{:>12}", format!("${:.2}", project.cost_usd)),
+                    Style::default().fg(self.theme.cost()),
+                ),
+                Span::styled(
+                    format!("{:>16}", bar),
+                    Style::default().fg(self.theme.bar()),
+                ),
+            ]);
+
+            Paragraph::new(row_line).alignment(Alignment::Left).render(
+                Rect {
+                    x: area.x + offset,
+                    y,
+                    width: TABLE_WIDTH.min(area.width),
+                    height: 1,
+                },
+                buf,
+            );
+        }
+    }
+
+    fn render_keybindings(&self, area: Rect, buf: &mut Buffer) {
+        let bindings = Paragraph::new(Line::from(vec![
+            Span::styled("↑↓", Style::default().fg(self.theme.accent())),
+            Span::styled(": Select", Style::default().fg(self.theme.muted())),
+            Span::raw("  "),
+            Span::styled("Enter", Style::default().fg(self.theme.accent())),
+            Span::styled(": Details", Style::default().fg(self.theme.muted())),
+            Span::raw("  "),
+            Span::styled("Tab", Style::default().fg(self.theme.accent())),
+            Span::styled(": Switch view", Style::default().fg(self.theme.muted())),
+            Span::raw("  "),
+            Span::styled("?", Style::default().fg(self.theme.accent())),
+            Span::styled(": Help", Style::default().fg(self.theme.muted())),
+        ]))
+        .alignment(Alignment::Center);
+        bindings.render(area, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn usage(cost: f64, input: u64) -> ProjectUsage {
+        ProjectUsage {
+            input_tokens: input,
+            cost_usd: cost,
+            count: 1,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_project_display_name_two_segments() {
+        assert_eq!(
+            project_display_name("/home/me/Scripts/toktrack"),
+            "Scripts/toktrack"
+        );
+        assert_eq!(
+            project_display_name("G:\\Scripts\\toktrack"),
+            "Scripts/toktrack"
+        );
+    }
+
+    #[test]
+    fn test_project_display_name_single_segment() {
+        assert_eq!(project_display_name("/toktrack"), "toktrack");
+        assert_eq!(project_display_name("toktrack"), "toktrack");
+    }
+
+    #[test]
+    fn test_project_display_name_no_project_sentinel() {
+        assert_eq!(project_display_name(NO_PROJECT), NO_PROJECT);
+    }
+
+    #[test]
+    fn test_projects_data_sorted_by_cost_desc() {
+        let mut map: HashMap<String, ProjectUsage> = HashMap::new();
+        map.insert("/a/low".to_string(), usage(0.10, 100));
+        map.insert("/a/high".to_string(), usage(0.90, 100));
+        map.insert("/a/mid".to_string(), usage(0.50, 100));
+
+        let data = ProjectsData::from_project_usage(&map);
+        assert_eq!(data.projects.len(), 3);
+        assert_eq!(data.projects[0].key, "/a/high");
+        assert_eq!(data.projects[1].key, "/a/mid");
+        assert_eq!(data.projects[2].key, "/a/low");
+        assert!((data.total_cost - 1.50).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_projects_data_filters_zero_token() {
+        let mut map: HashMap<String, ProjectUsage> = HashMap::new();
+        map.insert("/a/empty".to_string(), usage(0.0, 0));
+        map.insert("/a/real".to_string(), usage(0.10, 50));
+
+        let data = ProjectsData::from_project_usage(&map);
+        assert_eq!(data.projects.len(), 1);
+        assert_eq!(data.projects[0].key, "/a/real");
+    }
+
+    #[test]
+    fn test_projects_view_renders_without_panic() {
+        let mut map: HashMap<String, ProjectUsage> = HashMap::new();
+        map.insert("/home/me/Scripts/toktrack".to_string(), usage(1.0, 1000));
+        let data = ProjectsData::from_project_usage(&map);
+        let view = ProjectsView::new(&data, Some(0), Theme::Dark);
+        let area = Rect::new(0, 0, 120, 20);
+        let mut buf = Buffer::empty(area);
+        view.render(area, &mut buf);
+
+        let mut content = String::new();
+        for y in 0..area.height {
+            for x in 0..area.width {
+                content.push_str(buf[(x, y)].symbol());
+            }
+        }
+        assert!(content.contains("Scripts/toktrack"));
+        assert!(content.contains("Project"));
+    }
+
+    #[test]
+    fn test_projects_view_empty_shows_hint() {
+        let data = ProjectsData::default();
+        let view = ProjectsView::new(&data, None, Theme::Dark);
+        let area = Rect::new(0, 0, 120, 20);
+        let mut buf = Buffer::empty(area);
+        view.render(area, &mut buf);
+
+        let mut content = String::new();
+        for y in 0..area.height {
+            for x in 0..area.width {
+                content.push_str(buf[(x, y)].symbol());
+            }
+        }
+        assert!(content.contains("No project data"));
+    }
+}

--- a/src/tui/widgets/source_detail.rs
+++ b/src/tui/widgets/source_detail.rs
@@ -245,6 +245,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: 12.50,
             models: HashMap::new(),
+            projects: HashMap::new(),
         }];
         DailyData::from_daily_summaries(summaries)
     }

--- a/src/tui/widgets/tabs.rs
+++ b/src/tui/widgets/tabs.rs
@@ -16,6 +16,7 @@ pub enum Tab {
     Overview,
     Stats,
     Models,
+    Projects,
     Audit,
 }
 
@@ -26,13 +27,20 @@ impl Tab {
             Self::Overview => "Overview",
             Self::Stats => "Stats",
             Self::Models => "Models",
+            Self::Projects => "Projects",
             Self::Audit => "Audit",
         }
     }
 
     /// Get all tabs in order
     pub fn all() -> &'static [Tab] {
-        &[Tab::Overview, Tab::Stats, Tab::Models, Tab::Audit]
+        &[
+            Tab::Overview,
+            Tab::Stats,
+            Tab::Models,
+            Tab::Projects,
+            Tab::Audit,
+        ]
     }
 
     /// Get the next tab (wrapping)
@@ -40,7 +48,8 @@ impl Tab {
         match self {
             Self::Overview => Self::Stats,
             Self::Stats => Self::Models,
-            Self::Models => Self::Audit,
+            Self::Models => Self::Projects,
+            Self::Projects => Self::Audit,
             Self::Audit => Self::Overview,
         }
     }
@@ -51,17 +60,19 @@ impl Tab {
             Self::Overview => Self::Audit,
             Self::Stats => Self::Overview,
             Self::Models => Self::Stats,
-            Self::Audit => Self::Models,
+            Self::Projects => Self::Models,
+            Self::Audit => Self::Projects,
         }
     }
 
-    /// Get tab from number key (1-4)
+    /// Get tab from number key (1-5)
     pub fn from_number(n: u8) -> Option<Self> {
         match n {
             1 => Some(Self::Overview),
             2 => Some(Self::Stats),
             3 => Some(Self::Models),
-            4 => Some(Self::Audit),
+            4 => Some(Self::Projects),
+            5 => Some(Self::Audit),
             _ => None,
         }
     }
@@ -144,24 +155,27 @@ mod tests {
         assert_eq!(Tab::Overview.label(), "Overview");
         assert_eq!(Tab::Stats.label(), "Stats");
         assert_eq!(Tab::Models.label(), "Models");
+        assert_eq!(Tab::Projects.label(), "Projects");
         assert_eq!(Tab::Audit.label(), "Audit");
     }
 
     #[test]
     fn test_tab_all() {
         let all = Tab::all();
-        assert_eq!(all.len(), 4);
+        assert_eq!(all.len(), 5);
         assert_eq!(all[0], Tab::Overview);
         assert_eq!(all[1], Tab::Stats);
         assert_eq!(all[2], Tab::Models);
-        assert_eq!(all[3], Tab::Audit);
+        assert_eq!(all[3], Tab::Projects);
+        assert_eq!(all[4], Tab::Audit);
     }
 
     #[test]
     fn test_tab_next() {
         assert_eq!(Tab::Overview.next(), Tab::Stats);
         assert_eq!(Tab::Stats.next(), Tab::Models);
-        assert_eq!(Tab::Models.next(), Tab::Audit);
+        assert_eq!(Tab::Models.next(), Tab::Projects);
+        assert_eq!(Tab::Projects.next(), Tab::Audit);
         assert_eq!(Tab::Audit.next(), Tab::Overview);
     }
 
@@ -170,7 +184,8 @@ mod tests {
         assert_eq!(Tab::Overview.prev(), Tab::Audit);
         assert_eq!(Tab::Stats.prev(), Tab::Overview);
         assert_eq!(Tab::Models.prev(), Tab::Stats);
-        assert_eq!(Tab::Audit.prev(), Tab::Models);
+        assert_eq!(Tab::Projects.prev(), Tab::Models);
+        assert_eq!(Tab::Audit.prev(), Tab::Projects);
     }
 
     #[test]
@@ -183,8 +198,9 @@ mod tests {
         assert_eq!(Tab::from_number(1), Some(Tab::Overview));
         assert_eq!(Tab::from_number(2), Some(Tab::Stats));
         assert_eq!(Tab::from_number(3), Some(Tab::Models));
-        assert_eq!(Tab::from_number(4), Some(Tab::Audit));
+        assert_eq!(Tab::from_number(4), Some(Tab::Projects));
+        assert_eq!(Tab::from_number(5), Some(Tab::Audit));
         assert_eq!(Tab::from_number(0), None);
-        assert_eq!(Tab::from_number(5), None);
+        assert_eq!(Tab::from_number(6), None);
     }
 }

--- a/src/types/usage.rs
+++ b/src/types/usage.rs
@@ -116,6 +116,10 @@ pub struct UsageEntry {
     /// Provider ID (e.g., "anthropic", "github-copilot")
     #[serde(default)]
     pub provider: Option<String>,
+    /// Project this usage belongs to (e.g. the working directory for Claude Code).
+    /// `None` for sources that do not record a project (Codex, Gemini, etc.).
+    #[serde(default)]
+    pub project: Option<String>,
 }
 
 impl UsageEntry {
@@ -166,6 +170,106 @@ pub struct DailySummary {
     pub total_web_search_requests: u64,
     pub total_cost_usd: f64,
     pub models: HashMap<String, ModelUsage>,
+    /// Per-project breakdown for this day. Keyed by project identifier (the raw
+    /// working directory for Claude Code, or "(no project)" for sources that do
+    /// not record one). Empty for caches written before this field existed.
+    #[serde(default)]
+    pub projects: HashMap<String, ProjectUsage>,
+}
+
+/// The sentinel project key used for usage from sources that do not record a
+/// project (Codex, Gemini, Qwen, OpenCode, PI Agent).
+pub const NO_PROJECT: &str = "(no project)";
+
+/// Usage aggregated for a single project within a day (or rolled up across days).
+/// Mirrors [`ModelUsage`] but also keeps a nested per-model breakdown so a project
+/// can be drilled into by model.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct ProjectUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    #[serde(default)]
+    pub reasoning_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_5m_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_1h_tokens: u64,
+    #[serde(default)]
+    pub web_search_requests: u64,
+    pub cost_usd: f64,
+    pub count: u64,
+    /// Per-model breakdown within this project.
+    #[serde(default)]
+    pub models: HashMap<String, ModelUsage>,
+}
+
+impl ProjectUsage {
+    pub fn total_tokens(&self) -> u64 {
+        self.input_tokens
+            + self.output_tokens
+            + self.cache_read_tokens
+            + self.cache_creation_tokens
+            + self.reasoning_tokens
+    }
+
+    /// Accumulate a single entry, also updating the nested per-model breakdown
+    /// under `model_key`.
+    pub fn add(&mut self, entry: &UsageEntry, cost: f64, model_key: &str) {
+        self.input_tokens = self.input_tokens.saturating_add(entry.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(entry.output_tokens);
+        self.cache_read_tokens = self
+            .cache_read_tokens
+            .saturating_add(entry.cache_read_tokens);
+        self.cache_creation_tokens = self
+            .cache_creation_tokens
+            .saturating_add(entry.cache_creation_tokens);
+        self.reasoning_tokens = self.reasoning_tokens.saturating_add(entry.reasoning_tokens);
+        self.cache_creation_5m_tokens = self
+            .cache_creation_5m_tokens
+            .saturating_add(entry.cache_creation_5m_tokens);
+        self.cache_creation_1h_tokens = self
+            .cache_creation_1h_tokens
+            .saturating_add(entry.cache_creation_1h_tokens);
+        self.web_search_requests = self
+            .web_search_requests
+            .saturating_add(entry.web_search_requests);
+        self.cost_usd += cost;
+        self.count = self.count.saturating_add(1);
+        self.models
+            .entry(model_key.to_string())
+            .or_default()
+            .add(entry, cost);
+    }
+
+    /// Merge another project's usage into this one (used when rolling daily
+    /// summaries up into weekly/monthly views or across sources).
+    pub fn merge(&mut self, other: &ProjectUsage) {
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.cache_read_tokens = self
+            .cache_read_tokens
+            .saturating_add(other.cache_read_tokens);
+        self.cache_creation_tokens = self
+            .cache_creation_tokens
+            .saturating_add(other.cache_creation_tokens);
+        self.reasoning_tokens = self.reasoning_tokens.saturating_add(other.reasoning_tokens);
+        self.cache_creation_5m_tokens = self
+            .cache_creation_5m_tokens
+            .saturating_add(other.cache_creation_5m_tokens);
+        self.cache_creation_1h_tokens = self
+            .cache_creation_1h_tokens
+            .saturating_add(other.cache_creation_1h_tokens);
+        self.web_search_requests = self
+            .web_search_requests
+            .saturating_add(other.web_search_requests);
+        self.cost_usd += other.cost_usd;
+        self.count = self.count.saturating_add(other.count);
+        for (model, usage) in &other.models {
+            self.models.entry(model.clone()).or_default().merge(usage);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -208,6 +312,30 @@ impl ModelUsage {
             .saturating_add(entry.web_search_requests);
         self.cost_usd += cost;
         self.count = self.count.saturating_add(1);
+    }
+
+    /// Merge another model's usage into this one.
+    pub fn merge(&mut self, other: &ModelUsage) {
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.cache_read_tokens = self
+            .cache_read_tokens
+            .saturating_add(other.cache_read_tokens);
+        self.cache_creation_tokens = self
+            .cache_creation_tokens
+            .saturating_add(other.cache_creation_tokens);
+        self.reasoning_tokens = self.reasoning_tokens.saturating_add(other.reasoning_tokens);
+        self.cache_creation_5m_tokens = self
+            .cache_creation_5m_tokens
+            .saturating_add(other.cache_creation_5m_tokens);
+        self.cache_creation_1h_tokens = self
+            .cache_creation_1h_tokens
+            .saturating_add(other.cache_creation_1h_tokens);
+        self.web_search_requests = self
+            .web_search_requests
+            .saturating_add(other.web_search_requests);
+        self.cost_usd += other.cost_usd;
+        self.count = self.count.saturating_add(other.count);
     }
 }
 
@@ -289,6 +417,7 @@ mod tests {
             total_web_search_requests: 0,
             total_cost_usd: cost,
             models: HashMap::new(),
+            projects: HashMap::new(),
         }
     }
 
@@ -377,6 +506,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         };
         assert_eq!(entry.total_tokens(), 180);
     }
@@ -401,6 +531,7 @@ mod tests {
             request_id: None,
             source: Some("gemini".into()),
             provider: None,
+            project: None,
         };
         assert_eq!(entry.total_tokens(), 210);
     }
@@ -425,6 +556,7 @@ mod tests {
             request_id: Some("req456".into()),
             source: None,
             provider: None,
+            project: None,
         };
         assert_eq!(entry.dedup_hash(), Some("msg123:req456".into()));
     }
@@ -449,6 +581,7 @@ mod tests {
             request_id: Some("req456".into()),
             source: None,
             provider: None,
+            project: None,
         };
         assert_eq!(entry.dedup_hash(), None);
     }
@@ -473,6 +606,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         };
         assert_eq!(entry.dedup_hash(), Some("msg789:gpt-4:100:50".into()));
     }
@@ -502,6 +636,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         };
 
         let local_date = entry.local_date();
@@ -531,6 +666,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         };
         let local = late_entry.local_date();
         let utc_naive = late_utc.date_naive();
@@ -562,6 +698,7 @@ mod tests {
             request_id: None,
             source: None,
             provider: None,
+            project: None,
         };
         usage.add(&entry, 0.01);
 

--- a/src/types/usage.rs
+++ b/src/types/usage.rs
@@ -173,7 +173,13 @@ pub struct DailySummary {
     /// Per-project breakdown for this day. Keyed by project identifier (the raw
     /// working directory for Claude Code, or "(no project)" for sources that do
     /// not record one). Empty for caches written before this field existed.
-    #[serde(default)]
+    ///
+    /// `skip_serializing_if` keeps the key out of JSON when empty so the public
+    /// `--json` schema is unchanged for days with no project data; the CLI also
+    /// strips populated maps from `--json` output (raw paths can include the OS
+    /// username) — see `cli::redact_project_paths`. The persistent cache still
+    /// retains the data because it serializes non-empty maps.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub projects: HashMap<String, ProjectUsage>,
 }
 
@@ -419,6 +425,34 @@ mod tests {
             models: HashMap::new(),
             projects: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn test_daily_summary_omits_empty_projects_from_json() {
+        let s = make_summary(2026, 1, 1, 100, 50, 0, 0, 1.0);
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(
+            !json.contains("projects"),
+            "empty projects map must be omitted from JSON: {json}"
+        );
+    }
+
+    #[test]
+    fn test_daily_summary_serializes_nonempty_projects_and_round_trips() {
+        let mut s = make_summary(2026, 1, 1, 100, 50, 0, 0, 1.0);
+        s.projects.insert(
+            "/work/demo".to_string(),
+            ProjectUsage {
+                input_tokens: 100,
+                ..Default::default()
+            },
+        );
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains("projects"));
+        // The cache relies on this round-trip to preserve per-project history.
+        let back: DailySummary = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.projects.len(), 1);
+        assert!(back.projects.contains_key("/work/demo"));
     }
 
     #[test]

--- a/tests/fixtures/codex/cwd-session.jsonl
+++ b/tests/fixtures/codex/cwd-session.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-06-19T13:09:05.000Z","type":"session_meta","payload":{"id":"sess-cwd-001","model_provider":"openai"}}
+{"timestamp":"2026-06-19T13:09:05.288Z","type":"turn_context","payload":{"turn_id":"turn-1","cwd":"/home/user/code/myrepo","workspace_roots":["/home/user/code/myrepo"],"model":"gpt-5.5"}}
+{"timestamp":"2026-06-19T13:09:10.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":150,"output_tokens":75,"cached_input_tokens":25},"last_token_usage":{"input_tokens":150,"output_tokens":75,"cached_input_tokens":25}}}}

--- a/tests/fixtures/codex/cwd-session.jsonl
+++ b/tests/fixtures/codex/cwd-session.jsonl
@@ -1,3 +1,3 @@
 {"timestamp":"2026-06-19T13:09:05.000Z","type":"session_meta","payload":{"id":"sess-cwd-001","model_provider":"openai"}}
-{"timestamp":"2026-06-19T13:09:05.288Z","type":"turn_context","payload":{"turn_id":"turn-1","cwd":"/home/user/code/myrepo","workspace_roots":["/home/user/code/myrepo"],"model":"gpt-5.5"}}
+{"timestamp":"2026-06-19T13:09:05.288Z","type":"turn_context","payload":{"turn_id":"turn-1","cwd":"/work/myrepo","workspace_roots":["/work/myrepo"],"model":"gpt-5.5"}}
 {"timestamp":"2026-06-19T13:09:10.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":150,"output_tokens":75,"cached_input_tokens":25},"last_token_usage":{"input_tokens":150,"output_tokens":75,"cached_input_tokens":25}}}}


### PR DESCRIPTION
## Summary

Adds a new **Projects** tab so you can see token & cost usage **per project**, and drill into any project for its day-by-day, per-model breakdown.

Tab order is now: `Overview · Stats · Models · Projects · Audit` (number keys `1`–`5`).

- **Projects tab** — a selectable list of projects sorted by cost, each with tokens / cost / a usage bar. Labels are shown as `parent/folder` (e.g. `Scripts/toktrack`).
- **Drill-down** — `Enter` on a project opens its daily/weekly/monthly view (reusing the existing source-detail view); `Enter` on a day opens the existing per-model breakdown popup. `Esc` returns to the Projects tab.

## Which CLIs are covered

Per-project attribution needs a working directory in the session data. Each below was verified against live local data:

- **Claude Code** — ✅ per-line `cwd`.
- **Codex** — ✅ `cwd` on `turn_context.payload` (with `workspace_roots`), and sometimes on `session_meta`.
- **OpenCode** — ✅ `session.directory` (joined via `session_id`); falls back gracefully on older schemas without the column.
- **PI Agent** — ✅ `cwd` on the leading `session` line.
- **Gemini CLI** — ✅ `cwd` from a `.project_root` sidecar next to the session's `chats/` dir (the chat log itself carries only a hashed `projectHash`).
- **Qwen Code** — ❌ **not supported.** Qwen *does* record a cwd, but v0.18.3 changed both its storage layout (`~/.qwen/projects/<cwd>/chats/…`, no longer `~/.qwen/tmp/*/chats/session-*.jsonl`) **and** its token format (usage now lives in `type:"system"` / `ui_telemetry` `qwen-code.api_response` events, not the Gemini-style `{"type":"gemini","tokens":{…}}` blocks). toktrack's Gemini-based Qwen parser therefore ingests **zero** usage for this version — a pre-existing breakage independent of this PR. Once Qwen ingestion is fixed (separate change), per-project would come almost for free since the cwd is present.

Usage from any source without a project is grouped under a single **`(no project)`** entry.

## How it works

- **types** — `UsageEntry` gains an optional `project`; `DailySummary` gains a nested `projects: HashMap<String, ProjectUsage>` (token totals + cost + count + a per-model map) so the breakdown is stored, not recomputed.
- **parsers** — `claude.rs` reads the per-line `cwd`; `codex.rs` reads `turn_context`/`session_meta` `cwd`; `pi_agent.rs` reads the session-line `cwd`; `opencode.rs` joins `session.directory`; `gemini.rs` resolves the `.project_root` sidecar. Sources without a project set `project: None`.
- **aggregator** — `daily()` populates the per-project / per-model breakdown; merged through `weekly()` / `monthly()` / `merge_by_date()`. New helpers: `by_project_from_daily()` (the list) and `project_daily_summaries()` (explodes summaries into per-project daily series for the drill-down).
- **cache** — `CACHE_VERSION` 13 → 14. A version mismatch **keeps** existing history (no wipe) and triggers a full reparse that backfills `projects` for every day whose raw files still exist, then caches it (surviving the CLI's 30-day deletion). The warm path now also checks the version **per source** (`is_version_current`), so a stale source cache is re-parsed even when other sources are current — previously such a source was never backfilled. Days already cache-only before upgrading keep an empty `projects` map (raw `cwd` gone), which is unavoidable.

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all pass.
- New tests cover: `cwd` → project extraction for Claude Code, Codex, OpenCode, PI Agent, and Gemini (plus no-cwd → `None` paths); per-project/per-model aggregation; weekly rollup; explode-into-per-project-summaries; the stale-version-source backfill fix; the Projects widget rendering; and the tab navigation + drill-down interaction. Tests use synthetic placeholder paths (no machine-specific paths).
- Smoke-tested against real local data for **Claude Code, Codex, OpenCode, PI Agent, and Gemini** — cache rebuilt to v14 with days populated per project (nested per-model usage), each attributed to the correct working directory.

https://claude.ai/code/session_015Hunjgo5bjbvCfbtCeXMUq
