### PR TITLE
ci: add id-token permission for Claude review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,6 +16,8 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  # Required by claude-code-action to exchange an OIDC token for its GitHub token.
+  id-token: write
 
 jobs:
   review:


### PR DESCRIPTION
## Summary

The `review` job added in #197-era commit 27ada5f has failed on every PR since introduction (e.g. [PR #199 run](https://github.com/mag123c/toktrack/actions/runs/28561921060)) with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

`anthropics/claude-code-action@v1` exchanges an OIDC token for its GitHub token, which requires `id-token: write`. This adds the missing permission.

Note: since the workflow runs on `pull_request_target`, PRs pick up the workflow from `main` — the fix takes effect for other PRs only after this merges. After merging, re-run the failed `review` job on #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)