### PR TITLE
fix(parser): Resolve gemini-default by timestamp

### DIFF
--- a/src/parsers/antigravity.rs
+++ b/src/parsers/antigravity.rs
@@ -249,8 +249,38 @@ fn decode_entry(
     }
 
     let message_id = proto::string(usage, 11).map(String::from);
-    let model = proto::string(cmm, 19).map(String::from);
+    let raw_model = proto::string(cmm, 19)
+        .map(String::from)
+        .filter(|s| !s.is_empty());
     let timestamp = decode_timestamp(cmm).unwrap_or(fallback_ts);
+
+    let model = match raw_model {
+        Some(m) => {
+            let lower = m.to_lowercase();
+            if lower == "gemini-default" || lower == "gemini/default" {
+                let ts = timestamp.timestamp();
+                if ts < 1742860800 {
+                    Some("gemini-2.0-flash".to_string())
+                } else if ts < 1779148800 {
+                    Some("gemini-2.5-flash".to_string())
+                } else {
+                    Some("gemini-3.5-flash".to_string())
+                }
+            } else {
+                Some(m)
+            }
+        }
+        None => {
+            let ts = timestamp.timestamp();
+            if ts < 1742860800 {
+                Some("gemini-2.0-flash".to_string())
+            } else if ts < 1779148800 {
+                Some("gemini-2.5-flash".to_string())
+            } else {
+                Some("gemini-3.5-flash".to_string())
+            }
+        }
+    };
 
     Some(UsageEntry {
         timestamp,
@@ -1036,6 +1066,39 @@ mod tests {
         let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
         let entries = parser.parse_all().unwrap();
         assert_eq!(entries[0].project.as_deref(), Some("g:/Scripts/proj"));
+    }
+
+    #[test]
+    fn test_missing_model_maps_by_timestamp() {
+        let test_cases = vec![
+            (1740000000, "gemini-2.0-flash"),
+            (1750000000, "gemini-2.5-flash"),
+            (1782298900, "gemini-3.5-flash"),
+        ];
+
+        for (secs, expected_model) in test_cases {
+            let tmp = TempDir::new().unwrap();
+            let usage = model_usage_stats(10, 5, 0, 0, 0, "r");
+            let start = chat_start(secs as u64, 0);
+            let mut cmm = Vec::new();
+            field_bytes(&mut cmm, 4, &usage);
+            field_bytes(&mut cmm, 9, &start);
+            seed_db(
+                tmp.path(),
+                "antigravity-ide",
+                "t.db",
+                "file:///work/x",
+                "traj-1",
+                &[Row {
+                    idx: 1,
+                    data: gen_blob(&cmm, "uuid-1"),
+                }],
+            );
+            let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
+            let entries = parser.parse_all().unwrap();
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].model.as_deref(), Some(expected_model));
+        }
     }
 
     #[test]

--- a/src/services/cache.rs
+++ b/src/services/cache.rs
@@ -65,8 +65,9 @@ fn normalize_model_keys(models: HashMap<String, ModelUsage>) -> HashMap<String, 
 /// Mismatched version → past summaries are kept (history is preserved) but a
 /// warning is surfaced, and every date whose raw files still exist is recomputed
 /// so the new shape is populated. v14 added per-project breakdown
-/// (`DailySummary.projects`).
-const CACHE_VERSION: u32 = 14;
+/// (`DailySummary.projects`). v15 resolves gemini-default / missing-model
+/// records by timestamp so they no longer appear as "unknown".
+const CACHE_VERSION: u32 = 15;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DailySummaryCache {

--- a/src/services/normalizer.rs
+++ b/src/services/normalizer.rs
@@ -183,6 +183,17 @@ fn format_version(version: &str) -> String {
 /// assert_eq!(normalize_model_name("claude-opus-4.5"), "claude-opus-4-5");
 /// ```
 pub fn normalize_model_name(model: &str) -> String {
+    let lower = model.to_lowercase();
+    if lower == "gemini-default" || lower == "gemini/default" {
+        return "gemini-3-5-flash".to_string();
+    }
+    if lower == "gemini-3-flash-a" || lower == "gemini/gemini-3-flash-a" {
+        return "gemini-3-flash-preview".to_string();
+    }
+    if lower == "gemini-3-pro-a" || lower == "gemini/gemini-3-pro-a" {
+        return "gemini-3-pro-preview".to_string();
+    }
+
     // Step 1: Replace dots with hyphens
     let normalized = model.replace('.', "-");
 
@@ -352,6 +363,19 @@ mod tests {
     }
 
     // ========== No-op cases ==========
+
+    #[test]
+    fn test_normalize_gemini_default() {
+        assert_eq!(normalize_model_name("gemini-default"), "gemini-3-5-flash");
+    }
+
+    #[test]
+    fn test_normalize_gemini_3_flash_a() {
+        assert_eq!(
+            normalize_model_name("gemini-3-flash-a"),
+            "gemini-3-flash-preview"
+        );
+    }
 
     #[test]
     fn test_already_normalized() {


### PR DESCRIPTION
- Map gemini-default / no model by timestamp: pre-2025-03-25 → gemini-2.0-flash, pre-2026-05-19 → gemini-2.5-flash, after → gemini-3.5-flash
- Normalize gemini-3-flash-a → gemini-3-flash-preview
- Normalize gemini-3-pro-a → gemini-3-pro-preview
- Add gemini-default normalizer fallback
- Bump CACHE_VERSION 14→15 to re-parse stale "unknown" entries