### PR TITLE
feat(parser): add Antigravity IDE/CLI token tracking

### DIFF
--- a/.claude/ai-context/architecture.md
+++ b/.claude/ai-context/architecture.md
@@ -53,7 +53,7 @@ trait CLIParser: Send + Sync {
 | GeminiParser (qwen) | JSON + JSONL | ~/.qwen/tmp/*/chats/ | ✅ Qwen Code (Gemini fork, source="qwen") |
 | OpenCodeParser | SQLite (v1.2.0+) + JSON fallback | ~/.local/share/opencode/{opencode.db, storage/message/} | ✅ |
 | PiAgentParser | JSONL | ~/.pi/agent/sessions/ | ✅ |
-| (Antigravity) | — | ~/.gemini/antigravity-cli/ | ⚠️ detected, unsupported (no file-readable usage) |
+| AntigravityParser | SQLite + protobuf blobs | ~/.gemini/antigravity-{ide,cli}/conversations/*.db | ✅ (gen_metadata → ChatModelMetadata/ModelUsageStats) |
 
 ## Data Flow
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@
 
 **비용 기록을 절대 잃지 않는 토큰 & 비용 트래커.** 대부분의 도구는 매 실행마다 CLI 세션 파일을 다시 읽습니다 — 그래서 Claude Code가 30일 후 파일을 삭제하면 비용 기록도 함께 사라집니다. toktrack은 **영구 캐시**를 유지해 기록이 살아남습니다.
 
-**모든 AI 코딩 CLI**의 사용량을 한 곳에서 — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent 통합 대시보드. Rust 기반이라 대용량 기록에서도 빠릅니다 (simd-json + rayon).
+**모든 AI 코딩 CLI**의 사용량을 한 곳에서 — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent, Antigravity 통합 대시보드. Rust 기반이라 대용량 기록에서도 빠릅니다 (simd-json + rayon).
 
 ![toktrack overview](assets/demo.gif)
 
@@ -25,7 +25,7 @@
 ## 주요 기능
 
 - **데이터 보존** — 영구 캐시로 CLI가 세션 파일을 삭제한 뒤에도 비용 기록 유지
-- **멀티 CLI 지원** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent 한 곳에서
+- **멀티 CLI 지원** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent, Antigravity 한 곳에서
 - **TUI 대시보드** — 5개 탭 (Overview, Stats, Models, Projects, Audit), 일별/주별/월별 뷰
 - **프로젝트별 분석** — Projects 탭에서 프로젝트(세션 작업 디렉토리)별 토큰/비용 표시 (기록하는 CLI 한정). 프로젝트를 열면 일별·모델별 분석으로 드릴다운. 프로젝트를 기록하지 않는 CLI는 `(no project)`로 묶임. 프로젝트 상세는 캐시되므로 CLI의 30일 삭제 후에도 유지
 - **CLI 명령어** — `daily`, `weekly`, `monthly`, `stats` (JSON 출력 지원)

--- a/README.ko.md
+++ b/README.ko.md
@@ -149,7 +149,7 @@ zsh/bash/fish 몇 줄이면 됩니다 — **[셸 통합 가이드](docs/shell-in
 | PI Agent | ✅ | `~/.pi/agent/sessions/` |
 | Antigravity | ✅ | `~/.gemini/antigravity-{ide,cli}/conversations/*.db` |
 
-> 자체 비용을 기록하지 않는 소스(Gemini, Qwen, Codex, 최신 Claude 로그)의 비용은
+> 자체 비용을 기록하지 않는 소스(Gemini, Qwen, Codex, Antigravity, 최신 Claude 로그)의 비용은
 > [LiteLLM](https://github.com/BerriAI/litellm) 가격으로 계산되며 `~` 마커(추정치)로 표시됩니다.
 > 네트워크가 없을 때도 번들된 스냅샷으로 가격 계산이 동작합니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@
 - **데이터 보존** — 영구 캐시로 CLI가 세션 파일을 삭제한 뒤에도 비용 기록 유지
 - **멀티 CLI 지원** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent 한 곳에서
 - **TUI 대시보드** — 5개 탭 (Overview, Stats, Models, Projects, Audit), 일별/주별/월별 뷰
-- **프로젝트별 분석** — Projects 탭에서 프로젝트(세션 작업 디렉토리)별 토큰/비용 표시 (기록하는 CLI: Claude Code, Codex, OpenCode, PI Agent, Gemini CLI, Qwen Code). 프로젝트를 열면 일별·모델별 분석으로 드릴다운. 프로젝트를 기록하지 않는 CLI는 `(no project)`로 묶임. 프로젝트 상세는 캐시되므로 CLI의 30일 삭제 후에도 유지
+- **프로젝트별 분석** — Projects 탭에서 프로젝트(세션 작업 디렉토리)별 토큰/비용 표시 (기록하는 CLI 한정). 프로젝트를 열면 일별·모델별 분석으로 드릴다운. 프로젝트를 기록하지 않는 CLI는 `(no project)`로 묶임. 프로젝트 상세는 캐시되므로 CLI의 30일 삭제 후에도 유지
 - **CLI 명령어** — `daily`, `weekly`, `monthly`, `stats` (JSON 출력 지원)
 - **사용량 리포트** — 공유 가능한 텍스트 & SVG 영수증 (`toktrack report`)
 - **대용량에서도 빠름** — simd-json + rayon 병렬 파싱 (~3 GiB/s), 캐시 시 ~0.04초
@@ -147,7 +147,7 @@ zsh/bash/fish 몇 줄이면 됩니다 — **[셸 통합 가이드](docs/shell-in
 | Qwen Code | ✅ | `~/.qwen/tmp/*/chats/` |
 | OpenCode | ✅ | `~/.local/share/opencode/storage/message/` |
 | PI Agent | ✅ | `~/.pi/agent/sessions/` |
-| Antigravity | ⚠️ 감지됨, 미지원 | `~/.gemini/antigravity-cli/` (로컬 파일에 토큰 사용량 없음) |
+| Antigravity | ✅ | `~/.gemini/antigravity-{ide,cli}/conversations/*.db` |
 
 > 자체 비용을 기록하지 않는 소스(Gemini, Qwen, Codex, 최신 Claude 로그)의 비용은
 > [LiteLLM](https://github.com/BerriAI/litellm) 가격으로 계산되며 `~` 마커(추정치)로 표시됩니다.
@@ -273,7 +273,7 @@ cargo bench   # 벤치마크 실행
 
 ## 로드맵
 
-현재 6개 CLI 지원 (Claude Code, Codex, Gemini, Qwen Code, OpenCode, PI Agent) — [지원하는 AI CLI](#지원하는-ai-cli) 참조. 예정: 실시간/번레이트 모니터링, MCP 서버 / statusline, 추가 CLI(Goose, Amp, Kimi, Copilot).
+현재 7개 CLI 지원 (Claude Code, Codex, Gemini, Qwen Code, OpenCode, PI Agent, Antigravity) — [지원하는 AI CLI](#지원하는-ai-cli) 참조. 예정: 실시간/번레이트 모니터링, MCP 서버 / statusline, 추가 CLI(Goose, Amp, Kimi, Copilot).
 
 ## 기여하기
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ existing snapshot/cache for that remote.
 | PI Agent | ✅ | `~/.pi/agent/sessions/` |
 | Antigravity | ✅ | `~/.gemini/antigravity-{ide,cli}/conversations/*.db` |
 
-> Costs from sources that don't record their own price (Gemini, Qwen, Codex, and modern Claude logs)
+> Costs from sources that don't record their own price (Gemini, Qwen, Codex, Antigravity, and modern Claude logs)
 > are computed from [LiteLLM](https://github.com/BerriAI/litellm) pricing and shown with a `~` marker
 > (estimated). Pricing works offline via a bundled snapshot when the network is unavailable.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **The token & cost tracker that never loses your history.** Most tools re-read your CLI's session files on every run — so when Claude Code deletes them after 30 days, your cost history goes with them. toktrack keeps a **persistent cache**, so your history survives.
 
-Track usage across **all your AI coding CLIs** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, and PI Agent — in one dashboard. Built in Rust, so it stays fast even on huge histories (simd-json + rayon).
+Track usage across **all your AI coding CLIs** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent, and Antigravity — in one dashboard. Built in Rust, so it stays fast even on huge histories (simd-json + rayon).
 
 ![toktrack overview](assets/demo.gif)
 
@@ -29,7 +29,7 @@ Track usage across **all your AI coding CLIs** — Claude Code, Codex CLI, Gemin
 ## Features
 
 - **Data Preservation** — Persistent cache keeps your cost history even after a CLI deletes its own session files
-- **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent in one place
+- **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent, Antigravity in one place
 - **TUI Dashboard** — 5 tabs (Overview, Stats, Models, Projects, Audit) with daily/weekly/monthly views
 - **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
 - **CLI Commands** — `daily`, `weekly`, `monthly`, `stats` with JSON output support

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Track usage across **all your AI coding CLIs** — Claude Code, Codex CLI, Gemin
 - **Data Preservation** — Persistent cache keeps your cost history even after a CLI deletes its own session files
 - **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent in one place
 - **TUI Dashboard** — 5 tabs (Overview, Stats, Models, Projects, Audit) with daily/weekly/monthly views
-- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one — currently Claude Code, Codex, OpenCode, PI Agent, Gemini CLI, and Qwen Code. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
+- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
 - **CLI Commands** — `daily`, `weekly`, `monthly`, `stats` with JSON output support
 - **Usage Reports** — Shareable text & SVG receipts via `toktrack report`
 - **Fast on huge histories** — simd-json + rayon parallel parsing (~3 GiB/s); cached runs in ~0.04s
@@ -208,7 +208,7 @@ existing snapshot/cache for that remote.
 | Qwen Code | ✅ | `~/.qwen/tmp/*/chats/` |
 | OpenCode | ✅ | `~/.local/share/opencode/storage/message/` |
 | PI Agent | ✅ | `~/.pi/agent/sessions/` |
-| Antigravity | ⚠️ detected, unsupported | `~/.gemini/antigravity-cli/` (no file-readable token usage) |
+| Antigravity | ✅ | `~/.gemini/antigravity-{ide,cli}/conversations/*.db` |
 
 > Costs from sources that don't record their own price (Gemini, Qwen, Codex, and modern Claude logs)
 > are computed from [LiteLLM](https://github.com/BerriAI/litellm) pricing and shown with a `~` marker
@@ -335,7 +335,7 @@ cargo bench   # Benchmarks
 
 ## Roadmap
 
-Now tracking 6 CLIs (Claude Code, Codex, Gemini, Qwen Code, OpenCode, PI Agent) — see [Supported AI CLIs](#supported-ai-clis). Planned: live/burn-rate monitoring, MCP server / statusline, more CLIs (Goose, Amp, Kimi, Copilot).
+Now tracking 7 CLIs (Claude Code, Codex, Gemini, Qwen Code, OpenCode, PI Agent, Antigravity) — see [Supported AI CLIs](#supported-ai-clis). Planned: live/burn-rate monitoring, MCP server / statusline, more CLIs (Goose, Amp, Kimi, Copilot).
 
 ## Contributing
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -39,7 +39,7 @@ brew install toktrack
 
 - **Ultra-Fast Parsing** — simd-json + rayon parallel processing (~3 GiB/s throughput)
 - **TUI Dashboard** — 5 tabs (Overview, Stats, Models, Projects, Audit) with daily/weekly/monthly views
-- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one — currently Claude Code, Codex, OpenCode, PI Agent, Gemini CLI, and Qwen Code. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
+- **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
 - **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent
 - **CLI Commands** — `daily`, `weekly`, `monthly`, `stats` with JSON output
 - **Data Preservation** — Cached daily summaries survive CLI data deletion

--- a/npm/README.md
+++ b/npm/README.md
@@ -4,7 +4,7 @@
 [![npm](https://img.shields.io/npm/v/toktrack)](https://www.npmjs.com/package/toktrack)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/mag123c/toktrack/blob/main/LICENSE)
 
-Ultra-fast token & cost tracker for Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, and PI Agent. Built with Rust for ultra-fast performance (simd-json + rayon).
+Ultra-fast token & cost tracker for Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent, and Antigravity. Built with Rust for ultra-fast performance (simd-json + rayon).
 
 > **⚠️ Did you know?** Claude Code **deletes your session data after 30 days** by default. Once deleted, your token usage and cost history are gone forever — unless you preserve them.
 
@@ -40,7 +40,7 @@ brew install toktrack
 - **Ultra-Fast Parsing** — simd-json + rayon parallel processing (~3 GiB/s throughput)
 - **TUI Dashboard** — 5 tabs (Overview, Stats, Models, Projects, Audit) with daily/weekly/monthly views
 - **Per-Project Breakdown** — the Projects tab shows token & cost usage per project (the session working directory), for CLIs that record one. Drill into any project for its day-by-day, per-model breakdown. Usage from CLIs that don't record a project is grouped under `(no project)`. Project details are cached, so they survive past the CLI's 30-day deletion
-- **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent
+- **Multi-CLI Support** — Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, PI Agent, Antigravity
 - **CLI Commands** — `daily`, `weekly`, `monthly`, `stats` with JSON output
 - **Data Preservation** — Cached daily summaries survive CLI data deletion
 
@@ -51,8 +51,10 @@ brew install toktrack
 | Claude Code | `~/.claude/projects/` |
 | Codex CLI | `~/.codex/sessions/` |
 | Gemini CLI | `~/.gemini/tmp/*/chats/` |
+| Qwen Code | `~/.qwen/tmp/*/chats/` |
 | OpenCode | `~/.local/share/opencode/storage/message/` |
 | PI Agent | `~/.pi/agent/sessions/` |
+| Antigravity | `~/.gemini/antigravity-{ide,cli}/conversations/*.db` |
 
 ## Supported Platforms
 

--- a/src/parsers/antigravity.rs
+++ b/src/parsers/antigravity.rs
@@ -222,10 +222,20 @@ fn decode_entry(
     let reasoning_tokens = proto::varint(usage, 9).unwrap_or(0);
     let output_tokens = proto::varint(usage, 10).unwrap_or(0);
 
-    // Skip rows with no usage (e.g. interrupted/empty generations).
-    if input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens + reasoning_tokens
-        == 0
-    {
+    // Skip rows with no usage (e.g. interrupted/empty generations). Sum with
+    // `saturating_add`: the counts are raw varints from an untrusted blob, so a
+    // corrupt DB could carry oversized values that would overflow a plain `+`
+    // (panic in debug, wrap in release) — the module contract is skip, never panic.
+    let total = [
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_creation_tokens,
+        reasoning_tokens,
+    ]
+    .into_iter()
+    .fold(0u64, u64::saturating_add);
+    if total == 0 {
         return None;
     }
 
@@ -476,6 +486,17 @@ mod tests {
     }
 
     fn seed_db(root: &Path, variant: &str, db_name: &str, uri: &str, traj_id: &str, rows: &[Row]) {
+        seed_db_with_traj(root, variant, db_name, &traj_meta_blob(uri), traj_id, rows);
+    }
+
+    fn seed_db_with_traj(
+        root: &Path,
+        variant: &str,
+        db_name: &str,
+        traj_blob: &[u8],
+        traj_id: &str,
+        rows: &[Row],
+    ) {
         let dir = root.join(variant).join("conversations");
         std::fs::create_dir_all(&dir).unwrap();
         let conn = Connection::open(dir.join(db_name)).unwrap();
@@ -488,7 +509,7 @@ mod tests {
         .unwrap();
         conn.execute(
             "INSERT INTO trajectory_metadata_blob (id, data) VALUES ('main', ?)",
-            params![traj_meta_blob(uri)],
+            params![traj_blob],
         )
         .unwrap();
         conn.execute(
@@ -515,6 +536,30 @@ mod tests {
             idx,
             data: gen_blob(&cmm, &format!("uuid-{idx}")),
         }
+    }
+
+    /// ChatModelMetadata with optionally-omitted usage (f4) / start (f9) — used to
+    /// exercise the missing-usage skip and the timestamp→mtime fallback branches.
+    fn cmm_parts(usage: Option<&[u8]>, start: Option<&[u8]>, model: &str) -> Vec<u8> {
+        let mut m = Vec::new();
+        if let Some(u) = usage {
+            field_bytes(&mut m, 4, u);
+        }
+        if let Some(s) = start {
+            field_bytes(&mut m, 9, s);
+        }
+        field_bytes(&mut m, 19, model.as_bytes());
+        m
+    }
+
+    /// trajectory_metadata_blob carrying ONLY the nested field 1→1 URI (older
+    /// layout, no field 7) — exercises the fallback path in `read_project`.
+    fn traj_meta_blob_field1_only(uri: &str) -> Vec<u8> {
+        let mut inner = Vec::new();
+        field_bytes(&mut inner, 1, uri.as_bytes());
+        let mut t = Vec::new();
+        field_bytes(&mut t, 1, &inner);
+        t
     }
 
     // ===== tests =====
@@ -700,5 +745,163 @@ mod tests {
         assert!(entries
             .iter()
             .all(|e| e.source.as_deref() == Some("antigravity")));
+    }
+
+    #[test]
+    fn test_dedup_same_response_id_within_db_collapses() {
+        // Two rows in ONE DB sharing a response_id have the same dedup key
+        // (response_id:trajectory_id, since trajectory_id is constant per DB),
+        // so they collapse to a single entry.
+        let tmp = TempDir::new().unwrap();
+        seed_db(
+            tmp.path(),
+            "antigravity-ide",
+            "t.db",
+            "file:///work/x",
+            "traj-1",
+            &[
+                usage_row(1, 10, 5, 0, 0, 0, "dup"),
+                usage_row(2, 20, 7, 0, 0, 0, "dup"),
+            ],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        assert_eq!(parser.parse_all().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_same_response_id_across_ide_and_cli_both_survive() {
+        // The same response_id in two DBs with DIFFERENT trajectory_ids yields
+        // distinct dedup keys, so both are kept. Pins the intended cross-source
+        // behavior so a future trajectory_id change can't silently collapse them.
+        let tmp = TempDir::new().unwrap();
+        seed_db(
+            tmp.path(),
+            "antigravity-ide",
+            "ide.db",
+            "file:///work/x",
+            "traj-ide",
+            &[usage_row(1, 10, 5, 0, 0, 0, "same")],
+        );
+        seed_db(
+            tmp.path(),
+            "antigravity-cli",
+            "cli.db",
+            "file:///work/y",
+            "traj-cli",
+            &[usage_row(1, 10, 5, 0, 0, 0, "same")],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        assert_eq!(parser.parse_all().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_missing_usage_submessage_skipped() {
+        // A valid ChatModelMetadata with model + timestamp but NO usage (f4) is
+        // skipped — distinct from the malformed-blob and zero-token paths.
+        let tmp = TempDir::new().unwrap();
+        let start = chat_start(1_782_298_900, 0);
+        let no_usage = cmm_parts(None, Some(&start), "gemini-3-flash-a");
+        seed_db(
+            tmp.path(),
+            "antigravity-ide",
+            "t.db",
+            "file:///work/x",
+            "traj-1",
+            &[
+                Row {
+                    idx: 1,
+                    data: gen_blob(&no_usage, "uuid-1"),
+                },
+                usage_row(2, 10, 5, 0, 0, 0, "good"),
+            ],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        let entries = parser.parse_all().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].message_id.as_deref(), Some("good"));
+    }
+
+    #[test]
+    fn test_missing_timestamp_falls_back_to_file_mtime() {
+        // No chat_start (f9) → decode_timestamp returns None → timestamp falls back
+        // to the DB file's mtime.
+        let tmp = TempDir::new().unwrap();
+        let usage = model_usage_stats(10, 5, 0, 0, 0, "r");
+        let no_start = cmm_parts(Some(&usage), None, "gemini-3-flash-a");
+        seed_db(
+            tmp.path(),
+            "antigravity-ide",
+            "t.db",
+            "file:///work/x",
+            "traj-1",
+            &[Row {
+                idx: 1,
+                data: gen_blob(&no_start, "uuid-1"),
+            }],
+        );
+        let db = tmp
+            .path()
+            .join("antigravity-ide")
+            .join("conversations")
+            .join("t.db");
+        let mtime_secs = std::fs::metadata(&db)
+            .unwrap()
+            .modified()
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        let entries = parser.parse_all().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].timestamp.timestamp(), mtime_secs);
+    }
+
+    #[test]
+    fn test_project_resolves_via_field1_fallback() {
+        // Older layout: trajectory_metadata_blob has ONLY the nested field 1→1 URI
+        // (no field 7). The project must still resolve.
+        let tmp = TempDir::new().unwrap();
+        seed_db_with_traj(
+            tmp.path(),
+            "antigravity-ide",
+            "t.db",
+            &traj_meta_blob_field1_only("file:///g:/Scripts/proj"),
+            "traj-1",
+            &[usage_row(1, 10, 5, 0, 0, 0, "r")],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        let entries = parser.parse_all().unwrap();
+        assert_eq!(entries[0].project.as_deref(), Some("g:/Scripts/proj"));
+    }
+
+    #[test]
+    fn test_oversized_token_varints_do_not_panic() {
+        // Corrupt/adversarial usage counts near u64::MAX must not overflow-panic
+        // the zero-check sum; the row is still produced.
+        let tmp = TempDir::new().unwrap();
+        // Build the usage blob directly (model_usage_stats would overflow its own
+        // f3 = thinking + response computation with MAX inputs).
+        let mut usage = Vec::new();
+        field_varint(&mut usage, 2, u64::MAX); // input
+        field_varint(&mut usage, 10, u64::MAX); // response output
+        field_varint(&mut usage, 5, u64::MAX); // cache read
+        field_bytes(&mut usage, 11, b"big");
+        let cmm = chat_model_metadata(&usage, &chat_start(1_782_298_900, 0), "gemini-3-flash-a");
+        seed_db(
+            tmp.path(),
+            "antigravity-ide",
+            "t.db",
+            "file:///work/x",
+            "traj-1",
+            &[Row {
+                idx: 1,
+                data: gen_blob(&cmm, "uuid-1"),
+            }],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        let entries = parser.parse_all().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].input_tokens, u64::MAX);
     }
 }

--- a/src/parsers/antigravity.rs
+++ b/src/parsers/antigravity.rs
@@ -1,0 +1,704 @@
+//! Antigravity IDE / CLI parser.
+//!
+//! Antigravity (Google's agentic IDE, built on Codeium/Windsurf tech) persists
+//! agent token usage locally in **per-conversation SQLite databases**, as
+//! **protobuf blobs** — not JSON. One DB per trajectory:
+//! - IDE: `~/.gemini/antigravity-ide/conversations/<trajectory_id>.db`
+//! - CLI: `~/.gemini/antigravity-cli/conversations/<trajectory_id>.db`
+//!
+//! Token usage lives in the `gen_metadata` table (one row per model
+//! generation). Each `data` blob is a `ChatModelMetadata` message:
+//! - field 4  `usage` → `ModelUsageStats`
+//!     - 2 `input_tokens`            (non-cached input)
+//!     - 3 `output_tokens`          (= thinking + response; not used directly)
+//!     - 4 `cache_write_tokens`
+//!     - 5 `cache_read_tokens`
+//!     - 9 `thinking_output_tokens` (reasoning)
+//!     - 10 `response_output_tokens` (visible output)
+//!     - 11 `response_id`           (string; unique per generation)
+//! - field 9  `chat_start_metadata` → field 4 `Timestamp {1 seconds, 2 nanos}`
+//! - field 19 `response_model`      (string model id, e.g. `gemini-3-flash-a`)
+//!
+//! The session's working directory (used as the project key) is stored once per
+//! DB in `trajectory_metadata_blob` (field 7, or field 1→1) as a `file://` URI.
+//!
+//! The field numbers were reverse-engineered from the language-server binary's
+//! embedded proto descriptors and validated against real sessions
+//! (`output_tokens == thinking + response`). They may drift across Antigravity
+//! versions, so decoding is defensive: any malformed/under-specified blob is
+//! skipped rather than panicking.
+
+use crate::types::{Result, UsageEntry};
+use chrono::{DateTime, Utc};
+use rusqlite::{Connection, OpenFlags};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use super::CLIParser;
+
+/// Minimal protobuf wire-format reader. Only what we need: iterate top-level
+/// fields and pluck the first varint / length-delimited value by field number.
+/// No schema, no allocation — slices borrow the input buffer.
+mod proto {
+    /// A single decoded wire value. Fixed-width variants are retained only so
+    /// iteration stays in sync; the getters ignore them.
+    enum Wire<'a> {
+        Varint(u64),
+        Bytes(&'a [u8]),
+        /// 32/64-bit fixed fields. We never read the value — the variant exists
+        /// only so iteration stays byte-aligned past such fields.
+        Fixed,
+    }
+
+    fn read_varint(buf: &[u8], pos: &mut usize) -> Option<u64> {
+        let mut result = 0u64;
+        let mut shift = 0u32;
+        loop {
+            let byte = *buf.get(*pos)?;
+            *pos += 1;
+            result |= u64::from(byte & 0x7f) << shift;
+            if byte & 0x80 == 0 {
+                return Some(result);
+            }
+            shift += 7;
+            if shift >= 64 {
+                return None;
+            }
+        }
+    }
+
+    struct Reader<'a> {
+        buf: &'a [u8],
+        pos: usize,
+    }
+
+    impl<'a> Iterator for Reader<'a> {
+        type Item = (u64, Wire<'a>);
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.pos >= self.buf.len() {
+                return None;
+            }
+            let tag = read_varint(self.buf, &mut self.pos)?;
+            let field = tag >> 3;
+            let value = match tag & 7 {
+                0 => Wire::Varint(read_varint(self.buf, &mut self.pos)?),
+                1 => {
+                    let end = self.pos.checked_add(8)?;
+                    if end > self.buf.len() {
+                        return None;
+                    }
+                    self.pos = end;
+                    Wire::Fixed
+                }
+                2 => {
+                    let len = read_varint(self.buf, &mut self.pos)? as usize;
+                    let end = self.pos.checked_add(len)?;
+                    let slice = self.buf.get(self.pos..end)?;
+                    self.pos = end;
+                    Wire::Bytes(slice)
+                }
+                5 => {
+                    let end = self.pos.checked_add(4)?;
+                    if end > self.buf.len() {
+                        return None;
+                    }
+                    self.pos = end;
+                    Wire::Fixed
+                }
+                _ => return None, // unsupported wire type (3/4 groups): stop
+            };
+            Some((field, value))
+        }
+    }
+
+    fn fields(buf: &[u8]) -> Reader<'_> {
+        Reader { buf, pos: 0 }
+    }
+
+    /// First varint value for `field` (0 if absent — callers treat missing
+    /// token counts as zero).
+    pub fn varint(buf: &[u8], field: u64) -> Option<u64> {
+        fields(buf).find_map(|(f, v)| match v {
+            Wire::Varint(n) if f == field => Some(n),
+            _ => None,
+        })
+    }
+
+    /// First length-delimited value (sub-message or string bytes) for `field`.
+    pub fn bytes(buf: &[u8], field: u64) -> Option<&[u8]> {
+        fields(buf).find_map(|(f, v)| match v {
+            Wire::Bytes(b) if f == field => Some(b),
+            _ => None,
+        })
+    }
+
+    /// First length-delimited value for `field` decoded as UTF-8.
+    pub fn string(buf: &[u8], field: u64) -> Option<&str> {
+        bytes(buf, field).and_then(|b| std::str::from_utf8(b).ok())
+    }
+}
+
+/// Parser for Antigravity IDE/CLI usage data.
+pub struct AntigravityParser {
+    /// `~/.gemini` root (honors `GEMINI_CLI_HOME`). Conversation DBs live under
+    /// `antigravity-ide/conversations/` and `antigravity-cli/conversations/`.
+    data_dir: PathBuf,
+    source: &'static str,
+}
+
+impl AntigravityParser {
+    /// Create a parser with the default data directory (`~/.gemini`, or
+    /// `$GEMINI_CLI_HOME/.gemini`).
+    pub fn new() -> Self {
+        let base = super::discovery::first_env_dir(&["GEMINI_CLI_HOME"])
+            .or_else(|| directories::BaseDirs::new().map(|d| d.home_dir().to_path_buf()))
+            .unwrap_or_else(|| {
+                eprintln!("[toktrack] Warning: Could not determine home directory");
+                PathBuf::from(".")
+            });
+        Self::with_data_dir(base.join(".gemini"))
+    }
+
+    /// Create a parser rooted at a custom `.gemini`-style directory (the dir that
+    /// directly contains `antigravity-ide/` and/or `antigravity-cli/`).
+    pub fn with_data_dir(data_dir: PathBuf) -> Self {
+        Self {
+            data_dir,
+            source: "antigravity",
+        }
+    }
+
+    /// Read every `gen_metadata` blob from one conversation DB and decode it into
+    /// a `UsageEntry`. Open failures and undecodable rows yield nothing (warned,
+    /// never fatal) so one corrupt DB can't sink the whole scan.
+    fn parse_db(&self, path: &Path) -> Vec<UsageEntry> {
+        let conn = match Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "[toktrack] Warning: failed to open Antigravity db {:?}: {}",
+                    path, e
+                );
+                return Vec::new();
+            }
+        };
+
+        let project = read_project(&conn);
+        let trajectory_id = read_trajectory_id(&conn);
+        let fallback_ts = file_mtime(path);
+
+        read_gen_metadata(&conn)
+            .into_iter()
+            .filter_map(|data| {
+                decode_entry(
+                    &data,
+                    project.as_deref(),
+                    trajectory_id.as_deref(),
+                    fallback_ts,
+                    self.source,
+                )
+            })
+            .collect()
+    }
+}
+
+/// Decode one `gen_metadata` blob (`ChatModelMetadata`) into a `UsageEntry`.
+/// Returns `None` for blobs missing the usage sub-message or carrying no tokens.
+fn decode_entry(
+    data: &[u8],
+    project: Option<&str>,
+    trajectory_id: Option<&str>,
+    fallback_ts: DateTime<Utc>,
+    source: &'static str,
+) -> Option<UsageEntry> {
+    let cmm = proto::bytes(data, 1)?; // ChatModelMetadata
+    let usage = proto::bytes(cmm, 4)?; // ModelUsageStats
+
+    let input_tokens = proto::varint(usage, 2).unwrap_or(0);
+    let cache_creation_tokens = proto::varint(usage, 4).unwrap_or(0);
+    let cache_read_tokens = proto::varint(usage, 5).unwrap_or(0);
+    let reasoning_tokens = proto::varint(usage, 9).unwrap_or(0);
+    let output_tokens = proto::varint(usage, 10).unwrap_or(0);
+
+    // Skip rows with no usage (e.g. interrupted/empty generations).
+    if input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens + reasoning_tokens
+        == 0
+    {
+        return None;
+    }
+
+    let message_id = proto::string(usage, 11).map(String::from);
+    let model = proto::string(cmm, 19).map(String::from);
+    let timestamp = decode_timestamp(cmm).unwrap_or(fallback_ts);
+
+    Some(UsageEntry {
+        timestamp,
+        model,
+        // `input_tokens` is already the non-cached input (cache reads are a
+        // separate field), matching the v2 contract — no subtraction needed.
+        input_tokens,
+        // `response_output_tokens` is the visible output; `thinking_output_tokens`
+        // is reasoning. Their sum equals ModelUsageStats `output_tokens` (f3), so
+        // splitting here keeps the contract (output excludes reasoning) without
+        // double-counting.
+        output_tokens,
+        cache_read_tokens,
+        cache_creation_tokens,
+        reasoning_tokens,
+        cache_creation_5m_tokens: 0,
+        cache_creation_1h_tokens: 0,
+        web_search_requests: 0,
+        web_fetch_requests: 0,
+        reported_total_tokens: None,
+        cost_usd: None,
+        message_id,
+        request_id: trajectory_id.map(String::from),
+        source: Some(source.into()),
+        provider: None,
+        project: project.map(String::from),
+    })
+}
+
+/// `ChatModelMetadata.chat_start_metadata(9).timestamp(4) = {seconds(1), nanos(2)}`.
+fn decode_timestamp(cmm: &[u8]) -> Option<DateTime<Utc>> {
+    let start = proto::bytes(cmm, 9)?;
+    let ts = proto::bytes(start, 4)?;
+    let seconds = i64::try_from(proto::varint(ts, 1)?).ok()?;
+    let nanos = u32::try_from(proto::varint(ts, 2).unwrap_or(0)).unwrap_or(0);
+    DateTime::from_timestamp(seconds, nanos)
+}
+
+/// Workspace folder URI from `trajectory_metadata_blob` (field 7, or field 1→1),
+/// normalized to a plain path for use as the project key.
+fn read_project(conn: &Connection) -> Option<String> {
+    let blob: Vec<u8> = conn
+        .query_row(
+            "SELECT data FROM trajectory_metadata_blob LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .ok()?;
+    let uri = proto::string(&blob, 7)
+        .or_else(|| proto::bytes(&blob, 1).and_then(|m| proto::string(m, 1)))?;
+    Some(workspace_path(uri))
+}
+
+/// Trajectory id (used as `request_id` for dedup), if the table is present.
+fn read_trajectory_id(conn: &Connection) -> Option<String> {
+    conn.query_row(
+        "SELECT trajectory_id FROM trajectory_meta LIMIT 1",
+        [],
+        |r| r.get(0),
+    )
+    .ok()
+}
+
+/// All `gen_metadata` blobs in insertion order. Missing table → empty.
+fn read_gen_metadata(conn: &Connection) -> Vec<Vec<u8>> {
+    let mut stmt = match conn.prepare("SELECT data FROM gen_metadata ORDER BY idx") {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let rows = match stmt.query_map([], |r| r.get::<_, Vec<u8>>(0)) {
+        Ok(rows) => rows,
+        Err(_) => return Vec::new(),
+    };
+    rows.filter_map(std::result::Result::ok).collect()
+}
+
+/// Strip the `file://` scheme and a leading slash before a Windows drive letter,
+/// e.g. `file:///g:/Scripts/x` → `g:/Scripts/x`; `file:///home/x` → `/home/x`.
+fn workspace_path(uri: &str) -> String {
+    let p = uri.strip_prefix("file://").unwrap_or(uri);
+    let bytes = p.as_bytes();
+    if bytes.len() >= 3 && bytes[0] == b'/' && bytes[2] == b':' {
+        p[1..].to_string()
+    } else {
+        p.to_string()
+    }
+}
+
+/// DB file mtime as a UTC datetime; falls back to `now` if unavailable. Used only
+/// when a row's embedded timestamp is missing.
+fn file_mtime(path: &Path) -> DateTime<Utc> {
+    path.metadata()
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .and_then(|d| DateTime::from_timestamp(d.as_secs() as i64, 0))
+        .unwrap_or_else(Utc::now)
+}
+
+impl Default for AntigravityParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CLIParser for AntigravityParser {
+    fn name(&self) -> &str {
+        self.source
+    }
+
+    fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+
+    /// Representative pattern. Actual collection globs both the IDE and CLI
+    /// `conversations/` directories via `collect_files`.
+    fn file_pattern(&self) -> &str {
+        "antigravity-ide/conversations/*.db"
+    }
+
+    fn collect_files(&self) -> Vec<PathBuf> {
+        let patterns = [
+            "antigravity-ide/conversations/*.db",
+            "antigravity-cli/conversations/*.db",
+        ];
+        let mut seen: HashSet<PathBuf> = HashSet::new();
+        let mut out = Vec::new();
+        for pat in patterns {
+            let full = self.data_dir.join(pat);
+            if let Ok(paths) = glob::glob(&full.to_string_lossy()) {
+                for p in paths.filter_map(std::result::Result::ok) {
+                    if seen.insert(p.clone()) {
+                        out.push(p);
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    fn parse_file(&self, path: &Path) -> Result<Vec<UsageEntry>> {
+        Ok(self.parse_db(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+    use tempfile::TempDir;
+
+    // ===== protobuf encode helpers (build fixture blobs) =====
+
+    fn enc_varint(out: &mut Vec<u8>, mut n: u64) {
+        loop {
+            let mut byte = (n & 0x7f) as u8;
+            n >>= 7;
+            if n != 0 {
+                byte |= 0x80;
+            }
+            out.push(byte);
+            if n == 0 {
+                break;
+            }
+        }
+    }
+
+    fn field_varint(out: &mut Vec<u8>, field: u64, n: u64) {
+        enc_varint(out, field << 3);
+        enc_varint(out, n);
+    }
+
+    fn field_bytes(out: &mut Vec<u8>, field: u64, b: &[u8]) {
+        enc_varint(out, (field << 3) | 2);
+        enc_varint(out, b.len() as u64);
+        out.extend_from_slice(b);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn model_usage_stats(
+        input: u64,
+        response_out: u64,
+        thinking: u64,
+        cache_read: u64,
+        cache_write: u64,
+        response_id: &str,
+    ) -> Vec<u8> {
+        let mut u = Vec::new();
+        field_varint(&mut u, 2, input);
+        field_varint(&mut u, 3, thinking + response_out); // output_tokens (= think+resp)
+        if cache_write > 0 {
+            field_varint(&mut u, 4, cache_write);
+        }
+        if cache_read > 0 {
+            field_varint(&mut u, 5, cache_read);
+        }
+        field_varint(&mut u, 9, thinking);
+        field_varint(&mut u, 10, response_out);
+        field_bytes(&mut u, 11, response_id.as_bytes());
+        u
+    }
+
+    fn chat_start(seconds: u64, nanos: u64) -> Vec<u8> {
+        let mut ts = Vec::new();
+        field_varint(&mut ts, 1, seconds);
+        field_varint(&mut ts, 2, nanos);
+        let mut start = Vec::new();
+        field_bytes(&mut start, 4, &ts);
+        start
+    }
+
+    fn chat_model_metadata(usage: &[u8], start: &[u8], model: &str) -> Vec<u8> {
+        let mut m = Vec::new();
+        field_bytes(&mut m, 4, usage);
+        field_bytes(&mut m, 9, start);
+        field_bytes(&mut m, 19, model.as_bytes());
+        m
+    }
+
+    /// Top-level `gen_metadata.data`: field 1 = ChatModelMetadata, field 4 = uuid.
+    fn gen_blob(cmm: &[u8], uuid: &str) -> Vec<u8> {
+        let mut g = Vec::new();
+        field_bytes(&mut g, 1, cmm);
+        field_bytes(&mut g, 4, uuid.as_bytes());
+        g
+    }
+
+    fn traj_meta_blob(uri: &str) -> Vec<u8> {
+        let mut inner = Vec::new();
+        field_bytes(&mut inner, 1, uri.as_bytes());
+        let mut t = Vec::new();
+        field_bytes(&mut t, 1, &inner);
+        field_bytes(&mut t, 7, uri.as_bytes());
+        t
+    }
+
+    // ===== fixture DB builder =====
+
+    struct Row {
+        idx: i64,
+        data: Vec<u8>,
+    }
+
+    fn seed_db(root: &Path, variant: &str, db_name: &str, uri: &str, traj_id: &str, rows: &[Row]) {
+        let dir = root.join(variant).join("conversations");
+        std::fs::create_dir_all(&dir).unwrap();
+        let conn = Connection::open(dir.join(db_name)).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB, size INTEGER);
+             CREATE TABLE trajectory_metadata_blob (id TEXT PRIMARY KEY, data BLOB);
+             CREATE TABLE trajectory_meta (trajectory_id TEXT, cascade_id TEXT, \
+               trajectory_type INTEGER, source INTEGER);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO trajectory_metadata_blob (id, data) VALUES ('main', ?)",
+            params![traj_meta_blob(uri)],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO trajectory_meta (trajectory_id, cascade_id, trajectory_type, source) \
+             VALUES (?, 'c', 4, 1)",
+            params![traj_id],
+        )
+        .unwrap();
+        for r in rows {
+            conn.execute(
+                "INSERT INTO gen_metadata (idx, data, size) VALUES (?, ?, ?)",
+                params![r.idx, r.data, r.data.len() as i64],
+            )
+            .unwrap();
+        }
+    }
+
+    /// One realistic assistant generation, mirroring real-session field layout.
+    fn usage_row(idx: i64, input: u64, resp: u64, think: u64, cr: u64, cw: u64, id: &str) -> Row {
+        let usage = model_usage_stats(input, resp, think, cr, cw, id);
+        let start = chat_start(1_782_298_884 + idx as u64, 0);
+        let cmm = chat_model_metadata(&usage, &start, "gemini-3-flash-a");
+        Row {
+            idx,
+            data: gen_blob(&cmm, &format!("uuid-{idx}")),
+        }
+    }
+
+    // ===== tests =====
+
+    #[test]
+    fn test_name_and_data_dir_with_env() {
+        let saved = std::env::var("GEMINI_CLI_HOME").ok();
+
+        std::env::remove_var("GEMINI_CLI_HOME");
+        let parser = AntigravityParser::new();
+        assert_eq!(parser.name(), "antigravity");
+        assert!(parser.data_dir().ends_with(".gemini"));
+
+        std::env::set_var("GEMINI_CLI_HOME", "/tmp/toktrack-ag-env");
+        assert_eq!(
+            AntigravityParser::new().data_dir(),
+            Path::new("/tmp/toktrack-ag-env/.gemini")
+        );
+
+        match saved {
+            Some(v) => std::env::set_var("GEMINI_CLI_HOME", v),
+            None => std::env::remove_var("GEMINI_CLI_HOME"),
+        }
+    }
+
+    #[test]
+    fn test_token_mapping_and_invariant() {
+        let tmp = TempDir::new().unwrap();
+        seed_db(
+            tmp.path(),
+            "antigravity-ide",
+            "t.db",
+            "file:///g:/Scripts/proj",
+            "traj-1",
+            &[usage_row(1, 4626, 1474, 577, 12208, 0, "resp-a")],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        let entries = parser.parse_all().unwrap();
+
+        assert_eq!(entries.len(), 1);
+        let e = &entries[0];
+        assert_eq!(e.model.as_deref(), Some("gemini-3-flash-a"));
+        assert_eq!(e.input_tokens, 4626);
+        assert_eq!(e.output_tokens, 1474); // response_output_tokens (visible only)
+        assert_eq!(e.reasoning_tokens, 577); // thinking_output_tokens
+        assert_eq!(e.cache_read_tokens, 12208);
+        assert_eq!(e.cache_creation_tokens, 0);
+        // total = 4626 + 1474 + 12208 + 0 + 577
+        assert_eq!(e.total_tokens(), 18885);
+        assert_eq!(e.source.as_deref(), Some("antigravity"));
+        assert_eq!(e.message_id.as_deref(), Some("resp-a"));
+        assert_eq!(e.request_id.as_deref(), Some("traj-1"));
+        // file:///g:/... → g:/... (drive-letter slash stripped)
+        assert_eq!(e.project.as_deref(), Some("g:/Scripts/proj"));
+        // timestamp decoded from chat_start_metadata (1_782_298_884 + idx)
+        assert_eq!(e.timestamp.timestamp(), 1_782_298_885);
+    }
+
+    #[test]
+    fn test_cache_write_mapped() {
+        let tmp = TempDir::new().unwrap();
+        seed_db(
+            tmp.path(),
+            "antigravity-ide",
+            "t.db",
+            "file:///work/x",
+            "traj-1",
+            &[usage_row(1, 100, 50, 10, 0, 77, "r")],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        let entries = parser.parse_all().unwrap();
+        assert_eq!(entries[0].cache_creation_tokens, 77);
+        // unix-style path keeps its leading slash
+        assert_eq!(entries[0].project.as_deref(), Some("/work/x"));
+    }
+
+    #[test]
+    fn test_zero_token_rows_skipped() {
+        let tmp = TempDir::new().unwrap();
+        seed_db(
+            tmp.path(),
+            "antigravity-ide",
+            "t.db",
+            "file:///work/x",
+            "traj-1",
+            &[
+                usage_row(1, 0, 0, 0, 0, 0, "zero"),
+                usage_row(2, 10, 5, 0, 0, 0, "real"),
+            ],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        let entries = parser.parse_all().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].message_id.as_deref(), Some("real"));
+    }
+
+    #[test]
+    fn test_malformed_blob_skipped_good_kept() {
+        let tmp = TempDir::new().unwrap();
+        seed_db(
+            tmp.path(),
+            "antigravity-ide",
+            "t.db",
+            "file:///work/x",
+            "traj-1",
+            &[
+                Row {
+                    idx: 1,
+                    data: vec![0xff, 0xff, 0xff], // not valid protobuf
+                },
+                usage_row(2, 10, 5, 0, 0, 0, "good"),
+            ],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        let entries = parser.parse_all().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].message_id.as_deref(), Some("good"));
+    }
+
+    #[test]
+    fn test_open_failure_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("antigravity-ide").join("conversations");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("bad.db"), b"not a sqlite file").unwrap();
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        let entries = parser.parse_all().unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_collect_files_finds_ide_and_cli() {
+        let tmp = TempDir::new().unwrap();
+        seed_db(
+            tmp.path(),
+            "antigravity-ide",
+            "ide.db",
+            "file:///work/x",
+            "traj-ide",
+            &[usage_row(1, 10, 5, 0, 0, 0, "i")],
+        );
+        seed_db(
+            tmp.path(),
+            "antigravity-cli",
+            "cli.db",
+            "file:///work/y",
+            "traj-cli",
+            &[usage_row(1, 10, 5, 0, 0, 0, "c")],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        let files = parser.collect_files();
+        assert_eq!(files.len(), 2, "got: {files:?}");
+        assert!(files.iter().any(|f| f.to_string_lossy().contains("ide")));
+        assert!(files.iter().any(|f| f.to_string_lossy().contains("cli")));
+    }
+
+    #[test]
+    fn test_parse_all_aggregates_and_dedups() {
+        let tmp = TempDir::new().unwrap();
+        // Two distinct generations in IDE + one in CLI = 3 entries.
+        seed_db(
+            tmp.path(),
+            "antigravity-ide",
+            "ide.db",
+            "file:///work/x",
+            "traj-ide",
+            &[
+                usage_row(1, 10, 5, 0, 0, 0, "a"),
+                usage_row(2, 20, 7, 0, 0, 0, "b"),
+            ],
+        );
+        seed_db(
+            tmp.path(),
+            "antigravity-cli",
+            "cli.db",
+            "file:///work/y",
+            "traj-cli",
+            &[usage_row(1, 30, 9, 0, 0, 0, "c")],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        let entries = parser.parse_all().unwrap();
+        assert_eq!(entries.len(), 3);
+        assert!(entries
+            .iter()
+            .all(|e| e.source.as_deref() == Some("antigravity")));
+    }
+}

--- a/src/parsers/antigravity.rs
+++ b/src/parsers/antigravity.rs
@@ -7,7 +7,11 @@
 //! - CLI: `~/.gemini/antigravity-cli/conversations/<trajectory_id>.db`
 //!
 //! Token usage lives in the `gen_metadata` table (one row per model
-//! generation). Each `data` blob is a `ChatModelMetadata` message:
+//! generation). Each `data` blob is a wrapper message:
+//! - field 1  `metadata` → `ChatModelMetadata`
+//! - field 4  `generation_id` (uuid string; not used)
+//!
+//! The `ChatModelMetadata` (field 1) carries:
 //! - field 4  `usage` → `ModelUsageStats`
 //!     - 2 `input_tokens`            (non-cached input)
 //!     - 3 `output_tokens`          (= thinking + response; not used directly)
@@ -22,11 +26,13 @@
 //! The session's working directory (used as the project key) is stored once per
 //! DB in `trajectory_metadata_blob` (field 7, or field 1→1) as a `file://` URI.
 //!
-//! The field numbers were reverse-engineered from the language-server binary's
-//! embedded proto descriptors and validated against real sessions
-//! (`output_tokens == thinking + response`). They may drift across Antigravity
-//! versions, so decoding is defensive: any malformed/under-specified blob is
-//! skipped rather than panicking.
+//! The field numbers were reverse-engineered (2026-06-24) from the Antigravity
+//! IDE language-server binary's embedded proto descriptors
+//! (`resources/app/extensions/antigravity/bin/language_server_*`) and validated
+//! against real sessions (`output_tokens == thinking + response`). The binary
+//! exposes no semantic Antigravity version, so this layout is pinned to that
+//! extraction; field numbers may drift across versions, so decoding is defensive:
+//! any malformed/under-specified blob is skipped rather than panicking.
 
 use crate::types::{Result, UsageEntry};
 use chrono::{DateTime, Utc};
@@ -107,7 +113,7 @@ mod proto {
                     self.pos = end;
                     Wire::Fixed
                 }
-                _ => return None, // unsupported wire type (3/4 groups): stop
+                _ => return None, // unknown wire type (groups 3/4 or reserved 6/7): no schema to skip it, so stop
             };
             Some((field, value))
         }
@@ -118,7 +124,9 @@ mod proto {
     }
 
     /// First varint value for `field` (0 if absent — callers treat missing
-    /// token counts as zero).
+    /// token counts as zero). First-match is safe here: each field appears at
+    /// most once per blob, so protobuf's last-wins rule for singular scalars
+    /// never matters.
     pub fn varint(buf: &[u8], field: u64) -> Option<u64> {
         fields(buf).find_map(|(f, v)| match v {
             Wire::Varint(n) if f == field => Some(n),
@@ -127,6 +135,7 @@ mod proto {
     }
 
     /// First length-delimited value (sub-message or string bytes) for `field`.
+    /// Like `varint`, first-match is safe: each field occurs at most once per blob.
     pub fn bytes(buf: &[u8], field: u64) -> Option<&[u8]> {
         fields(buf).find_map(|(f, v)| match v {
             Wire::Bytes(b) if f == field => Some(b),
@@ -527,6 +536,33 @@ mod tests {
         }
     }
 
+    /// Like [`seed_db`] but omits the `trajectory_meta` table entirely, mirroring
+    /// older/partial DBs where `read_trajectory_id` returns `None` so `request_id`
+    /// is `None` and dedup falls back to the content arm.
+    fn seed_db_no_traj_meta(root: &Path, variant: &str, db_name: &str, uri: &str, rows: &[Row]) {
+        let dir = root.join(variant).join("conversations");
+        std::fs::create_dir_all(&dir).unwrap();
+        let conn = Connection::open(dir.join(db_name)).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB, size INTEGER);
+             CREATE TABLE trajectory_metadata_blob (id TEXT PRIMARY KEY, data BLOB);",
+        )
+        .unwrap();
+        let blob = traj_meta_blob(uri);
+        conn.execute(
+            "INSERT INTO trajectory_metadata_blob (id, data) VALUES ('main', ?)",
+            params![blob],
+        )
+        .unwrap();
+        for r in rows {
+            conn.execute(
+                "INSERT INTO gen_metadata (idx, data, size) VALUES (?, ?, ?)",
+                params![r.idx, r.data, r.data.len() as i64],
+            )
+            .unwrap();
+        }
+    }
+
     /// One realistic assistant generation, mirroring real-session field layout.
     fn usage_row(idx: i64, input: u64, resp: u64, think: u64, cr: u64, cw: u64, id: &str) -> Row {
         let usage = model_usage_stats(input, resp, think, cr, cw, id);
@@ -565,24 +601,19 @@ mod tests {
     // ===== tests =====
 
     #[test]
-    fn test_name_and_data_dir_with_env() {
-        let saved = std::env::var("GEMINI_CLI_HOME").ok();
-
-        std::env::remove_var("GEMINI_CLI_HOME");
-        let parser = AntigravityParser::new();
+    fn test_name_and_data_dir() {
+        // Do NOT mutate the process-global `GEMINI_CLI_HOME` here: it races with
+        // gemini.rs::test_gemini_cli_home_env_var (cargo runs both in one test
+        // binary in parallel). The override path is covered by gemini.rs and
+        // discovery.rs, since `new()` resolves it through the shared
+        // `discovery::first_env_dir(&["GEMINI_CLI_HOME"])`.
+        let parser = AntigravityParser::with_data_dir(PathBuf::from("/tmp/toktrack-ag/.gemini"));
         assert_eq!(parser.name(), "antigravity");
-        assert!(parser.data_dir().ends_with(".gemini"));
+        assert_eq!(parser.data_dir(), Path::new("/tmp/toktrack-ag/.gemini"));
 
-        std::env::set_var("GEMINI_CLI_HOME", "/tmp/toktrack-ag-env");
-        assert_eq!(
-            AntigravityParser::new().data_dir(),
-            Path::new("/tmp/toktrack-ag-env/.gemini")
-        );
-
-        match saved {
-            Some(v) => std::env::set_var("GEMINI_CLI_HOME", v),
-            None => std::env::remove_var("GEMINI_CLI_HOME"),
-        }
+        // `new()` only reads env (never writes), and the joined `.gemini` suffix
+        // holds regardless of `GEMINI_CLI_HOME`'s value, so this is race-safe.
+        assert!(AntigravityParser::new().data_dir().ends_with(".gemini"));
     }
 
     #[test]
@@ -616,6 +647,19 @@ mod tests {
         assert_eq!(e.project.as_deref(), Some("g:/Scripts/proj"));
         // timestamp decoded from chat_start_metadata (1_782_298_884 + idx)
         assert_eq!(e.timestamp.timestamp(), 1_782_298_885);
+
+        // Invariant the test name claims: ModelUsageStats.output_tokens (f3) ==
+        // thinking_output_tokens (f9) + response_output_tokens (f10). We expose
+        // those two as reasoning_tokens and output_tokens, so their sum must
+        // reconcile with the upstream aggregate — guards a future split that
+        // could double-count or drop reasoning. (Asserted here, not via a
+        // debug_assert in decode_entry, to preserve the skip-never-panic
+        // contract on untrusted blobs.)
+        let usage = model_usage_stats(4626, 1474, 577, 12208, 0, "resp-a");
+        assert_eq!(
+            proto::varint(&usage, 3),
+            Some(e.output_tokens + e.reasoning_tokens)
+        );
     }
 
     #[test]
@@ -789,6 +833,32 @@ mod tests {
             "file:///work/y",
             "traj-cli",
             &[usage_row(1, 10, 5, 0, 0, 0, "same")],
+        );
+        let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+        assert_eq!(parser.parse_all().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_missing_trajectory_meta_falls_back_to_content_dedup() {
+        // No `trajectory_meta` table => `request_id` is `None` for every row, so
+        // dedup uses the content arm (`response_id:model:input:output`). Two such
+        // DBs with distinct response_ids both survive. (Two trajectory_meta-less
+        // DBs sharing a response_id AND identical counts would collapse cross-DB,
+        // but that is a non-issue in practice: response_ids are server-issued UUIDs.)
+        let tmp = TempDir::new().unwrap();
+        seed_db_no_traj_meta(
+            tmp.path(),
+            "antigravity-ide",
+            "ide.db",
+            "file:///work/x",
+            &[usage_row(1, 10, 5, 0, 0, 0, "r1")],
+        );
+        seed_db_no_traj_meta(
+            tmp.path(),
+            "antigravity-cli",
+            "cli.db",
+            "file:///work/y",
+            &[usage_row(1, 10, 5, 0, 0, 0, "r2")],
         );
         let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
         assert_eq!(parser.parse_all().unwrap().len(), 2);

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -1,5 +1,6 @@
 //! Parser traits and implementations for AI CLI tools
 
+mod antigravity;
 mod claude;
 mod codex;
 pub mod discovery;
@@ -8,6 +9,7 @@ mod opencode;
 mod pi_agent;
 mod qwen;
 
+pub use antigravity::AntigravityParser;
 pub use claude::ClaudeCodeParser;
 pub use codex::CodexParser;
 pub use gemini::GeminiParser;
@@ -156,6 +158,7 @@ impl ParserRegistry {
                 SourceInstance::local(Box::new(QwenParser::new())),
                 SourceInstance::local(Box::new(OpenCodeParser::new())),
                 SourceInstance::local(Box::new(PiAgentParser::new())),
+                SourceInstance::local(Box::new(AntigravityParser::new())),
             ],
         }
     }
@@ -204,13 +207,14 @@ mod tests {
     #[test]
     fn test_registry_default_parsers() {
         let registry = ParserRegistry::new();
-        assert_eq!(registry.sources().len(), 6);
+        assert_eq!(registry.sources().len(), 7);
         assert!(registry.get("claude-code").is_some());
         assert!(registry.get("codex").is_some());
         assert!(registry.get("gemini").is_some());
         assert!(registry.get("qwen").is_some());
         assert!(registry.get("opencode").is_some());
         assert!(registry.get("pi-agent").is_some());
+        assert!(registry.get("antigravity").is_some());
     }
 
     #[test]
@@ -266,8 +270,8 @@ mod tests {
             ))),
         )]);
 
-        assert_eq!(registry.sources().len(), 7);
-        assert_eq!(registry.sources()[6].id, "codex@testbox");
+        assert_eq!(registry.sources().len(), 8);
+        assert_eq!(registry.sources()[7].id, "codex@testbox");
     }
 
     #[test]

--- a/src/services/data_loader.rs
+++ b/src/services/data_loader.rs
@@ -208,8 +208,7 @@ impl DataLoaderService {
         }
 
         let all_summaries = Aggregator::merge_by_date(all_summaries);
-        let mut source_usage = Self::build_source_usage(source_stats, &source_estimated);
-        source_usage.extend(Self::antigravity_notice());
+        let source_usage = Self::build_source_usage(source_stats, &source_estimated);
 
         Ok(LoadResult {
             summaries: all_summaries,
@@ -303,8 +302,7 @@ impl DataLoaderService {
         }
 
         let all_summaries = Aggregator::merge_by_date(all_summaries);
-        let mut source_usage = Self::build_source_usage(source_stats, &source_estimated);
-        source_usage.extend(Self::antigravity_notice());
+        let source_usage = Self::build_source_usage(source_stats, &source_estimated);
 
         Ok(LoadResult {
             summaries: all_summaries,
@@ -398,31 +396,6 @@ impl DataLoaderService {
         result.sort_by_key(|b| std::cmp::Reverse(b.total_tokens));
         result
     }
-
-    /// Detect an Antigravity CLI install (`<gemini home>/.gemini/antigravity-cli`).
-    /// It is unsupported — Antigravity does not write file-readable token usage —
-    /// so surface a disabled source row (shown in the Sources list) rather than
-    /// silence. No stderr notice: it would bleed over the TUI while it renders.
-    fn antigravity_notice() -> Option<SourceUsage> {
-        let base = crate::parsers::discovery::first_env_dir(&["GEMINI_CLI_HOME"])
-            .or_else(|| directories::BaseDirs::new().map(|d| d.home_dir().to_path_buf()))?;
-        Self::antigravity_notice_at(&base)
-    }
-
-    /// Detection split out for testing without touching the global `GEMINI_CLI_HOME`.
-    fn antigravity_notice_at(home_base: &std::path::Path) -> Option<SourceUsage> {
-        if home_base.join(".gemini").join("antigravity-cli").exists() {
-            Some(SourceUsage {
-                source: "antigravity".into(),
-                total_tokens: 0,
-                total_cost_usd: 0.0,
-                supported: false,
-                estimated: false,
-            })
-        } else {
-            None
-        }
-    }
 }
 
 impl Default for DataLoaderService {
@@ -476,26 +449,6 @@ mod tests {
     #[test]
     fn test_is_copilot_provider_empty_string() {
         assert!(!is_copilot_provider(Some("")));
-    }
-
-    // ========== Antigravity detection ==========
-
-    #[test]
-    fn test_antigravity_notice_detected_as_unsupported() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        std::fs::create_dir_all(tmp.path().join(".gemini").join("antigravity-cli")).unwrap();
-        let notice =
-            DataLoaderService::antigravity_notice_at(tmp.path()).expect("dir present → notice");
-        assert_eq!(notice.source, "antigravity");
-        assert!(!notice.supported);
-        assert_eq!(notice.total_tokens, 0);
-        assert_eq!(notice.total_cost_usd, 0.0);
-    }
-
-    #[test]
-    fn test_antigravity_notice_absent_when_no_dir() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        assert!(DataLoaderService::antigravity_notice_at(tmp.path()).is_none());
     }
 
     // ========== build_source_usage tests ==========

--- a/src/tui/widgets/overview.rs
+++ b/src/tui/widgets/overview.rs
@@ -272,8 +272,8 @@ impl Overview<'_> {
             // Token count
             let count_str = format_number(source.total_tokens);
 
-            // Unsupported sources (e.g. Antigravity) render as a dimmed, bar-less
-            // notice row instead of a usage bar.
+            // Unsupported sources render as a dimmed, bar-less notice row
+            // instead of a usage bar.
             if !source.supported {
                 let dim = Style::default()
                     .fg(self.theme.muted())

--- a/src/types/usage.rs
+++ b/src/types/usage.rs
@@ -374,8 +374,9 @@ pub struct SourceUsage {
     pub source: String,
     pub total_tokens: u64,
     pub total_cost_usd: f64,
-    /// False for detected-but-unsupported sources (e.g. Antigravity, which does
-    /// not write file-readable token usage). Rendered as a disabled row.
+    /// False for sources detected on disk whose token usage can't be read
+    /// (no file-readable usage). Rendered as a disabled notice row. Reserved for
+    /// future detect-but-can't-parse sources; all current parsers set this true.
     #[serde(default = "default_true")]
     pub supported: bool,
     /// True when this source's cost was LiteLLM-calculated (the source did not


### PR DESCRIPTION
## Summary

Adds a real parser for **Antigravity** (Google's agentic IDE + its CLI), promoting it
from a "detected, unsupported" placeholder row to a fully supported source with
per-model and per-project breakdown.

Antigravity was previously assumed to write no file-readable usage. It turns out it
does — token usage is persisted locally, just as **protobuf blobs inside per-conversation
SQLite databases** rather than JSON. The schema isn't published, so the field layout was
reverse-engineered from the language-server binary's embedded proto descriptors and
validated against real sessions.

## Where the data lives

```
~/.gemini/antigravity-ide/conversations/<trajectory_id>.db   # the IDE
~/.gemini/antigravity-cli/conversations/<trajectory_id>.db   # the CLI (same schema)
```

Per DB:
- `gen_metadata.data` — one protobuf `ChatModelMetadata` per model generation
  - field 4 `usage` → `ModelUsageStats` (the token counts)
  - field 9 `chat_start_metadata` → timestamp
  - field 19 `response_model` (model id)
- `trajectory_metadata_blob.data` — workspace folder URI → project attribution

## Token mapping (ModelUsageStats → UsageEntry, v2 contract)

| UsageEntry            | source field                        |
|-----------------------|-------------------------------------|
| `input_tokens`        | `input_tokens` (already non-cached) |
| `output_tokens`       | `response_output_tokens` (visible)  |
| `reasoning_tokens`    | `thinking_output_tokens`            |
| `cache_read_tokens`   | `cache_read_tokens`                 |
| `cache_creation_tokens` | `cache_write_tokens`              |
| `model`               | `response_model`                    |
| `project`             | workspace URI (`file://` stripped)  |

The split keeps the contract invariant `output + reasoning == ModelUsageStats.output_tokens`.

## Changes

- **New** `src/parsers/antigravity.rs` — rusqlite read + a ~40-line dependency-free
  protobuf wire reader (defensive: malformed/truncated blobs are skipped, never panic).
- `src/parsers/mod.rs` — registers a supported `antigravity` source.
- `src/services/data_loader.rs` — removes the old `antigravity_notice` "unsupported" stub.
- Docs: README (+ ko, npm), architecture.md updated to ✅ supported.

## Validation

- Schema cross-checked against the binary's proto descriptors (`ModelUsageStats`,
  `ChatModelMetadata`).
- Decoded 28 real generations; the invariant `output == thinking + response` held 28/28.
- End-to-end on live data: `gemini-3-flash-a`, 28 entries, input 151,751 / cache_read
  838,104 / reasoning 12,621 / output 20,780 — matches the raw decode.
- `cargo test` (incl. 8 new parser tests), `clippy -D warnings`, `fmt` all green.

## Notes / caveats

- Field numbers are reverse-engineered and may drift across Antigravity versions;
  decoding degrades gracefully (skip-on-mismatch) rather than failing.
- `response_model` values are Antigravity's internal routing aliases and inconsistent
  (`gemini-3-flash-a`, `gemini-pro-default`, `claude-sonnet-4-6`). LiteLLM has no price
  for the Gemini preview aliases, so their cost shows as $0 (tokens still tracked).
  Antigravity also serves Claude models, which could price if normalized — possible
  follow-up.
- One `antigravity` source covers both ide + cli dirs (disjoint trajectory ids).
