### PR TITLE
fix(tui): render nav bar on the top row across all views

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -206,12 +206,12 @@ impl App {
     }
 
     /// Calculate the effective number of visible rows based on the current view and terminal height.
-    /// SourceDetail fixed overhead: padding(1) + header(1) + stats(1) + sep(1) + mode(1) + header(1) + sep(1) + keybindings(1) = 8
-    /// Dashboard fixed overhead: padding(1) + tabs(1) + sep(1) + mode(1) + header(1) + sep(1) + keybindings(1) = 7
+    /// SourceDetail fixed overhead: header(1) + stats(1) + sep(1) + mode(1) + header(1) + sep(1) + keybindings(1) = 7
+    /// Dashboard fixed overhead: tabs(1) + sep(1) + mode(1) + header(1) + sep(1) + keybindings(1) = 6
     fn effective_visible_rows(&self) -> usize {
         let overhead: u16 = match &self.view_mode {
-            ViewMode::SourceDetail { .. } | ViewMode::ProjectDetail { .. } => 8,
-            ViewMode::Dashboard { .. } => 7,
+            ViewMode::SourceDetail { .. } | ViewMode::ProjectDetail { .. } => 7,
+            ViewMode::Dashboard { .. } => 6,
         };
         self.terminal_height.saturating_sub(overhead) as usize
     }

--- a/src/tui/widgets/audit.rs
+++ b/src/tui/widgets/audit.rs
@@ -89,7 +89,6 @@ impl Widget for AuditView<'_> {
         };
 
         let chunks = Layout::vertical([
-            Constraint::Length(1), // top padding
             Constraint::Length(1), // tabs
             Constraint::Length(1), // separator
             Constraint::Length(1), // title
@@ -100,12 +99,12 @@ impl Widget for AuditView<'_> {
         ])
         .split(centered);
 
-        TabBar::new(self.selected_tab, self.theme).render(chunks[1], buf);
-        self.render_separator(chunks[2], buf);
-        self.render_title(chunks[3], buf);
-        self.render_content(chunks[5], buf);
-        self.render_separator(chunks[6], buf);
-        self.render_keybindings(chunks[7], buf);
+        TabBar::new(self.selected_tab, self.theme).render(chunks[0], buf);
+        self.render_separator(chunks[1], buf);
+        self.render_title(chunks[2], buf);
+        self.render_content(chunks[4], buf);
+        self.render_separator(chunks[5], buf);
+        self.render_keybindings(chunks[6], buf);
     }
 }
 

--- a/src/tui/widgets/models.rs
+++ b/src/tui/widgets/models.rs
@@ -116,7 +116,6 @@ impl Widget for ModelsView<'_> {
         // Calculate layout with models list
         let max_model_rows = self.data.models.len().min(10) as u16; // Show up to 10 models
         let chunks = Layout::vertical([
-            Constraint::Length(1),              // Top padding
             Constraint::Length(1),              // Tabs
             Constraint::Length(1),              // Separator
             Constraint::Length(1),              // Header
@@ -128,22 +127,22 @@ impl Widget for ModelsView<'_> {
         .split(centered_area);
 
         // Render tab bar
-        TabBar::new(self.tab, self.theme).render(chunks[1], buf);
+        TabBar::new(self.tab, self.theme).render(chunks[0], buf);
 
         // Render separator
-        self.render_separator(chunks[2], buf);
+        self.render_separator(chunks[1], buf);
 
         // Render header
-        self.render_header(chunks[3], buf);
+        self.render_header(chunks[2], buf);
 
         // Render model rows
-        self.render_models(chunks[4], buf);
+        self.render_models(chunks[3], buf);
 
         // Render separator
-        self.render_separator(chunks[5], buf);
+        self.render_separator(chunks[4], buf);
 
         // Render keybindings
-        self.render_keybindings(chunks[6], buf);
+        self.render_keybindings(chunks[5], buf);
     }
 }
 

--- a/src/tui/widgets/projects.rs
+++ b/src/tui/widgets/projects.rs
@@ -125,22 +125,21 @@ impl Widget for ProjectsView<'_> {
         };
 
         let chunks = Layout::vertical([
-            Constraint::Length(1), // 0: Top padding
-            Constraint::Length(1), // 1: Tabs
-            Constraint::Length(1), // 2: Separator
-            Constraint::Length(1), // 3: Header
-            Constraint::Fill(1),   // 4: Project rows
-            Constraint::Length(1), // 5: Separator
-            Constraint::Length(1), // 6: Keybindings
+            Constraint::Length(1), // 0: Tabs
+            Constraint::Length(1), // 1: Separator
+            Constraint::Length(1), // 2: Header
+            Constraint::Fill(1),   // 3: Project rows
+            Constraint::Length(1), // 4: Separator
+            Constraint::Length(1), // 5: Keybindings
         ])
         .split(centered_area);
 
-        TabBar::new(self.tab, self.theme).render(chunks[1], buf);
-        self.render_separator(chunks[2], buf);
-        self.render_header(chunks[3], buf);
-        self.render_projects(chunks[4], buf);
-        self.render_separator(chunks[5], buf);
-        self.render_keybindings(chunks[6], buf);
+        TabBar::new(self.tab, self.theme).render(chunks[0], buf);
+        self.render_separator(chunks[1], buf);
+        self.render_header(chunks[2], buf);
+        self.render_projects(chunks[3], buf);
+        self.render_separator(chunks[4], buf);
+        self.render_keybindings(chunks[5], buf);
     }
 }
 

--- a/src/tui/widgets/source_detail.rs
+++ b/src/tui/widgets/source_detail.rs
@@ -61,22 +61,21 @@ impl Widget for SourceDetailView<'_> {
         };
 
         let chunks = Layout::vertical([
-            Constraint::Length(1), // 0: Top padding
-            Constraint::Length(1), // 1: Source header
-            Constraint::Length(1), // 2: Stats inline
-            Constraint::Length(1), // 3: Separator
-            Constraint::Length(1), // 4: Mode indicator
-            Constraint::Length(1), // 5: Daily table header
-            Constraint::Fill(1),   // 6: Daily rows (fill remaining)
-            Constraint::Length(1), // 7: Separator
-            Constraint::Length(1), // 8: Keybindings
+            Constraint::Length(1), // 0: Source header
+            Constraint::Length(1), // 1: Stats inline
+            Constraint::Length(1), // 2: Separator
+            Constraint::Length(1), // 3: Mode indicator
+            Constraint::Length(1), // 4: Daily table header
+            Constraint::Fill(1),   // 5: Daily rows (fill remaining)
+            Constraint::Length(1), // 6: Separator
+            Constraint::Length(1), // 7: Keybindings
         ])
         .split(centered_area);
 
-        self.render_source_header(chunks[1], buf);
-        self.render_stats_inline(chunks[2], buf);
-        self.render_separator(chunks[3], buf);
-        self.render_mode_indicator(chunks[4], buf);
+        self.render_source_header(chunks[0], buf);
+        self.render_stats_inline(chunks[1], buf);
+        self.render_separator(chunks[2], buf);
+        self.render_mode_indicator(chunks[3], buf);
 
         // Render daily table (header + rows)
         let daily_view = DailyView::new(
@@ -88,11 +87,11 @@ impl Widget for SourceDetailView<'_> {
         )
         .with_selected_index(self.selected_index);
 
-        daily_view.render_header(chunks[5], buf, &daily_view_visible_columns(chunks[5].width));
-        daily_view.render_daily_rows(chunks[6], buf, &daily_view_visible_columns(chunks[6].width));
+        daily_view.render_header(chunks[4], buf, &daily_view_visible_columns(chunks[4].width));
+        daily_view.render_daily_rows(chunks[5], buf, &daily_view_visible_columns(chunks[5].width));
 
-        self.render_separator(chunks[7], buf);
-        self.render_keybindings(chunks[8], buf);
+        self.render_separator(chunks[6], buf);
+        self.render_keybindings(chunks[7], buf);
     }
 }
 

--- a/src/tui/widgets/stats.rs
+++ b/src/tui/widgets/stats.rs
@@ -70,7 +70,6 @@ impl Widget for StatsView<'_> {
         let grid_height = (rows as u16) * (CARD_HEIGHT + 1); // +1 for spacing
 
         let chunks = Layout::vertical([
-            Constraint::Length(1),           // Top padding
             Constraint::Length(1),           // Tabs
             Constraint::Length(1),           // Separator
             Constraint::Length(1),           // Title
@@ -83,22 +82,22 @@ impl Widget for StatsView<'_> {
         .split(centered_area);
 
         // Render tabs
-        self.render_tabs(chunks[1], buf);
+        self.render_tabs(chunks[0], buf);
 
         // Render separator
-        self.render_separator(chunks[2], buf);
+        self.render_separator(chunks[1], buf);
 
         // Render title
-        self.render_title(chunks[3], buf);
+        self.render_title(chunks[2], buf);
 
         // Render card grid
-        self.render_card_grid(chunks[5], buf, cols);
+        self.render_card_grid(chunks[4], buf, cols);
 
         // Render separator
-        self.render_separator(chunks[6], buf);
+        self.render_separator(chunks[5], buf);
 
         // Render keybindings
-        self.render_keybindings(chunks[7], buf);
+        self.render_keybindings(chunks[6], buf);
     }
 }
 


### PR DESCRIPTION
## What

The navigation bar shifted down a line whenever you switched away from the **Overview** tab.

Overview rendered its tab bar on the very top row, but every other dashboard tab (Stats / Models / Projects / Audit) **and** the source/project drilldown views each reserved a blank top-padding row above the bar. So leaving Overview pushed the whole top bar down one line.

This removes that leading padding row from those views so the tab bar sits on the top row everywhere, and updates the documented layout overhead in `effective_visible_rows` to match (Dashboard 7→6, detail 8→7) so scroll math stays correct.

## Before / After

### Overview — unchanged (already on the top row)

| Before | After |
|---|---|
| ![Overview before](https://i.cubityfir.st/WindowsTerminal_SN3dbq2rbZ.png) | ![Overview after](https://i.cubityfir.st/WindowsTerminal_8TP0DJj9ko.png) |

### Stats — nav bar moves up to the top row

| Before | After |
|---|---|
| ![Stats before](https://i.cubityfir.st/WindowsTerminal_DAKtY9LYgM.png) | ![Stats after](https://i.cubityfir.st/WindowsTerminal_ugW8IDRvrZ.png) |

(Models, Projects, Audit and the source/project drilldown pages get the same one-line shift.)

## Changes

- `src/tui/widgets/{stats,models,projects,audit,source_detail}.rs` — drop the leading `Constraint::Length(1)` top-padding row; tab bar / content now render from row 0.
- `src/tui/app.rs` — `effective_visible_rows` overhead constants updated (Dashboard 7→6, detail 8→7).
- `overview.rs` is untouched (it already rendered on the top row).

## Testing

- 184 TUI tests pass (`cargo test --lib tui`)
- `cargo fmt --check` clean
- `cargo clippy --all-targets` — no warnings
- release build OK
