### PR TITLE
refactor(cli): remove redundant comments

### DIFF
--- a/.claude/hooks/clarify-first.sh
+++ b/.claude/hooks/clarify-first.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 세션 첫 프롬프트에 /clarify 강제
+# Require /clarify on the first prompt of each session.
 set -e
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')

--- a/.claude/hooks/impl-after-plan.sh
+++ b/.claude/hooks/impl-after-plan.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# Plan Mode 진입 제거 - 비활성화
-# plan exit 마커 기반 안내가 더 이상 필요 없음 (PLAN 인라인 제시 → /implement 직접 호출)
+# Disabled: plans are presented inline, so no Plan Mode marker is needed.
 exit 0

--- a/.claude/hooks/implement-detector.sh
+++ b/.claude/hooks/implement-detector.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Skill 호출 감지 → 마커 관리
+# Track workflow markers when skills start.
 set -e
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')
@@ -14,12 +14,10 @@ if [ "$TOOL_NAME" = "Skill" ]; then
   case "$SKILL_NAME" in
     "implement")
       touch "$IMPLEMENT_STARTED_MARKER"
-      # plan-exited 마커 제거 (정상 흐름 완료)
       rm -f "$PLAN_EXITED_MARKER"
       rm -f "$CLARIFY_IN_PROGRESS_MARKER"
       ;;
     "clarify")
-      # clarify 시작 → Plan Mode 필요 상태
       touch "$CLARIFY_IN_PROGRESS_MARKER"
       ;;
   esac

--- a/.claude/hooks/implement-guard.sh
+++ b/.claude/hooks/implement-guard.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-# Edit/Write 호출 전 워크플로우 체크
-# 코드 파일(*.rs, *.ts, *.js, *.py 등) 수정 시에만 체크
-# 문서, 설정, 마케팅 자료 등은 직접 수정 허용
+# Warn when code edits bypass the clarify-to-implement workflow.
 set -e
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
@@ -11,26 +9,23 @@ PLAN_EXITED_MARKER="/tmp/toktrack-plan-exited-$SESSION_ID"
 IMPLEMENT_STARTED_MARKER="/tmp/toktrack-implement-started-$SESSION_ID"
 CLARIFY_IN_PROGRESS_MARKER="/tmp/toktrack-clarify-in-progress-$SESSION_ID"
 
-# 코드 파일 확장자 패턴
 CODE_EXTENSIONS="rs|ts|tsx|js|jsx|py|go|java|kt|swift|c|cpp|h|hpp"
 
-# 코드 파일인지 확인
 is_code_file() {
   echo "$1" | grep -qE "\.($CODE_EXTENSIONS)$"
 }
 
-# 코드 파일이 아니면 통과 (문서, 설정 등)
 if ! is_code_file "$FILE_PATH"; then
   exit 0
 fi
 
-# clarify 진행 중인데 Plan Mode 없이 코드 수정 시도 시 경고 (차단 아님)
+# Warn without blocking while clarification is still in progress.
 if [ -f "$CLARIFY_IN_PROGRESS_MARKER" ]; then
   echo "⚠️ /clarify 후 Plan Mode 진행 권장 (코드 파일 수정)" >&2
   exit 0
 fi
 
-# Plan Mode 종료됐는데 implement 스킬 미실행 상태면 경고 (차단 아님)
+# Warn without blocking when implementation has not started.
 if [ -f "$PLAN_EXITED_MARKER" ] && [ ! -f "$IMPLEMENT_STARTED_MARKER" ]; then
   echo "⚠️ 코드 구현은 /implement 스킬 사용 권장 (TDD 워크플로우)" >&2
   exit 0

--- a/.claude/hooks/plan-exit-detector.sh
+++ b/.claude/hooks/plan-exit-detector.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# Plan Mode 진입 제거 - 비활성화
-# clarify는 더 이상 plan mode로 진입하지 않고 PLAN을 인라인 제시 → /implement 직접 호출
+# Disabled: clarification presents the plan inline before implementation.
 exit 0

--- a/.claude/hooks/plan-provided-detector.sh
+++ b/.claude/hooks/plan-provided-detector.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
-# 플랜 제공 감지 - 비활성화
-# 플랜 키워드만으로 /implement 강제는 너무 광범위
-# 코드 작업이 아닌 경우(문서, 마케팅 등)도 플랜이 제공될 수 있음
+# Disabled: plan keywords are too broad to require implementation for non-code work.
 exit 0

--- a/.claude/hooks/post-tool-implement-check.sh
+++ b/.claude/hooks/post-tool-implement-check.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
-# ExitPlanMode 후 체크 - 비활성화
-# 계획서에 /implement 강제 명시는 불필요
-# 코드 작업이 아닌 플랜도 있음
+# Disabled: not every plan describes code that requires implementation.
 exit 0

--- a/.claude/hooks/skill-chain-detector.sh
+++ b/.claude/hooks/skill-chain-detector.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# 스킬 체인 상태 관리
-# Skill 호출 시 체인 단계를 마커 파일로 추적
+# Track skill-chain state with marker files.
 set -e
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')

--- a/.claude/hooks/skill-chain-enforcer.sh
+++ b/.claude/hooks/skill-chain-enforcer.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 스킬 체인 강제 - UserPromptSubmit 시 다음 단계 안내
+# Remind the next workflow phase on UserPromptSubmit.
 set -e
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
@@ -9,10 +9,8 @@ CHAIN_DIR="/tmp/toktrack-chain-$SESSION_ID"
 
 CURRENT=$(cat "$CHAIN_DIR/current" 2>/dev/null || echo "")
 
-# 각 단계 완료 후 다음 단계 안내
 case "$CURRENT" in
   "implement")
-    # implement 단계에서 verify가 시작되지 않은 경우
     if [ ! -f "$CHAIN_DIR/verify-started" ]; then
       cat << 'EOF'
 {
@@ -26,7 +24,6 @@ EOF
     fi
     ;;
   "verify")
-    # verify 단계에서 review가 시작되지 않은 경우
     if [ ! -f "$CHAIN_DIR/review-started" ]; then
       cat << 'EOF'
 {
@@ -40,7 +37,6 @@ EOF
     fi
     ;;
   "review")
-    # review 단계에서 wrap이 시작되지 않은 경우
     if [ ! -f "$CHAIN_DIR/wrap-started" ]; then
       cat << 'EOF'
 {

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,25 @@
 .PHONY: check fmt clippy test build release setup
 
-# Run all checks (used by pre-commit)
 check: fmt-check clippy test
 
-# Format code
 fmt:
 	cargo fmt --all
 
-# Check formatting without modifying
 fmt-check:
 	cargo fmt --all -- --check
 
-# Run clippy
 clippy:
 	cargo clippy --all-targets --all-features -- -D warnings
 
-# Run tests
 test:
 	cargo test
 
-# Build debug
 build:
 	cargo build
 
-# Build release
 release:
 	cargo build --release
 
-# Setup git hooks
 setup:
 	git config core.hooksPath .githooks
 	@echo "Git hooks configured!"

--- a/benches/parser_bench.rs
+++ b/benches/parser_bench.rs
@@ -5,7 +5,6 @@ use std::hint::black_box;
 use std::path::{Path, PathBuf};
 use toktrack::parsers::{CLIParser, ClaudeCodeParser};
 
-/// Find all JSONL files in a directory recursively
 fn find_all_jsonl(dir: &Path) -> Vec<PathBuf> {
     let pattern = dir.join("**/*.jsonl");
     let pattern_str = pattern.to_string_lossy();
@@ -20,14 +19,12 @@ fn find_all_jsonl(dir: &Path) -> Vec<PathBuf> {
         .unwrap_or_default()
 }
 
-/// Find the largest JSONL file in a directory recursively
 fn find_largest_jsonl(dir: &Path) -> Option<PathBuf> {
     find_all_jsonl(dir)
         .into_iter()
         .max_by_key(|path| std::fs::metadata(path).map(|m| m.len()).unwrap_or(0))
 }
 
-/// Get test file: prefer real Claude data, fallback to fixture
 fn get_bench_file(parser: &ClaudeCodeParser) -> PathBuf {
     let real_data_dir = parser.data_dir();
 
@@ -126,7 +123,7 @@ fn bench_parse_all_files(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("parser");
     group.throughput(Throughput::Bytes(total_size));
-    group.sample_size(10); // 3GB는 시간이 오래 걸리므로 샘플 수 줄임
+    group.sample_size(10); // Keep the 3 GiB benchmark practical.
 
     group.bench_function("parse_all_files_sequential", |b| {
         b.iter(|| {

--- a/demo.tape
+++ b/demo.tape
@@ -4,12 +4,12 @@ Set Height 600
 Set FontSize 14
 Set Theme "Homebrew"
 
-# 실행
+# Launch
 Type "toktrack"
 Enter
 Sleep 1500ms
 
-# Overview: 소스 탐색 (j로 이동)
+# Overview: move through sources with j
 Type "j"
 Sleep 300ms
 Type "j"
@@ -17,7 +17,7 @@ Sleep 300ms
 Type "j"
 Sleep 1000ms
 
-# 첫 번째 소스로 돌아가서 SourceDetail 진입
+# Return to the first source and open SourceDetail
 Type "k"
 Sleep 200ms
 Type "k"
@@ -27,7 +27,7 @@ Sleep 200ms
 Enter
 Sleep 1500ms
 
-# SourceDetail: Daily 스크롤
+# SourceDetail: scroll Daily
 Type "k"
 Sleep 200ms
 Type "k"
@@ -45,29 +45,29 @@ Sleep 2000ms
 Escape
 Sleep 500ms
 
-# Weekly 뷰
+# Weekly view
 Type "w"
 Sleep 1500ms
 
-# Monthly 뷰
+# Monthly view
 Type "m"
 Sleep 1500ms
 
-# Overview로 돌아가기
+# Return to Overview
 Escape
 Sleep 1000ms
 
-# 두 번째 소스(Codex)로 이동 후 진입
+# Open the second source (Codex)
 Type "j"
 Sleep 300ms
 Enter
 Sleep 500ms
 
-# Monthly 상태이므로 Daily로 전환
+# Switch from Monthly to Daily
 Type "d"
 Sleep 1500ms
 
-# Codex Daily 스크롤
+# Scroll Codex Daily
 Type "k"
 Sleep 200ms
 Type "k"
@@ -81,7 +81,7 @@ Sleep 2000ms
 Escape
 Sleep 500ms
 
-# Overview로 돌아가기
+# Return to Overview
 Escape
 Sleep 1000ms
 
@@ -93,7 +93,7 @@ Sleep 1500ms
 Type "3"
 Sleep 1500ms
 
-# 종료 (Ctrl+C → y)
+# Quit (Ctrl+C, then y)
 Ctrl+C
 Sleep 500ms
 Type "y"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -343,10 +343,8 @@ fn run_report(
         sr.estimated = estimated.get(sr.name.as_str()).copied().unwrap_or(false);
     }
 
-    // Always print text report
     println!("{}", crate::report::text::render(&data));
 
-    // Optionally write SVG
     if let Some(path) = svg {
         let svg_content = crate::report::svg::render(&data);
         std::fs::write(&path, svg_content)?;
@@ -549,7 +547,6 @@ mod tests {
 
     #[test]
     fn test_cli_parse_backup_removed() {
-        // backup subcommand should no longer exist
         let result = Cli::try_parse_from(["toktrack", "backup"]);
         assert!(result.is_err());
     }

--- a/src/parsers/antigravity.rs
+++ b/src/parsers/antigravity.rs
@@ -460,8 +460,6 @@ mod tests {
     use rusqlite::params;
     use tempfile::TempDir;
 
-    // ===== protobuf encode helpers (build fixture blobs) =====
-
     fn enc_varint(out: &mut Vec<u8>, mut n: u64) {
         loop {
             let mut byte = (n & 0x7f) as u8;
@@ -544,8 +542,6 @@ mod tests {
         field_bytes(&mut t, 7, uri.as_bytes());
         t
     }
-
-    // ===== fixture DB builder =====
 
     struct Row {
         idx: i64,
@@ -656,13 +652,8 @@ mod tests {
         t
     }
 
-    // ===== tests =====
-
     #[test]
     fn test_read_gen_metadata_skips_unreadable_rows() {
-        // The "warned, never fatal" contract: a row whose `data` can't be read as
-        // a blob (e.g. a NULL cell in a partially-written DB) is skipped, while the
-        // readable rows are still returned in `idx` order.
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB, size INTEGER);",
@@ -673,7 +664,6 @@ mod tests {
             params![vec![1u8, 2, 3]],
         )
         .unwrap();
-        // NULL `data` → `get::<Vec<u8>>` errors → this row is warned-and-skipped.
         conn.execute(
             "INSERT INTO gen_metadata (idx, data, size) VALUES (1, NULL, 0)",
             [],
@@ -694,17 +684,12 @@ mod tests {
 
     #[test]
     fn test_read_gen_metadata_caps_warnings_past_threshold() {
-        // More unreadable rows than `MAX_ROW_WARNINGS` (5) exercises the summary
-        // branch: every bad row is still skipped (none fatal), and only the one
-        // readable blob comes back. Guards the warn-cap path so a partially-written
-        // DB can't flood stderr.
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB, size INTEGER);",
         )
         .unwrap();
         for idx in 0..7 {
-            // NULL `data` → `get::<Vec<u8>>` errors → warned-and-skipped.
             conn.execute(
                 "INSERT INTO gen_metadata (idx, data, size) VALUES (?, NULL, 0)",
                 params![idx],
@@ -762,14 +747,11 @@ mod tests {
         assert_eq!(e.reasoning_tokens, 577); // thinking_output_tokens
         assert_eq!(e.cache_read_tokens, 12208);
         assert_eq!(e.cache_creation_tokens, 0);
-        // total = 4626 + 1474 + 12208 + 0 + 577
         assert_eq!(e.total_tokens(), 18885);
         assert_eq!(e.source.as_deref(), Some("antigravity"));
         assert_eq!(e.message_id.as_deref(), Some("resp-a"));
         assert_eq!(e.request_id.as_deref(), Some("traj-1"));
-        // file:///g:/... → g:/... (drive-letter slash stripped)
         assert_eq!(e.project.as_deref(), Some("g:/Scripts/proj"));
-        // timestamp decoded from chat_start_metadata (1_782_298_884 + idx)
         assert_eq!(e.timestamp.timestamp(), 1_782_298_885);
 
         // Invariant the test name claims: ModelUsageStats.output_tokens (f3) ==
@@ -800,7 +782,6 @@ mod tests {
         let parser = AntigravityParser::with_data_dir(tmp.path().to_path_buf());
         let entries = parser.parse_all().unwrap();
         assert_eq!(entries[0].cache_creation_tokens, 77);
-        // unix-style path keeps its leading slash
         assert_eq!(entries[0].project.as_deref(), Some("/work/x"));
     }
 
@@ -887,7 +868,6 @@ mod tests {
     #[test]
     fn test_parse_all_aggregates_and_dedups() {
         let tmp = TempDir::new().unwrap();
-        // Two distinct generations in IDE + one in CLI = 3 entries.
         seed_db(
             tmp.path(),
             "antigravity-ide",
@@ -990,8 +970,6 @@ mod tests {
 
     #[test]
     fn test_missing_usage_submessage_skipped() {
-        // A valid ChatModelMetadata with model + timestamp but NO usage (f4) is
-        // skipped — distinct from the malformed-blob and zero-token paths.
         let tmp = TempDir::new().unwrap();
         let start = chat_start(1_782_298_900, 0);
         let no_usage = cmm_parts(None, Some(&start), "gemini-3-flash-a");
@@ -1017,8 +995,6 @@ mod tests {
 
     #[test]
     fn test_missing_timestamp_falls_back_to_file_mtime() {
-        // No chat_start (f9) → decode_timestamp returns None → timestamp falls back
-        // to the DB file's mtime.
         let tmp = TempDir::new().unwrap();
         let usage = model_usage_stats(10, 5, 0, 0, 0, "r");
         let no_start = cmm_parts(Some(&usage), None, "gemini-3-flash-a");
@@ -1053,8 +1029,6 @@ mod tests {
 
     #[test]
     fn test_project_resolves_via_field1_fallback() {
-        // Older layout: trajectory_metadata_blob has ONLY the nested field 1→1 URI
-        // (no field 7). The project must still resolve.
         let tmp = TempDir::new().unwrap();
         seed_db_with_traj(
             tmp.path(),
@@ -1104,8 +1078,6 @@ mod tests {
 
     #[test]
     fn test_resolve_gemini_default_boundaries() {
-        // Boundaries are exclusive upper bounds: a timestamp exactly on a
-        // boundary belongs to the LATER bucket. Pins `<` vs `<=`.
         assert_eq!(resolve_gemini_default(1742860799), "gemini-2.0-flash"); // 1s before 2025-03-25
         assert_eq!(resolve_gemini_default(1742860800), "gemini-2.5-flash"); // exactly 2025-03-25
         assert_eq!(resolve_gemini_default(1779148799), "gemini-2.5-flash"); // 1s before 2026-05-19
@@ -1114,8 +1086,6 @@ mod tests {
 
     #[test]
     fn test_oversized_token_varints_do_not_panic() {
-        // Corrupt/adversarial usage counts near u64::MAX must not overflow-panic
-        // the zero-check sum; the row is still produced.
         let tmp = TempDir::new().unwrap();
         // Build the usage blob directly (model_usage_stats would overflow its own
         // f3 = thinking + response computation with MAX inputs).

--- a/src/parsers/claude.rs
+++ b/src/parsers/claude.rs
@@ -89,11 +89,9 @@ impl ClaudeCodeParser {
 
         let data: ClaudeJsonLine = simd_json::from_slice(line).ok()?;
 
-        // Only process lines with message and usage data
         let message = data.message.as_ref()?;
         let usage = message.usage.as_ref()?;
 
-        // Skip synthetic responses (no actual API call)
         if message.model == Some("<synthetic>") {
             return None;
         }
@@ -163,7 +161,6 @@ impl CLIParser for ClaudeCodeParser {
         let reader = BufReader::new(file);
         let mut entries = Vec::new();
 
-        // Stream line-by-line to avoid loading entire file into memory
         for line_result in reader.lines() {
             let line = match line_result {
                 Ok(l) => l,
@@ -174,7 +171,6 @@ impl CLIParser for ClaudeCodeParser {
                 continue;
             }
 
-            // Convert to mutable bytes for simd-json
             let mut line_bytes = line.into_bytes();
             if let Some(entry) = self.parse_line(&mut line_bytes) {
                 entries.push(entry);
@@ -232,7 +228,6 @@ mod tests {
             .parse_file(&fixture_path("claude-sample.jsonl"))
             .unwrap();
 
-        // Should parse 4 assistant messages (skipping user message, invalid line, and synthetic)
         assert_eq!(entries.len(), 4);
     }
 
@@ -272,7 +267,6 @@ mod tests {
             .parse_file(&fixture_path("claude-sample.jsonl"))
             .unwrap();
 
-        // Third entry has no cache tokens, message_id, or request_id
         let third = &entries[2];
         assert_eq!(third.cache_creation_tokens, 0);
         assert_eq!(third.cache_read_tokens, 0);
@@ -287,7 +281,6 @@ mod tests {
             .parse_file(&fixture_path("claude-sample.jsonl"))
             .unwrap();
 
-        // Invalid JSON line should be skipped, not cause an error
         assert_eq!(entries.len(), 4);
     }
 
@@ -298,8 +291,6 @@ mod tests {
             .parse_file(&fixture_path("claude-sample.jsonl"))
             .unwrap();
 
-        // User message has no usage, should be skipped
-        // All entries should have input_tokens > 0
         assert!(entries.iter().all(|e| e.input_tokens > 0));
     }
 
@@ -310,10 +301,8 @@ mod tests {
             .parse_file(&fixture_path("claude-sample.jsonl"))
             .unwrap();
 
-        // First entry has both message_id and request_id
         assert_eq!(entries[0].dedup_hash(), Some("msg-001:req-001".to_string()));
 
-        // Third entry has neither
         assert_eq!(entries[2].dedup_hash(), None);
     }
 
@@ -364,7 +353,6 @@ mod tests {
             .parse_file(&fixture_path("claude-sample.jsonl"))
             .unwrap();
 
-        // <synthetic> model entries should be filtered out
         assert!(
             entries
                 .iter()
@@ -380,7 +368,6 @@ mod tests {
             .parse_file(&fixture_path("claude-sample.jsonl"))
             .unwrap();
 
-        // Fourth entry has cache_creation with ephemeral_5m and ephemeral_1h
         let fourth = &entries[3];
         assert_eq!(fourth.cache_creation_tokens, 5000);
         assert_eq!(fourth.cache_creation_5m_tokens, 3000);
@@ -394,7 +381,6 @@ mod tests {
             .parse_file(&fixture_path("claude-sample.jsonl"))
             .unwrap();
 
-        // Fourth entry has web_search_requests = 3
         let fourth = &entries[3];
         assert_eq!(fourth.web_search_requests, 3);
     }
@@ -406,7 +392,6 @@ mod tests {
             .parse_file(&fixture_path("claude-sample.jsonl"))
             .unwrap();
 
-        // First entry has no cache_creation detail or server_tool_use
         let first = &entries[0];
         assert_eq!(first.cache_creation_5m_tokens, 0);
         assert_eq!(first.cache_creation_1h_tokens, 0);

--- a/src/parsers/codex.rs
+++ b/src/parsers/codex.rs
@@ -274,7 +274,6 @@ impl CLIParser for CodexParser {
 
                     prev_totals = data.total;
 
-                    // Skip zero-delta events
                     if delta_input == 0 && delta_output == 0 && delta_cached == 0 {
                         continue;
                     }
@@ -330,7 +329,6 @@ mod tests {
             .parse_file(&fixture_path("sample-session.jsonl"))
             .unwrap();
 
-        // Two token_count events → two entries (delta per turn)
         assert_eq!(entries.len(), 2);
     }
 
@@ -341,19 +339,15 @@ mod tests {
             .parse_file(&fixture_path("sample-session.jsonl"))
             .unwrap();
 
-        // Entry 1: last_token_usage={input:150, output:75, cached:25}
-        //   normalized input = 150 - 25 = 125
         let e1 = &entries[0];
         assert_eq!(e1.model, Some("o4-mini".to_string()));
-        assert_eq!(e1.input_tokens, 125); // 150 - 25
+        assert_eq!(e1.input_tokens, 125);
         assert_eq!(e1.output_tokens, 75);
         assert_eq!(e1.cache_read_tokens, 25);
 
-        // Entry 2: last_token_usage={input:350, output:125, cached:75}
-        //   normalized input = 350 - 75 = 275
         let e2 = &entries[1];
         assert_eq!(e2.model, Some("gpt-4.1".to_string()));
-        assert_eq!(e2.input_tokens, 275); // 350 - 75
+        assert_eq!(e2.input_tokens, 275);
         assert_eq!(e2.output_tokens, 125);
         assert_eq!(e2.cache_read_tokens, 75);
     }
@@ -365,10 +359,6 @@ mod tests {
             .parse_file(&fixture_path("multi-turn-session.jsonl"))
             .unwrap();
 
-        // Turn 1: last={100,50,20} → input=80, output=50, cached=20
-        // Turn 2: last={200,70,40} → input=160, output=70, cached=40
-        // Turn 3: no last → diff={0,0,0} → SKIP
-        // Turn 4: last={200,80,40} → input=160, output=80, cached=40
         assert_eq!(entries.len(), 3);
 
         assert_eq!(entries[0].input_tokens, 80);
@@ -391,8 +381,6 @@ mod tests {
             .parse_file(&fixture_path("multi-turn-session.jsonl"))
             .unwrap();
 
-        // Turn 3 has zero delta (no last_token_usage, totals unchanged) → skipped
-        // So 3 entries, not 4
         assert_eq!(entries.len(), 3);
     }
 
@@ -403,7 +391,6 @@ mod tests {
             .parse_file(&fixture_path("sample-session.jsonl"))
             .unwrap();
 
-        // Invalid JSON line, null info, and non-token events are skipped
         assert_eq!(entries.len(), 2);
     }
 
@@ -436,7 +423,6 @@ mod tests {
 
     #[test]
     fn test_project_none_when_no_cwd() {
-        // Legacy fixtures without cwd must keep project=None.
         let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
         let entries = parser
             .parse_file(&fixture_path("sample-session.jsonl"))
@@ -480,8 +466,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ========== Issue #134: provider extraction from session_meta ==========
-
     #[test]
     fn test_provider_extracted_from_session_meta() {
         // Real Codex CLI v0.116+ writes `session_meta.payload.model_provider`
@@ -524,7 +508,6 @@ mod tests {
 
     #[test]
     fn test_provider_none_when_session_meta_lacks_provider() {
-        // Regression: legacy fixture without model_provider must keep provider=None.
         let parser = CodexParser::with_data_dir(PathBuf::from("tests/fixtures/codex"));
         let entries = parser
             .parse_file(&fixture_path("sample-session.jsonl"))

--- a/src/parsers/copilot.rs
+++ b/src/parsers/copilot.rs
@@ -340,7 +340,6 @@ impl CLIParser for CopilotParser {
         let mut session_start_time: Option<DateTime<Utc>> = None;
         let mut last_shutdown: Option<(DateTime<Utc>, Vec<ShutdownModelEntry>)> = None;
 
-        // Internal struct to keep parsed assistant messages
         struct ParsedMessage {
             timestamp: DateTime<Utc>,
             message_id: Option<String>,
@@ -644,7 +643,6 @@ mod tests {
         assert_eq!(entries.len(), 1);
         let entry = &entries[0];
         assert_eq!(entry.model.as_deref(), Some("gpt-5.3-codex"));
-        // 92078 input - 1043840 cache_read - 0 cache_write = saturating to 0
         assert_eq!(entry.input_tokens, 0);
         assert_eq!(entry.cache_read_tokens, 1_043_840);
         assert_eq!(entry.cache_creation_tokens, 0);
@@ -698,7 +696,6 @@ mod tests {
 
         assert_eq!(entries.len(), 2);
 
-        // Message 1 on 2026-07-14 gets 100 / 400 = 25% of the total tokens
         let m1 = entries
             .iter()
             .find(|e| e.message_id.as_deref() == Some("msg-m1"))
@@ -708,7 +705,6 @@ mod tests {
         assert_eq!(m1.cache_read_tokens, 1000); // 25% of 4000 = 1000
         assert_eq!(m1.output_tokens, 100); // 25% of 400 = 100
 
-        // Message 2 on 2026-07-15 gets 300 / 400 = 75% of the total tokens
         let m2 = entries
             .iter()
             .find(|e| e.message_id.as_deref() == Some("msg-m2"))
@@ -726,7 +722,6 @@ mod tests {
             .parse_file(&fixture_path("resumed-session.log"))
             .unwrap();
 
-        // Should return 2 entries: the reconciled shutdown entry and the new provisional entry
         assert_eq!(entries.len(), 2);
 
         let m1 = entries
@@ -800,7 +795,6 @@ mod tests {
         // Copilot re-dates cumulative shutdown totals onto earlier messages, so
         // the warm path must treat its recent files as able to touch old days.
         assert!(CopilotParser::new().retroactive_reconciliation());
-        // Sources whose entries are final when written must not (perf).
         assert!(!crate::parsers::ClaudeCodeParser::new().retroactive_reconciliation());
     }
 }

--- a/src/parsers/gemini.rs
+++ b/src/parsers/gemini.rs
@@ -213,7 +213,7 @@ impl GeminiParser {
             let mut bytes = line.into_bytes();
             let parsed: GeminiJsonlLine = match simd_json::from_slice(&mut bytes) {
                 Ok(v) => v,
-                Err(_) => continue, // malformed line: skip
+                Err(_) => continue,
             };
 
             // Metadata line — capture sessionId for subsequent message records.
@@ -415,8 +415,6 @@ mod tests {
             .join("session-2026-04-22T11-00-00-no00meta.jsonl")
     }
 
-    // ===== Legacy .json regression tests (preserved from prior version) =====
-
     #[test]
     fn test_parse_gemini_json() {
         let parser = GeminiParser::with_data_dir(PathBuf::from("tests/fixtures/gemini"));
@@ -431,7 +429,6 @@ mod tests {
 
         let first = &entries[0];
         assert_eq!(first.model, Some("gemini-2.5-pro".to_string()));
-        // input(100) includes cached(20) upstream → billable non-cached = 80
         assert_eq!(first.input_tokens, 80);
         assert_eq!(first.output_tokens, 50);
         assert_eq!(first.cache_read_tokens, 20);
@@ -448,7 +445,6 @@ mod tests {
         let entries = parser.parse_file(&fixture_path()).unwrap();
 
         let second = &entries[1];
-        // input(250) includes cached(50) upstream → billable non-cached = 200
         assert_eq!(second.input_tokens, 200);
         assert_eq!(second.output_tokens, 150);
         assert_eq!(second.cache_read_tokens, 50);
@@ -472,7 +468,6 @@ mod tests {
     #[test]
     fn test_parser_file_pattern() {
         let parser = GeminiParser::new();
-        // Representative — see `collect_files` for the full glob set.
         assert_eq!(parser.file_pattern(), "*/chats/session-*.jsonl");
     }
 
@@ -487,8 +482,6 @@ mod tests {
     fn test_total_tokens_includes_thinking() {
         let parser = GeminiParser::with_data_dir(PathBuf::from("tests/fixtures/gemini"));
         let entries = parser.parse_file(&fixture_path()).unwrap();
-        // non-cached input + output + cache_read + reasoning
-        // e0: 80 + 50 + 20 + 30 = 180 ; e1: 200 + 150 + 50 + 100 = 500
         assert_eq!(entries[0].total_tokens(), 180);
         assert_eq!(entries[1].total_tokens(), 500);
     }
@@ -518,7 +511,6 @@ mod tests {
 
     #[test]
     fn test_project_none_when_no_project_root() {
-        // Without a `.project_root` sidecar, project stays None (→ no-project bucket).
         let tmp = tempfile::TempDir::new().unwrap();
         let chats = tmp.path().join("tmp").join("p").join("chats");
         std::fs::create_dir_all(&chats).unwrap();
@@ -557,14 +549,11 @@ mod tests {
             .all(|e| e.model.is_some() && e.model.as_deref() != Some("unknown")));
     }
 
-    // ===== JSONL tests =====
-
     #[test]
     fn test_parse_jsonl_main_session() {
         let parser = GeminiParser::with_data_dir(PathBuf::from("tests/fixtures/gemini"));
         let entries = parser.parse_file(&jsonl_fixture_path()).unwrap();
 
-        // Only `type: "gemini"` lines (m2, m4) count; user/error/$set/$rewindTo are skipped.
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].message_id, Some("m2".to_string()));
         assert_eq!(entries[0].model, Some("gemini-2.5-pro".to_string()));
@@ -577,9 +566,7 @@ mod tests {
         let parser = GeminiParser::with_data_dir(PathBuf::from("tests/fixtures/gemini"));
         let entries = parser.parse_file(&jsonl_fixture_path()).unwrap();
 
-        // m2: input=100 (incl. cached=20), tool=10 → (100-20)+10 = 90
         assert_eq!(entries[0].input_tokens, 90);
-        // m4: input=250 (incl. cached=50), no tool → 250-50 = 200
         assert_eq!(entries[1].input_tokens, 200);
     }
 
@@ -600,13 +587,11 @@ mod tests {
                 "total_tokens() must reconcile with upstream reported total"
             );
         }
-        // m2: 90 + 50 + 20 + 30 = 190
         assert_eq!(entries[0].reported_total_tokens, Some(190));
     }
 
     #[test]
     fn test_legacy_json_has_no_reported_total() {
-        // Legacy .json fixtures carry no `total` field → None.
         let parser = GeminiParser::with_data_dir(PathBuf::from("tests/fixtures/gemini"));
         let entries = parser.parse_file(&fixture_path()).unwrap();
         assert!(entries.iter().all(|e| e.reported_total_tokens.is_none()));
@@ -624,8 +609,6 @@ mod tests {
 
     #[test]
     fn test_parse_jsonl_skips_set_and_rewind_and_non_gemini() {
-        // Implicitly covered by main_session test (len == 2), but make it explicit:
-        // m1 (user), $set, m3 (error), $rewindTo are all skipped.
         let parser = GeminiParser::with_data_dir(PathBuf::from("tests/fixtures/gemini"));
         let entries = parser.parse_file(&jsonl_fixture_path()).unwrap();
         let ids: Vec<_> = entries
@@ -642,7 +625,6 @@ mod tests {
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].message_id, Some("sm2".to_string()));
-        // input=40 includes cached=5 → billable non-cached = 35
         assert_eq!(entries[0].input_tokens, 35);
         assert_eq!(
             entries[0].request_id,
@@ -655,8 +637,6 @@ mod tests {
         let parser = GeminiParser::with_data_dir(PathBuf::from("tests/fixtures/gemini"));
         let entries = parser.parse_file(&jsonl_malformed_path()).unwrap();
 
-        // Blank line, `{not_json`, and gemini-without-timestamp should all skip.
-        // Only `bm1` (well-formed gemini) survives.
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].message_id, Some("bm1".to_string()));
         assert_eq!(entries[0].input_tokens, 7);
@@ -668,7 +648,6 @@ mod tests {
         let entries = parser.parse_file(&jsonl_no_meta_path()).unwrap();
 
         assert_eq!(entries.len(), 1);
-        // No metadata line → request_id falls back to the file stem.
         assert_eq!(
             entries[0].request_id,
             Some("session-2026-04-22T11-00-00-no00meta".to_string())
@@ -687,23 +666,14 @@ mod tests {
         let parser = GeminiParser::with_data_dir(fixture_root());
         let files = parser.collect_files();
 
-        // Expected matches:
-        // - tmp123/chats/session-abc123.json                          (legacy main)
-        // - tmp456/chats/session-no-session-model.json                (legacy main)
-        // - tmp_jsonl/chats/session-2026-04-20T10-00-00-abc12345.jsonl (main new)
-        // - tmp_jsonl/chats/parent-session-xyz/sub-abc.jsonl           (subagent)
-        // - tmp_jsonl_malformed/chats/session-bad.jsonl                (main new, bad lines)
-        // - tmp_jsonl_no_meta/chats/session-2026-04-22T11-00-00-no00meta.jsonl (main new)
         assert_eq!(files.len(), 6, "got files: {:?}", files);
 
-        // Spot-check both extensions present
         assert!(files
             .iter()
             .any(|f| f.extension().and_then(|s| s.to_str()) == Some("json")));
         assert!(files
             .iter()
             .any(|f| f.extension().and_then(|s| s.to_str()) == Some("jsonl")));
-        // Spot-check subagent path nested under a parent dir under chats/
         assert!(files
             .iter()
             .any(|f| f.to_string_lossy().contains("parent-session-xyz")));
@@ -714,14 +684,6 @@ mod tests {
         let parser = GeminiParser::with_data_dir(fixture_root());
         let entries = parser.parse_all().unwrap();
 
-        // Expected entries per file:
-        // - tmp123/...session-abc123.json: 2
-        // - tmp456/...session-no-session-model.json: 2
-        // - tmp_jsonl/...session-2026-04-20....jsonl: 2
-        // - tmp_jsonl/...parent-session-xyz/sub-abc.jsonl: 1
-        // - tmp_jsonl_malformed/...session-bad.jsonl: 1
-        // - tmp_jsonl_no_meta/...session-2026-04-22....jsonl: 1
-        // = 9 total, all unique message_id × request_id combos.
         assert_eq!(entries.len(), 9);
     }
 
@@ -733,18 +695,15 @@ mod tests {
     fn test_gemini_cli_home_env_var() {
         let saved = std::env::var("GEMINI_CLI_HOME").ok();
 
-        // Case 1 — non-empty value overrides home.
         std::env::set_var("GEMINI_CLI_HOME", "/tmp/toktrack-gemini-env-test");
         assert_eq!(
             GeminiParser::new().data_dir(),
             Path::new("/tmp/toktrack-gemini-env-test/.gemini/tmp")
         );
 
-        // Case 2 — empty value is treated as unset (matches gemini-cli JS falsiness).
         std::env::set_var("GEMINI_CLI_HOME", "");
         assert_ne!(GeminiParser::new().data_dir(), Path::new("/.gemini/tmp"));
 
-        // Restore prior env state.
         match saved {
             Some(v) => std::env::set_var("GEMINI_CLI_HOME", v),
             None => std::env::remove_var("GEMINI_CLI_HOME"),

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -103,9 +103,7 @@ pub trait CLIParser: Send + Sync {
                 if seen.insert(hash) {
                     deduped.push(entry);
                 }
-                // Skip duplicate (hash already in set)
             } else {
-                // No hash (missing message_id or request_id) - keep entry
                 deduped.push(entry);
             }
         }
@@ -307,8 +305,6 @@ mod tests {
         let parser = ClaudeCodeParser::with_data_dir(PathBuf::from("tests/fixtures"));
         let result = parser.parse_all().unwrap();
         assert!(!result.is_empty());
-        // claude-sample.jsonl (4) + empty.jsonl (0) + multi/*.jsonl (2)
-        //   + claude/real-shape-session.jsonl (1) = 7
         assert_eq!(result.len(), 7);
     }
 
@@ -316,33 +312,26 @@ mod tests {
     fn test_parse_all_multiple_files() {
         let parser = ClaudeCodeParser::with_data_dir(PathBuf::from("tests/fixtures/multi"));
         let result = parser.parse_all().unwrap();
-        // 2 files × 1 entry each = 2 entries
         assert_eq!(result.len(), 2);
     }
 
     #[test]
     fn test_parse_all_with_empty_file() {
-        // tests/fixtures has claude-sample.jsonl (3), empty.jsonl (0), multi/*.jsonl (2)
         let parser = ClaudeCodeParser::with_data_dir(PathBuf::from("tests/fixtures"));
         let result = parser.parse_all().unwrap();
-        // empty.jsonl contributes 0 entries, total = 7
         assert_eq!(result.len(), 7);
     }
 
     #[test]
     fn test_parse_recent_files_includes_all_recent() {
-        // All fixture files were modified recently (exist on disk now)
-        // Using epoch as since → all files should be included
         let parser = ClaudeCodeParser::with_data_dir(PathBuf::from("tests/fixtures"));
         let since = std::time::UNIX_EPOCH;
         let result = parser.parse_recent_files(since).unwrap();
-        // Same as parse_all: all files are "recent" relative to epoch
         assert_eq!(result.len(), 7);
     }
 
     #[test]
     fn test_parse_recent_files_filters_old() {
-        // Using a future time as since → no files should match
         let parser = ClaudeCodeParser::with_data_dir(PathBuf::from("tests/fixtures"));
         let since = SystemTime::now() + std::time::Duration::from_secs(3600);
         let result = parser.parse_recent_files(since).unwrap();
@@ -361,20 +350,6 @@ mod tests {
     fn test_collect_files() {
         let parser = ClaudeCodeParser::with_data_dir(PathBuf::from("tests/fixtures"));
         let files = parser.collect_files();
-        // claude-sample.jsonl, empty.jsonl, multi/file1.jsonl, multi/file2.jsonl,
-        // codex/sample-session.jsonl, codex/multi-turn-session.jsonl,
-        // codex/openai-session.jsonl, codex/multi-session-meta.jsonl,
-        // codex/cwd-session.jsonl,
-        // pi_agent/sample-session.jsonl,
-        // gemini/tmp_jsonl/chats/session-*.jsonl,
-        // gemini/tmp_jsonl/chats/parent-session-xyz/sub-abc.jsonl,
-        // gemini/tmp_jsonl_malformed/chats/session-bad.jsonl,
-        // gemini/tmp_jsonl_no_meta/chats/session-*.jsonl
-        // claude/real-shape-session.jsonl
-        // qwen/proj/chats/session-*.jsonl
-        // qwen_v2/projects/g--scripts-test-qwen/chats/sess-new.jsonl
-        // qwen_v2/tmp/hash1/chats/session-*.jsonl
-        // (claude parser uses `**/*.jsonl`; gemini/qwen-format files parse to 0 entries.)
         assert_eq!(files.len(), 18);
     }
 }

--- a/src/parsers/opencode.rs
+++ b/src/parsers/opencode.rs
@@ -354,8 +354,6 @@ mod tests {
         )
     }
 
-    // ===== Existing JSON-mode tests (regression coverage) =====
-
     #[test]
     fn parses_single_json_message() {
         let parser = OpenCodeParser::with_data_dir(fixture_dir());
@@ -441,7 +439,6 @@ mod tests {
     fn computes_total_tokens_for_json_entry() {
         let parser = OpenCodeParser::with_data_dir(fixture_dir());
         let entries = parser.parse_file(&fixture_path("msg_001.json")).unwrap();
-        // 1000 + 500 + 100 + 50 + 0 = 1650
         assert_eq!(entries[0].total_tokens(), 1650);
     }
 
@@ -449,11 +446,8 @@ mod tests {
     fn computes_total_tokens_with_reasoning() {
         let parser = OpenCodeParser::with_data_dir(fixture_dir());
         let entries = parser.parse_file(&fixture_path("msg_002.json")).unwrap();
-        // 2000 + 800 + 200 + 100 + 150 = 3250
         assert_eq!(entries[0].total_tokens(), 3250);
     }
-
-    // ===== New SQLite-mode tests =====
 
     #[test]
     fn reads_from_sqlite_when_db_exists() {
@@ -486,7 +480,6 @@ mod tests {
 
     #[test]
     fn falls_back_to_json_when_db_missing() {
-        // Re-uses existing JSON fixtures; no SQLite db present.
         let parser = OpenCodeParser::with_base_dir(
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("tests")
@@ -494,7 +487,6 @@ mod tests {
                 .join("opencode"),
         );
         let entries = parser.parse_all().unwrap();
-        // msg_001 + msg_002 yield entries; msg_003_no_tokens is skipped.
         assert_eq!(entries.len(), 2);
     }
 
@@ -503,7 +495,6 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let base = tmp.path().to_path_buf();
 
-        // Seed JSON files that should be ignored when the db is present.
         let json_dir = base.join("storage").join("message").join("ses_legacy");
         fs::create_dir_all(&json_dir).unwrap();
         fs::write(
@@ -649,7 +640,6 @@ mod tests {
     fn sqlite_open_failure_returns_empty() {
         let tmp = TempDir::new().unwrap();
         let base = tmp.path().to_path_buf();
-        // Write a non-sqlite file at the db path so opening fails after the existence check.
         fs::write(base.join("opencode.db"), b"not a real sqlite file").unwrap();
 
         let parser = OpenCodeParser::with_base_dir(base);
@@ -671,7 +661,6 @@ mod tests {
                 &assistant_data("opus-4", 1_700_000_000_000, 100, 50),
             )],
         );
-        // Add the `session` table (new OpenCode schema) with a directory.
         let conn = Connection::open(&db).unwrap();
         conn.execute_batch(
             "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL);\n\

--- a/src/parsers/pi_agent.rs
+++ b/src/parsers/pi_agent.rs
@@ -270,7 +270,6 @@ mod tests {
             .parse_file(&fixture_path("sample-session.jsonl"))
             .unwrap();
 
-        // Fixture contains a single assistant usage event
         assert_eq!(entries.len(), 1);
     }
 
@@ -301,8 +300,6 @@ mod tests {
             .parse_file(&fixture_path("sample-session.jsonl"))
             .unwrap();
 
-        // The leading `session` line carries cwd="/tmp/example-project"; it must
-        // be attached to the file's usage entries as the project.
         assert_eq!(entries[0].project.as_deref(), Some("/tmp/example-project"));
     }
 
@@ -313,8 +310,6 @@ mod tests {
             .parse_file(&fixture_path("sample-session.jsonl"))
             .unwrap();
 
-        // 5 lines total: session, model_change, thinking_level_change, user msg,
-        // assistant msg → only the assistant message produces an entry
         assert_eq!(entries.len(), 1);
     }
 
@@ -332,7 +327,6 @@ mod tests {
 
     #[test]
     fn test_pi_session_dir_env_takes_precedence() {
-        // PI_CODING_AGENT_SESSION_DIR (== --session-dir) wins over legacy PI_AGENT_DIR.
         let saved_s = std::env::var("PI_CODING_AGENT_SESSION_DIR").ok();
         let saved_a = std::env::var("PI_AGENT_DIR").ok();
         std::env::set_var("PI_AGENT_DIR", "/tmp/toktrack-pi-legacy");

--- a/src/parsers/qwen.rs
+++ b/src/parsers/qwen.rs
@@ -122,7 +122,7 @@ impl QwenParser {
             let mut bytes = line.into_bytes();
             let parsed: QwenLine = match simd_json::from_slice(&mut bytes) {
                 Ok(v) => v,
-                Err(_) => continue, // malformed line: skip
+                Err(_) => continue,
             };
 
             // Only `assistant` lines carry usage. The same counts also appear on
@@ -276,20 +276,17 @@ mod tests {
     fn test_parser_name_and_data_dir_with_env() {
         let saved = std::env::var("QWEN_HOME").ok();
 
-        // Default — without QWEN_HOME, data dir resolves under `~/.qwen`.
         std::env::remove_var("QWEN_HOME");
         let parser = QwenParser::new();
         assert_eq!(parser.name(), "qwen");
         assert!(parser.data_dir().ends_with(".qwen"));
 
-        // Override — QWEN_HOME points the data dir elsewhere.
         std::env::set_var("QWEN_HOME", "/tmp/toktrack-qwen-env-test");
         assert_eq!(
             QwenParser::new().data_dir(),
             Path::new("/tmp/toktrack-qwen-env-test")
         );
 
-        // Restore prior env state.
         match saved {
             Some(v) => std::env::set_var("QWEN_HOME", v),
             None => std::env::remove_var("QWEN_HOME"),
@@ -298,8 +295,6 @@ mod tests {
 
     #[test]
     fn test_new_format_counts_only_assistant_usage_lines() {
-        // user / system / ui_telemetry / tool_result / malformed / assistant-without-
-        // usage are all skipped; only a1 and a2 (assistant + usageMetadata) survive.
         let parser = QwenParser::with_data_dir(root());
         let entries = parser.parse_file(&new_session()).unwrap();
         let ids: Vec<_> = entries
@@ -316,19 +311,15 @@ mod tests {
 
         let a1 = &entries[0];
         assert_eq!(a1.model, Some("glm-5.2".to_string()));
-        // prompt(1000) includes cached(200) → billable non-cached input = 800
         assert_eq!(a1.input_tokens, 800);
-        // candidates(500) includes thoughts(100) → output = 400, reasoning = 100
         assert_eq!(a1.output_tokens, 400);
         assert_eq!(a1.cache_read_tokens, 200);
         assert_eq!(a1.cache_creation_tokens, 0);
         assert_eq!(a1.reasoning_tokens, 100);
         assert_eq!(a1.reported_total_tokens, Some(1500));
-        // total_tokens() must reconcile with the upstream-reported total.
         assert_eq!(a1.total_tokens(), 1500);
         assert_eq!(a1.source, Some("qwen".into()));
         assert_eq!(a1.request_id, Some("S".to_string()));
-        // cwd on the line is the project identifier (no sidecar needed)
         assert_eq!(a1.project.as_deref(), Some("G:\\proj"));
 
         let a2 = &entries[1];
@@ -352,8 +343,6 @@ mod tests {
     fn test_collect_files_finds_new_and_legacy() {
         let parser = QwenParser::with_data_dir(root());
         let files = parser.collect_files();
-        // projects/g--scripts-test-qwen/chats/sess-new.jsonl  (new)
-        // tmp/hash1/chats/session-2026-06-01....jsonl          (legacy)
         assert_eq!(files.len(), 2, "got files: {:?}", files);
         assert!(files
             .iter()
@@ -386,7 +375,6 @@ mod tests {
     fn test_parse_all_aggregates_new_and_legacy() {
         let parser = QwenParser::with_data_dir(root());
         let entries = parser.parse_all().unwrap();
-        // new: a1, a2 (2) + legacy: lq2 (1) = 3, all tagged "qwen"
         assert_eq!(entries.len(), 3);
         assert!(entries.iter().all(|e| e.source == Some("qwen".into())));
     }
@@ -403,11 +391,9 @@ mod tests {
         assert_eq!(entries.len(), 1);
         let e = &entries[0];
         assert_eq!(e.model, Some("qwen3-coder".to_string()));
-        // legacy: input 200 incl. cached 40 → 160 ; total reconciles to 300
         assert_eq!(e.input_tokens, 160);
         assert_eq!(e.cache_read_tokens, 40);
         assert_eq!(e.reported_total_tokens, Some(300));
-        // project comes from the `.project_root` sidecar in legacy layout
         assert_eq!(e.project.as_deref(), Some("/work/legacy-demo"));
     }
 }

--- a/src/report/data.rs
+++ b/src/report/data.rs
@@ -116,7 +116,6 @@ impl ReportData {
 
         daily.sort_by_key(|d| d.date);
 
-        // Build model reports
         let owned_filtered: Vec<DailySummary> = filtered.into_iter().cloned().collect();
         let model_map = Aggregator::by_model_from_daily(&owned_filtered);
         let mut by_model: Vec<ModelReport> = model_map
@@ -131,7 +130,6 @@ impl ReportData {
             .collect();
         by_model.sort_by(|a, b| b.cost_usd.total_cmp(&a.cost_usd));
 
-        // Build source reports (filtered to period)
         let mut by_source: Vec<SourceReport> = source_summaries
             .iter()
             .filter_map(|(source_name, daily_summaries)| {
@@ -354,7 +352,7 @@ mod tests {
             NaiveDate::from_ymd_opt(2024, 1, 7).unwrap(),
         );
         assert_eq!(data.by_source.len(), 2);
-        // claude: only the in-range entry ($3.00), not the $50 one
+        // Only Claude's in-range entry contributes, not the $50 entry.
         assert_eq!(data.by_source[0].name, "claude");
         assert!((data.by_source[0].cost_usd - 3.00).abs() < f64::EPSILON);
         assert_eq!(data.by_source[1].name, "codex");

--- a/src/report/text.rs
+++ b/src/report/text.rs
@@ -39,11 +39,9 @@ fn truncate(s: &str, max: usize) -> String {
 fn boxed_line(out: &mut String, w: usize, content: &str) {
     let char_count = content.chars().count();
     if char_count >= w {
-        // Truncate to fit
         let truncated: String = content.chars().take(w).collect();
         out.push_str(&format!("\u{2502}{}\u{2502}\n", truncated));
     } else {
-        // Pad with spaces
         out.push_str(&format!(
             "\u{2502}{}{}\u{2502}\n",
             content,
@@ -203,7 +201,6 @@ fn center_line(out: &mut String, w: usize, text: &str) {
 }
 
 fn kv_line(out: &mut String, w: usize, key: &str, value: &str) {
-    // " key............ value"
     let key_len = key.len();
     let val_len = value.len();
     let dots = w.saturating_sub(key_len + val_len + 2); // 1 leading space + 1 trailing space

--- a/src/services/aggregator.rs
+++ b/src/services/aggregator.rs
@@ -97,7 +97,6 @@ impl Aggregator {
             return Vec::new();
         }
 
-        // Group by date
         let mut daily_map: HashMap<chrono::NaiveDate, DailySummary> = HashMap::new();
 
         for entry in entries {
@@ -149,7 +148,6 @@ impl Aggregator {
                 .saturating_add(entry.web_search_requests);
             summary.total_cost_usd += cost;
 
-            // Update model breakdown
             let model_usage = summary.models.entry(model_name.clone()).or_default();
             model_usage.add(entry, cost);
 
@@ -163,7 +161,6 @@ impl Aggregator {
                 .add(entry, cost, &model_name);
         }
 
-        // Sort by date ascending
         let mut result: Vec<DailySummary> = daily_map.into_values().collect();
         result.sort_by_key(|s| s.date);
         result
@@ -178,7 +175,6 @@ impl Aggregator {
         let mut week_map: HashMap<chrono::NaiveDate, DailySummary> = HashMap::new();
 
         for summary in daily_summaries {
-            // Calculate the Sunday that starts this week
             let days_from_sunday = summary.date.weekday().num_days_from_sunday();
             let week_start = summary
                 .date
@@ -296,7 +292,6 @@ impl Aggregator {
                 .saturating_add(s.total_web_search_requests);
             summary.total_cost_usd += s.total_cost_usd;
 
-            // entry_count = sum of per-model counts across all daily summaries
             for model_usage in s.models.values() {
                 summary.entry_count = summary.entry_count.saturating_add(model_usage.count);
             }
@@ -452,7 +447,6 @@ impl Aggregator {
             })
             .collect();
 
-        // Sort by total_tokens descending
         result.sort_by_key(|b| std::cmp::Reverse(b.total_tokens));
         result
     }
@@ -572,7 +566,6 @@ mod tests {
                 Some(0.3),
                 Some("/proj/b"),
             ),
-            // No project -> bucketed under NO_PROJECT
             make_entry_with_project(2026, 1, 1, Some("gpt-4o"), 10, Some(0.1), None),
         ];
 
@@ -580,13 +573,11 @@ mod tests {
         assert_eq!(daily.len(), 1);
         let day = &daily[0];
 
-        // Three project buckets: /proj/a, /proj/b, NO_PROJECT
         assert_eq!(day.projects.len(), 3);
 
         let a = day.projects.get("/proj/a").expect("project a present");
         assert_eq!(a.input_tokens, 150);
         assert_eq!(a.count, 2);
-        // Nested per-model breakdown within the project.
         assert_eq!(a.models.len(), 2);
 
         let b = day.projects.get("/proj/b").expect("project b present");
@@ -595,7 +586,6 @@ mod tests {
         let none = day.projects.get(NO_PROJECT).expect("no-project bucket");
         assert_eq!(none.input_tokens, 10);
 
-        // Project totals reconcile with the day total.
         let proj_sum: u64 = day.projects.values().map(|p| p.input_tokens).sum();
         assert_eq!(proj_sum, day.total_input_tokens);
     }
@@ -674,12 +664,10 @@ mod tests {
         let daily = Aggregator::daily(&entries);
         let per_project = Aggregator::project_daily_summaries(&daily);
 
-        // Project a spans two days; project b only one.
         let a_days = per_project.get("/proj/a").unwrap();
         assert_eq!(a_days.len(), 2);
-        assert_eq!(a_days[0].total_input_tokens, 100); // sorted ascending by date
+        assert_eq!(a_days[0].total_input_tokens, 100);
         assert_eq!(a_days[1].total_input_tokens, 200);
-        // Each exploded day carries the project's per-model breakdown.
         assert!(!a_days[0].models.is_empty());
 
         let b_days = per_project.get("/proj/b").unwrap();
@@ -712,7 +700,6 @@ mod tests {
         let daily = Aggregator::daily(&entries);
         let weekly = Aggregator::weekly(&daily);
 
-        // Both days fall in the same week; the project breakdown must be merged.
         assert_eq!(weekly.len(), 1);
         let week = &weekly[0];
         assert_eq!(week.projects.get("/proj/a").unwrap().input_tokens, 300);
@@ -790,7 +777,6 @@ mod tests {
         let result = Aggregator::daily(&entries);
 
         assert_eq!(result.len(), 3);
-        // Should be sorted ascending by date
         assert_eq!(result[0].date.to_string(), "2024-01-10");
         assert_eq!(result[1].date.to_string(), "2024-01-15");
         assert_eq!(result[2].date.to_string(), "2024-01-20");
@@ -811,7 +797,6 @@ mod tests {
         assert_eq!(result[0].total_cache_read_tokens, 30);
         assert_eq!(result[0].total_cache_creation_tokens, 15);
         assert!((result[0].total_cost_usd - 0.03).abs() < f64::EPSILON);
-        // Should have 2 models in the breakdown
         assert_eq!(result[0].models.len(), 2);
     }
 
@@ -872,8 +857,8 @@ mod tests {
         assert_eq!(result.len(), 2);
 
         let claude = result.get("claude").unwrap();
-        assert_eq!(claude.input_tokens, 300); // 100 + 200
-        assert_eq!(claude.output_tokens, 150); // 50 + 100
+        assert_eq!(claude.input_tokens, 300);
+        assert_eq!(claude.output_tokens, 150);
         assert_eq!(claude.count, 2);
 
         let gpt = result.get("gpt-4").unwrap();
@@ -884,7 +869,6 @@ mod tests {
 
     #[test]
     fn test_by_model_normalizes_date_suffix() {
-        // claude-sonnet-4-20250514 and claude-sonnet-4 should be grouped together
         let entries = vec![
             make_entry(
                 2024,
@@ -900,10 +884,9 @@ mod tests {
 
         let result = Aggregator::by_model(&entries);
 
-        // Should have only one model: claude-sonnet-4
         assert_eq!(result.len(), 1);
         let usage = result.get("claude-sonnet-4").unwrap();
-        assert_eq!(usage.input_tokens, 300); // 100 + 200
+        assert_eq!(usage.input_tokens, 300);
         assert_eq!(usage.count, 2);
     }
 
@@ -925,7 +908,6 @@ mod tests {
         let result = Aggregator::daily(&entries);
 
         assert_eq!(result.len(), 1);
-        // Should have only one model in the breakdown
         assert_eq!(result[0].models.len(), 1);
         assert!(result[0].models.contains_key("claude-opus-4-5"));
     }
@@ -978,29 +960,26 @@ mod tests {
 
         let result = Aggregator::total(&entries);
 
-        assert_eq!(result.total_input_tokens, 600); // 100 + 200 + 300
-        assert_eq!(result.total_output_tokens, 300); // 50 + 100 + 150
-        assert_eq!(result.total_cache_read_tokens, 60); // 10 + 20 + 30
-        assert_eq!(result.total_cache_creation_tokens, 30); // 5 + 10 + 15
+        assert_eq!(result.total_input_tokens, 600);
+        assert_eq!(result.total_output_tokens, 300);
+        assert_eq!(result.total_cache_read_tokens, 60);
+        assert_eq!(result.total_cache_creation_tokens, 30);
         assert!((result.total_cost_usd - 0.06).abs() < f64::EPSILON);
         assert_eq!(result.entry_count, 3);
-        assert_eq!(result.day_count, 2); // 2 distinct days
+        assert_eq!(result.day_count, 2);
     }
 
     #[test]
     fn test_total_with_none_cost() {
         let entries = vec![
             make_entry(2024, 1, 15, Some("claude"), 100, 50, Some(0.01)),
-            make_entry(2024, 1, 15, Some("claude"), 100, 50, None), // No cost
+            make_entry(2024, 1, 15, Some("claude"), 100, 50, None),
         ];
 
         let result = Aggregator::total(&entries);
 
-        // None cost should be treated as 0.0
         assert!((result.total_cost_usd - 0.01).abs() < f64::EPSILON);
     }
-
-    // ========== Weekly aggregation tests ==========
 
     fn make_daily_summary(
         year: i32,
@@ -1059,7 +1038,6 @@ mod tests {
 
     #[test]
     fn test_weekly_single_day() {
-        // 2025-01-15 is Wednesday → week starts on 2025-01-12 (Sunday)
         let summaries = vec![make_daily_summary(2025, 1, 15, 100, 50, 0.01)];
         let result = Aggregator::weekly(&summaries);
 
@@ -1071,7 +1049,6 @@ mod tests {
 
     #[test]
     fn test_weekly_same_week_merge() {
-        // 2025-01-13 (Mon) and 2025-01-15 (Wed) → both in week starting 2025-01-12 (Sun)
         let summaries = vec![
             make_daily_summary(2025, 1, 13, 100, 50, 0.01),
             make_daily_summary(2025, 1, 15, 200, 100, 0.02),
@@ -1087,8 +1064,6 @@ mod tests {
 
     #[test]
     fn test_weekly_cross_week() {
-        // 2025-01-18 (Sat) → week of 2025-01-12
-        // 2025-01-19 (Sun) → week of 2025-01-19
         let summaries = vec![
             make_daily_summary(2025, 1, 18, 100, 50, 0.01),
             make_daily_summary(2025, 1, 19, 200, 100, 0.02),
@@ -1102,8 +1077,6 @@ mod tests {
 
     #[test]
     fn test_weekly_sunday_stays() {
-        // Sunday itself is the start of its own week
-        // 2025-01-12 is a Sunday
         let summaries = vec![make_daily_summary(2025, 1, 12, 100, 50, 0.01)];
         let result = Aggregator::weekly(&summaries);
 
@@ -1113,7 +1086,6 @@ mod tests {
 
     #[test]
     fn test_weekly_saturday_maps_to_sunday() {
-        // 2025-01-18 is Saturday → maps to Sunday 2025-01-12
         let summaries = vec![make_daily_summary(2025, 1, 18, 100, 50, 0.01)];
         let result = Aggregator::weekly(&summaries);
 
@@ -1157,7 +1129,6 @@ mod tests {
             },
         );
 
-        // Same week (Mon and Wed of 2025-01-12 week)
         let summaries = vec![
             make_daily_summary_with_models(2025, 1, 13, 100, 50, 0.01, models_a),
             make_daily_summary_with_models(2025, 1, 15, 250, 125, 0.025, models_b),
@@ -1179,9 +1150,9 @@ mod tests {
     #[test]
     fn test_weekly_sorted() {
         let summaries = vec![
-            make_daily_summary(2025, 1, 20, 100, 50, 0.01), // week of Jan 19
-            make_daily_summary(2025, 1, 6, 200, 100, 0.02), // week of Jan 5
-            make_daily_summary(2025, 1, 13, 150, 75, 0.015), // week of Jan 12
+            make_daily_summary(2025, 1, 20, 100, 50, 0.01),
+            make_daily_summary(2025, 1, 6, 200, 100, 0.02),
+            make_daily_summary(2025, 1, 13, 150, 75, 0.015),
         ];
         let result = Aggregator::weekly(&summaries);
 
@@ -1190,8 +1161,6 @@ mod tests {
         assert_eq!(result[1].date.to_string(), "2025-01-12");
         assert_eq!(result[2].date.to_string(), "2025-01-19");
     }
-
-    // ========== Monthly aggregation tests ==========
 
     #[test]
     fn test_monthly_empty() {
@@ -1239,7 +1208,6 @@ mod tests {
 
     #[test]
     fn test_monthly_first_of_month() {
-        // Date is already first of month
         let summaries = vec![make_daily_summary(2025, 3, 1, 100, 50, 0.01)];
         let result = Aggregator::monthly(&summaries);
 
@@ -1261,8 +1229,6 @@ mod tests {
         assert_eq!(result[1].date.to_string(), "2025-02-01");
         assert_eq!(result[2].date.to_string(), "2025-03-01");
     }
-
-    // ========== total_from_daily tests ==========
 
     #[test]
     fn test_total_from_daily_empty() {
@@ -1338,11 +1304,9 @@ mod tests {
         assert_eq!(result.total_input_tokens, 300);
         assert_eq!(result.total_output_tokens, 150);
         assert!((result.total_cost_usd - 0.03).abs() < f64::EPSILON);
-        assert_eq!(result.entry_count, 3); // 2 + 1
+        assert_eq!(result.entry_count, 3);
         assert_eq!(result.day_count, 2);
     }
-
-    // ========== by_model_from_daily tests ==========
 
     #[test]
     fn test_by_model_from_daily_empty() {
@@ -1402,8 +1366,6 @@ mod tests {
         assert_eq!(gpt.input_tokens, 50);
         assert_eq!(gpt.count, 1);
     }
-
-    // ========== accumulate_summary / merge_model_usage gap tests ==========
 
     #[test]
     fn test_accumulate_summary_with_cache_tokens() {
@@ -1484,7 +1446,6 @@ mod tests {
 
     #[test]
     fn test_total_from_daily_entry_count_zero_count_models() {
-        // Models with count=0 should not inflate entry_count
         let mut models = HashMap::new();
         models.insert(
             "claude".to_string(),
@@ -1492,7 +1453,7 @@ mod tests {
                 input_tokens: 100,
                 output_tokens: 50,
                 cost_usd: 0.01,
-                count: 0, // zero count edge case
+                count: 0,
                 ..Default::default()
             },
         );
@@ -1512,7 +1473,7 @@ mod tests {
 
         let result = Aggregator::total_from_daily(&summaries);
 
-        assert_eq!(result.entry_count, 5); // 0 + 5
+        assert_eq!(result.entry_count, 5);
         assert_eq!(result.day_count, 1);
     }
 
@@ -1582,7 +1543,6 @@ mod tests {
 
         accumulate_summary(&mut target, &source);
 
-        // Models should be merged
         assert_eq!(target.models.len(), 2);
         let claude = target.models.get("claude").unwrap();
         assert_eq!(claude.input_tokens, 300);
@@ -1591,8 +1551,6 @@ mod tests {
         assert_eq!(gpt.input_tokens, 50);
         assert_eq!(gpt.count, 1);
     }
-
-    // ========== by_source tests ==========
 
     #[allow(clippy::too_many_arguments)]
     fn make_entry_with_source(
@@ -1626,8 +1584,6 @@ mod tests {
             project: None,
         }
     }
-
-    // ========== Timezone boundary tests ==========
 
     #[test]
     fn test_daily_groups_by_local_date_not_utc() {
@@ -1680,18 +1636,14 @@ mod tests {
 
         let result = Aggregator::daily(&[entry_late.clone(), entry_early.clone()]);
 
-        // Both entries should be grouped by their LOCAL date, not UTC date.
-        // Verify grouping uses local_date()
         let expected_date_late = entry_late.local_date();
         let expected_date_early = entry_early.local_date();
 
         if expected_date_late == expected_date_early {
-            // Same local date → single summary
             assert_eq!(result.len(), 1);
             assert_eq!(result[0].date, expected_date_late);
-            assert_eq!(result[0].total_input_tokens, 300); // 100 + 200
+            assert_eq!(result[0].total_input_tokens, 300);
         } else {
-            // Different local dates → two summaries
             assert_eq!(result.len(), 2);
             let late_summary = result
                 .iter()
@@ -1757,7 +1709,6 @@ mod tests {
 
         let result = Aggregator::total(&entries);
 
-        // day_count should reflect local dates, not UTC dates
         let local_date1 = entries[0].local_date();
         let local_date2 = entries[1].local_date();
         let expected_days = if local_date1 == local_date2 { 1 } else { 2 };
@@ -1798,7 +1749,7 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].source, "claude");
-        assert_eq!(result[0].total_tokens, 450); // 100+50 + 200+100
+        assert_eq!(result[0].total_tokens, 450);
         assert!((result[0].total_cost_usd - 0.03).abs() < f64::EPSILON);
     }
 
@@ -1839,13 +1790,12 @@ mod tests {
         let result = Aggregator::by_source(&entries);
 
         assert_eq!(result.len(), 3);
-        // Sorted by total_tokens descending
         assert_eq!(result[0].source, "opencode");
-        assert_eq!(result[0].total_tokens, 450); // 300+150
+        assert_eq!(result[0].total_tokens, 450);
         assert_eq!(result[1].source, "claude");
-        assert_eq!(result[1].total_tokens, 150); // 100+50
+        assert_eq!(result[1].total_tokens, 150);
         assert_eq!(result[2].source, "gemini");
-        assert_eq!(result[2].total_tokens, 75); // 50+25
+        assert_eq!(result[2].total_tokens, 75);
     }
 
     #[test]
@@ -1865,8 +1815,6 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].source, "unknown");
     }
-
-    // ========== merge_by_date tests ==========
 
     #[test]
     fn test_merge_by_date_empty() {
@@ -1889,7 +1837,6 @@ mod tests {
 
     #[test]
     fn test_merge_by_date_merges_same_date() {
-        // Two summaries from different sources for the same date
         let summaries = vec![
             make_daily_summary(2025, 1, 15, 100, 50, 0.01),
             make_daily_summary(2025, 1, 15, 200, 100, 0.02),
@@ -1956,8 +1903,6 @@ mod tests {
         assert!(result[0].models.contains_key("gpt-4"));
     }
 
-    // ========== Issue #134: provider-aware model key ==========
-
     #[allow(clippy::too_many_arguments)]
     fn make_entry_with_provider(
         year: i32,
@@ -1993,13 +1938,11 @@ mod tests {
 
     #[test]
     fn test_format_model_key_provider_none() {
-        // provider=None preserves the legacy key (backward compatible).
         assert_eq!(format_model_key("claude-opus-4-5", None), "claude-opus-4-5");
     }
 
     #[test]
     fn test_format_model_key_provider_empty() {
-        // Empty string is treated as None.
         assert_eq!(format_model_key("gpt-4", Some("")), "gpt-4");
     }
 
@@ -2013,7 +1956,6 @@ mod tests {
 
     #[test]
     fn test_format_model_key_normalizes_model() {
-        // Model normalization (date-suffix removal) still applies.
         assert_eq!(
             format_model_key("claude-opus-4-5-20251101", Some("anthropic")),
             "claude-opus-4-5::anthropic"
@@ -2022,7 +1964,6 @@ mod tests {
 
     #[test]
     fn test_daily_separates_same_model_different_providers() {
-        // Issue #134: same model billed through different providers must split.
         let entries = vec![
             make_entry_with_provider(
                 2026,
@@ -2061,7 +2002,6 @@ mod tests {
 
     #[test]
     fn test_daily_keeps_legacy_key_when_provider_none() {
-        // Regression: provider=None entries must keep the legacy key format.
         let entries = vec![make_entry_with_provider(
             2026,
             4,
@@ -2114,7 +2054,6 @@ mod tests {
 
     #[test]
     fn test_weekly_separates_providers_across_days() {
-        // weekly() must keep same-model/different-provider entries separate.
         let entries = vec![
             make_entry_with_provider(
                 2026,
@@ -2183,7 +2122,6 @@ mod tests {
 
     #[test]
     fn test_merge_by_date_preserves_provider_separation() {
-        // merge_by_date must keep different-provider entries on the same date separate.
         let mut models_a = HashMap::new();
         models_a.insert(
             "gpt-5-4::github-copilot".to_string(),
@@ -2247,7 +2185,6 @@ mod tests {
 
     #[test]
     fn test_by_model_aggregates_same_provider() {
-        // Same model + same provider must aggregate into one entry.
         let entries = vec![
             make_entry_with_provider(
                 2026,

--- a/src/services/audit.rs
+++ b/src/services/audit.rs
@@ -70,7 +70,6 @@ pub fn audit_source(
     let id = id.into();
     let label = label.into();
 
-    // Union of all dates that carry data anywhere; bounds the covered range.
     let all: BTreeSet<NaiveDate> = live.iter().chain(cache.iter()).copied().collect();
     let start = all.iter().next().copied();
     let end = all.iter().next_back().copied();
@@ -179,7 +178,6 @@ mod tests {
 
     #[test]
     fn test_live_takes_precedence_over_cache() {
-        // A day present in BOTH live and cache is reported as live (recoverable).
         let day = d(2026, 3, 1);
         let audit = audit_source("claude-code", "claude-code", &set(&[day]), &set(&[day]));
 
@@ -191,7 +189,6 @@ mod tests {
 
     #[test]
     fn test_cache_only_when_raw_gone() {
-        // In cache but not on disk → preserved-by-toktrack.
         let day = d(2026, 3, 1);
         let audit = audit_source("codex", "codex", &HashSet::new(), &set(&[day]));
 
@@ -202,7 +199,6 @@ mod tests {
 
     #[test]
     fn test_missing_for_gap_days_inside_range() {
-        // Range is 03-01..=03-03; only the endpoints have data, the middle is a gap.
         let live = set(&[d(2026, 3, 1)]);
         let cache = set(&[d(2026, 3, 3)]);
         let audit = audit_source("gemini", "gemini", &live, &cache);
@@ -240,7 +236,6 @@ mod tests {
 
     #[test]
     fn test_counts_sum_to_total_days() {
-        // 03-01 live, 03-02 missing, 03-03 cache_only, 03-04 missing, 03-05 live.
         let live = set(&[d(2026, 3, 1), d(2026, 3, 5)]);
         let cache = set(&[d(2026, 3, 3)]);
         let audit = audit_source("claude-code", "claude-code", &live, &cache);
@@ -301,8 +296,6 @@ mod tests {
         )
         .unwrap();
 
-        // Parser points at a nonexistent dir → no live dates, so every cached
-        // date must be classified cache_only.
         let source = SourceInstance::new(
             "auditsrc",
             "auditsrc",

--- a/src/services/cache.rs
+++ b/src/services/cache.rs
@@ -268,7 +268,6 @@ impl DailySummaryCacheService {
             let _ = lf.unlock();
         }
 
-        // Migrate model names: normalize keys in the models HashMap
         let summaries: Vec<DailySummary> = cache
             .summaries
             .into_iter()
@@ -371,7 +370,6 @@ mod tests {
         (service, temp_dir)
     }
 
-    // Test 1: No cache computes all entries
     #[test]
     fn test_no_cache_computes_all_entries() {
         let (service, _temp) = create_test_service();
@@ -390,17 +388,15 @@ mod tests {
         assert_eq!(result[1].total_input_tokens, 200);
     }
 
-    // Test 2: Cache hit recomputes dates with new entries
     #[test]
     fn test_cache_recomputes_dates_with_entries() {
         let (service, _temp) = create_test_service();
         let today = Local::now().date_naive();
         let yesterday = today - chrono::Duration::days(1);
 
-        // Pre-populate cache with yesterday's data
         let cached_summary = DailySummary {
             date: yesterday,
-            total_input_tokens: 999, // Different from entries
+            total_input_tokens: 999,
             total_output_tokens: 999,
             total_cache_read_tokens: 0,
             total_cache_creation_tokens: 0,
@@ -422,7 +418,6 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(&cache_path, serde_json::to_string(&cache).unwrap()).unwrap();
 
-        // Entries for yesterday and today
         let entries = vec![
             UsageEntry {
                 timestamp: yesterday.and_hms_opt(12, 0, 0).unwrap().and_utc(),
@@ -468,20 +463,16 @@ mod tests {
 
         let (result, warning) = service.load_or_compute("claude-code", &entries).unwrap();
 
-        // Should have 2 summaries, no warning for valid cache
         assert!(warning.is_none());
         assert_eq!(result.len(), 2);
 
-        // Yesterday should be recomputed from entries (100), not cached (999)
         let yesterday_result = result.iter().find(|s| s.date == yesterday).unwrap();
         assert_eq!(yesterday_result.total_input_tokens, 100);
 
-        // Today should be recomputed (200)
         let today_result = result.iter().find(|s| s.date == today).unwrap();
         assert_eq!(today_result.total_input_tokens, 200);
     }
 
-    // Test 3: Corrupted cache falls back to full recomputation with warning
     #[test]
     fn test_corrupted_cache_falls_back() {
         let (service, _temp) = create_test_service();
@@ -493,13 +484,11 @@ mod tests {
 
         let (result, warning) = service.load_or_compute("claude-code", &entries).unwrap();
 
-        // Should return warning for corrupted cache
         assert!(matches!(warning, Some(CacheWarning::Corrupted(_))));
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].total_input_tokens, 100);
     }
 
-    // Test 4: Empty entries returns empty result
     #[test]
     fn test_empty_entries_returns_empty() {
         let (service, _temp) = create_test_service();
@@ -510,13 +499,11 @@ mod tests {
         assert!(result.is_empty());
     }
 
-    // Test 5: Merge deduplicates by date (new takes precedence)
     #[test]
     fn test_merge_deduplicates_by_date() {
         let (service, _temp) = create_test_service();
         let today = Local::now().date_naive();
 
-        // Pre-populate cache with today's old data
         let cached_summary = DailySummary {
             date: today,
             total_input_tokens: 999,
@@ -541,7 +528,6 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(&cache_path, serde_json::to_string(&cache).unwrap()).unwrap();
 
-        // New entry for today
         let entries = vec![UsageEntry {
             timestamp: today.and_hms_opt(12, 0, 0).unwrap().and_utc(),
             model: Some("claude".to_string()),
@@ -565,13 +551,11 @@ mod tests {
 
         let (result, _warning) = service.load_or_compute("claude-code", &entries).unwrap();
 
-        // Should only have one entry for today with the new value
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].date, today);
-        assert_eq!(result[0].total_input_tokens, 100); // New value, not 999
+        assert_eq!(result[0].total_input_tokens, 100);
     }
 
-    // Test 6: Results are sorted ascending by date
     #[test]
     fn test_results_sorted_ascending() {
         let (service, _temp) = create_test_service();
@@ -589,16 +573,14 @@ mod tests {
         assert_eq!(result[2].date.to_string(), "2024-01-20");
     }
 
-    // Test 7: Today is always recalculated even if in cache
     #[test]
     fn test_today_always_recalculated() {
         let (service, _temp) = create_test_service();
         let today = Local::now().date_naive();
 
-        // Pre-populate cache with today
         let cached_summary = DailySummary {
             date: today,
-            total_input_tokens: 50, // Old value
+            total_input_tokens: 50,
             total_output_tokens: 25,
             total_cache_read_tokens: 0,
             total_cache_creation_tokens: 0,
@@ -620,7 +602,6 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(&cache_path, serde_json::to_string(&cache).unwrap()).unwrap();
 
-        // New entry for today with different values
         let entries = vec![UsageEntry {
             timestamp: today.and_hms_opt(15, 0, 0).unwrap().and_utc(),
             model: Some("claude".to_string()),
@@ -645,10 +626,9 @@ mod tests {
         let (result, _warning) = service.load_or_compute("claude-code", &entries).unwrap();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].total_input_tokens, 200); // New value, not 50
+        assert_eq!(result[0].total_input_tokens, 200);
     }
 
-    // Test 8: Cache path format is correct
     #[test]
     fn test_cache_path_format() {
         let (service, temp) = create_test_service();
@@ -660,44 +640,36 @@ mod tests {
         assert_eq!(path2, temp.path().join("cursor_daily.json"));
     }
 
-    // Test 9: Clear removes cache file
     #[test]
     fn test_clear_removes_cache_file() {
         let (service, _temp) = create_test_service();
         let cache_path = service.cache_path("claude-code");
 
-        // Create cache file
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(&cache_path, "{}").unwrap();
         assert!(cache_path.exists());
 
-        // Clear it
         service.clear("claude-code").unwrap();
 
         assert!(!cache_path.exists());
     }
 
-    // Test 10: CLI isolation - different CLIs have separate caches
     #[test]
     fn test_cli_isolation() {
         let (service, _temp) = create_test_service();
 
-        // Store data for claude-code
         let entries1 = vec![make_entry(2024, 1, 10, Some("claude"), 100, 50, Some(0.01))];
         service.load_or_compute("claude-code", &entries1).unwrap();
 
-        // Store data for cursor
         let entries2 = vec![make_entry(2024, 1, 10, Some("gpt-4"), 500, 250, Some(0.05))];
         service.load_or_compute("cursor", &entries2).unwrap();
 
-        // Verify separate cache files exist
         let claude_cache = service.cache_path("claude-code");
         let cursor_cache = service.cache_path("cursor");
         assert!(claude_cache.exists());
         assert!(cursor_cache.exists());
         assert_ne!(claude_cache, cursor_cache);
 
-        // Verify data is isolated
         let claude_content: DailySummaryCache =
             serde_json::from_str(&fs::read_to_string(&claude_cache).unwrap()).unwrap();
         let cursor_content: DailySummaryCache =
@@ -709,13 +681,11 @@ mod tests {
         assert_eq!(cursor_content.summaries[0].total_input_tokens, 500);
     }
 
-    // Test 11: Cache migrates model names (normalizes keys)
     #[test]
     fn test_cache_migrates_model_names() {
         let (service, _temp) = create_test_service();
         let yesterday = Local::now().date_naive() - chrono::Duration::days(1);
 
-        // Create cache with non-normalized model names (with date suffixes)
         let mut models = HashMap::new();
         models.insert(
             "claude-opus-4-5-20251101".to_string(),
@@ -733,7 +703,7 @@ mod tests {
             },
         );
         models.insert(
-            "claude-opus-4.5".to_string(), // Dot version, same model
+            "claude-opus-4.5".to_string(),
             crate::types::ModelUsage {
                 input_tokens: 200,
                 output_tokens: 100,
@@ -772,32 +742,27 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(&cache_path, serde_json::to_string(&cache).unwrap()).unwrap();
 
-        // Load and verify normalization + merging
         let entries: Vec<UsageEntry> = vec![];
         let (result, _warning) = service.load_or_compute("claude-code", &entries).unwrap();
 
         assert_eq!(result.len(), 1);
         let summary = &result[0];
 
-        // Should have only one model key after normalization (merged)
         assert_eq!(summary.models.len(), 1);
         assert!(summary.models.contains_key("claude-opus-4-5"));
 
-        // Values should be merged
         let model = summary.models.get("claude-opus-4-5").unwrap();
-        assert_eq!(model.input_tokens, 300); // 100 + 200
-        assert_eq!(model.output_tokens, 150); // 50 + 100
-        assert!((model.cost_usd - 0.30).abs() < f64::EPSILON); // 0.10 + 0.20
-        assert_eq!(model.count, 3); // 1 + 2
+        assert_eq!(model.input_tokens, 300);
+        assert_eq!(model.output_tokens, 150);
+        assert!((model.cost_usd - 0.30).abs() < f64::EPSILON);
+        assert_eq!(model.count, 3);
     }
 
-    // Test 12: Old cache without version (deserialized as 0) triggers VersionMismatch
     #[test]
     fn test_old_cache_version_mismatch() {
         let (service, _temp) = create_test_service();
         let yesterday = Local::now().date_naive() - chrono::Duration::days(1);
 
-        // Write cache JSON without "version" field (simulates pre-versioning cache)
         let json = serde_json::json!({
             "cli": "claude-code",
             "updated_at": chrono::Utc::now().timestamp(),
@@ -828,14 +793,11 @@ mod tests {
 
         let (result, warning) = service.load_or_compute("claude-code", &entries).unwrap();
 
-        // Should return VersionMismatch warning
         assert!(matches!(warning, Some(CacheWarning::VersionMismatch(_))));
-        // Old cached value (999) should be discarded; recomputed from entries
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].total_input_tokens, 100);
     }
 
-    // Test 13: Matching version loads cache normally
     #[test]
     fn test_matching_version_loads_normally() {
         let (service, _temp) = create_test_service();
@@ -865,7 +827,6 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(&cache_path, serde_json::to_string(&cache).unwrap()).unwrap();
 
-        // No entries — should rely entirely on cache
         let entries: Vec<UsageEntry> = vec![];
         let (result, warning) = service.load_or_compute("claude-code", &entries).unwrap();
 
@@ -874,14 +835,12 @@ mod tests {
         assert_eq!(result[0].total_input_tokens, 500);
     }
 
-    // Test 14: Version mismatch preserves cached dates without entries
     #[test]
     fn test_version_mismatch_preserves_old_data_without_entries() {
         let (service, _temp) = create_test_service();
         let old_date = Local::now().date_naive() - chrono::Duration::days(30);
         let yesterday = Local::now().date_naive() - chrono::Duration::days(1);
 
-        // Old cache with two dates: old_date (no entries) + yesterday (has entries)
         let json = serde_json::json!({
             "cli": "claude-code",
             "version": 0,
@@ -913,7 +872,6 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(&cache_path, json.to_string()).unwrap();
 
-        // Only provide entries for yesterday (old_date JSONL is gone)
         let entries = vec![make_entry(
             yesterday.year(),
             yesterday.month(),
@@ -929,28 +887,23 @@ mod tests {
         assert!(matches!(warning, Some(CacheWarning::VersionMismatch(_))));
         assert_eq!(result.len(), 2);
 
-        // old_date: preserved from cache (no entries to recompute)
         let old = result.iter().find(|s| s.date == old_date).unwrap();
         assert_eq!(old.total_input_tokens, 500);
 
-        // yesterday: recomputed from entries
         let recent = result.iter().find(|s| s.date == yesterday).unwrap();
         assert_eq!(recent.total_input_tokens, 200);
 
-        // Saved cache should now have CACHE_VERSION
         let saved: DailySummaryCache =
             serde_json::from_str(&fs::read_to_string(&cache_path).unwrap()).unwrap();
         assert_eq!(saved.version, CACHE_VERSION);
     }
 
-    // Test 15: latest_cached_date returns None when no cache exists
     #[test]
     fn test_latest_cached_date_no_cache() {
         let (service, _temp) = create_test_service();
         assert_eq!(service.latest_cached_date("claude-code"), None);
     }
 
-    // Test 16: latest_cached_date returns max date from summaries
     #[test]
     fn test_latest_cached_date_returns_max() {
         let (service, _temp) = create_test_service();
@@ -1013,14 +966,12 @@ mod tests {
         );
     }
 
-    // Test: cached_dates is empty when no cache file exists
     #[test]
     fn test_cached_dates_empty_when_no_file() {
         let (service, _temp) = create_test_service();
         assert!(service.cached_dates("claude-code").is_empty());
     }
 
-    // Test: cached_dates collects every date from the cached summaries
     #[test]
     fn test_cached_dates_collects_all_summary_dates() {
         let (service, _temp) = create_test_service();
@@ -1057,7 +1008,6 @@ mod tests {
         assert!(dates.contains(&NaiveDate::from_ymd_opt(2026, 3, 3).unwrap()));
     }
 
-    // Test: cached_dates returns empty on a corrupted cache file (no panic)
     #[test]
     fn test_cached_dates_empty_on_corrupted_file() {
         let (service, _temp) = create_test_service();
@@ -1067,7 +1017,6 @@ mod tests {
         assert!(service.cached_dates("claude-code").is_empty());
     }
 
-    // Test 17: latest_cached_date returns None for empty summaries
     #[test]
     fn test_latest_cached_date_empty_summaries() {
         let (service, _temp) = create_test_service();
@@ -1084,11 +1033,8 @@ mod tests {
         assert_eq!(service.latest_cached_date("claude-code"), None);
     }
 
-    // ========== Issue #134: composite key normalization ==========
-
     #[test]
     fn test_normalize_composite_key_preserves_provider() {
-        // Only the model part is normalized; the provider must not be touched.
         assert_eq!(
             normalize_composite_key("claude-opus-4.5::anthropic"),
             "claude-opus-4-5::anthropic"
@@ -1111,7 +1057,6 @@ mod tests {
 
     #[test]
     fn test_normalize_composite_key_plain_key_unchanged_behavior() {
-        // Plain (non-composite) keys keep the original normalize_model_name behavior.
         assert_eq!(
             normalize_composite_key("claude-opus-4.5"),
             "claude-opus-4-5"
@@ -1172,7 +1117,6 @@ mod tests {
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(&cache_path, serde_json::to_string(&cache).unwrap()).unwrap();
 
-        // With no entries to recompute, load_or_compute returns the cached data as-is.
         let entries: Vec<UsageEntry> = vec![];
         let (result, warning) = service.load_or_compute("codex", &entries).unwrap();
 
@@ -1215,7 +1159,6 @@ mod tests {
             models,
             projects: HashMap::new(),
         };
-        // version=0 triggers the mismatch path which runs normalize_model_keys.
         let cache = serde_json::json!({
             "cli": "codex",
             "version": 0,
@@ -1229,9 +1172,8 @@ mod tests {
         let entries: Vec<UsageEntry> = vec![];
         let (result, warning) = service.load_or_compute("codex", &entries).unwrap();
 
-        assert!(warning.is_some()); // version mismatch warning
+        assert!(warning.is_some());
         assert_eq!(result.len(), 1);
-        // Model normalized (4.5 -> 4-5); provider preserved.
         assert!(result[0].models.contains_key("claude-opus-4-5::anthropic"));
     }
 }

--- a/src/services/data_loader.rs
+++ b/src/services/data_loader.rs
@@ -161,7 +161,6 @@ impl DataLoaderService {
             let entries = if has_source_cache {
                 let latest = cache_service.latest_cached_date(&source.id);
                 if has_date_gap(latest, yesterday) {
-                    // Gap detected: full re-parse to fill missing dates
                     match parser.parse_all() {
                         Ok(e) => e,
                         Err(e) => {
@@ -251,7 +250,6 @@ impl DataLoaderService {
 
     /// Cold path: full parse_all() per source + build cache
     fn load_cold_path(&self) -> Result<LoadResult> {
-        // Try network pricing if cache-only failed
         let fallback_pricing;
         let pricing_ref = match &self.pricing {
             Some(p) => Some(p),
@@ -292,7 +290,6 @@ impl DataLoaderService {
             let entries = Self::assign_source_id(entries, &source.id);
             let entries = self.apply_pricing_with_ref(entries, pricing_ref);
 
-            // Try to use cache service
             if let Some(cs) = &self.cache_service {
                 match cs.load_or_compute(&source.id, &entries) {
                     Ok((summaries, warning)) => {
@@ -316,7 +313,6 @@ impl DataLoaderService {
                 }
             }
 
-            // Cache unavailable: compute summaries directly
             let summaries = Aggregator::daily(&entries);
             self.collect_source_stats(&summaries, &source.id, &mut source_stats);
             source_summaries
@@ -423,7 +419,6 @@ impl DataLoaderService {
                 total_cost_usd,
             })
             .collect();
-        // Sort by total_tokens descending
         result.sort_by_key(|b| std::cmp::Reverse(b.total_tokens));
         result
     }
@@ -441,8 +436,6 @@ mod tests {
 
     use super::*;
     use std::path::PathBuf;
-
-    // ========== build_source_usage tests ==========
 
     #[test]
     fn test_build_source_usage_empty() {
@@ -493,9 +486,7 @@ mod tests {
             provider: provider.map(String::from),
             project: None,
         };
-        // upstream cost present → not estimated
         assert!(!DataLoaderService::batch_estimated(&[mk(Some(0.1), None)]));
-        // calculated (no upstream cost) → estimated
         assert!(DataLoaderService::batch_estimated(&[mk(None, None)]));
     }
 
@@ -517,8 +508,6 @@ mod tests {
         assert_eq!(result[2].total_tokens, 500);
     }
 
-    // ========== warm_path_since tests ==========
-
     use chrono::Timelike;
 
     #[test]
@@ -529,7 +518,6 @@ mod tests {
             .unwrap();
         let since_secs = since_duration.as_secs() as i64;
 
-        // Expected: yesterday 00:00:00 in local timezone
         let yesterday = chrono::Local::now().date_naive() - chrono::Duration::days(1);
         let yesterday_midnight = yesterday.and_hms_opt(0, 0, 0).unwrap();
         let expected_utc = chrono::Local
@@ -558,18 +546,14 @@ mod tests {
 
         let dt = chrono::DateTime::from_timestamp(since_secs, 0).unwrap();
         let local_dt = dt.with_timezone(&chrono::Local);
-        // Must be exactly 00:00:00 in local time
         assert_eq!(local_dt.hour(), 0);
         assert_eq!(local_dt.minute(), 0);
         assert_eq!(local_dt.second(), 0);
     }
 
-    // ========== DataLoaderService::new tests ==========
-
     #[test]
     fn test_data_loader_service_new() {
         let service = DataLoaderService::new();
-        // Just verify it can be constructed
         assert!(!service.registry.sources().is_empty());
     }
 
@@ -724,8 +708,6 @@ mod tests {
         );
     }
 
-    // ========== apply_pricing tests ==========
-
     fn make_entry(cost_usd: Option<f64>, provider: Option<&str>) -> UsageEntry {
         UsageEntry {
             timestamp: chrono::Utc::now(),
@@ -754,7 +736,6 @@ mod tests {
         let service = DataLoaderService::new();
         let entries = vec![make_entry(Some(0.0), Some("anthropic"))];
         let result = service.apply_pricing(entries);
-        // Some(0.0) is a legitimate cost (e.g. free-tier providers) — trust it as-is
         assert_eq!(result[0].cost_usd, Some(0.0));
     }
 
@@ -763,7 +744,6 @@ mod tests {
         let service = DataLoaderService::new();
         let entries = vec![make_entry(None, Some("anthropic"))];
         let result = service.apply_pricing(entries);
-        // None should trigger recalculation
         assert_ne!(result[0].cost_usd, None);
     }
 
@@ -790,13 +770,10 @@ mod tests {
     #[test]
     fn test_apply_pricing_copilot_existing_cost_preserved() {
         let service = DataLoaderService::new();
-        // A cost parsed from JSONL is trusted as-is.
         let entries = vec![make_entry(Some(0.10), Some("github-copilot"))];
         let result = service.apply_pricing(entries);
         assert_eq!(result[0].cost_usd, Some(0.10));
     }
-
-    // ========== warm path filtering tests ==========
 
     #[test]
     fn test_warm_path_filters_old_date_entries() {
@@ -870,7 +847,6 @@ mod tests {
 
         let all_entries = vec![old_entry, yesterday_entry, today_entry];
 
-        // Apply the same filter used in load_warm_path
         let filtered: Vec<UsageEntry> = all_entries
             .into_iter()
             .filter(|entry| entry.local_date() >= yesterday)
@@ -879,7 +855,6 @@ mod tests {
         assert_eq!(filtered.len(), 2);
         assert_eq!(filtered[0].local_date(), yesterday);
         assert_eq!(filtered[1].local_date(), today);
-        // The old entry with massive tokens should be gone
         assert!(filtered.iter().all(|e| e.input_tokens < 50_000_000));
     }
 
@@ -931,29 +906,24 @@ mod tests {
         assert!(needs_full_reparse(true, &[old, recent], yesterday));
     }
 
-    // ========== gap detection tests ==========
-
     #[test]
     fn test_has_date_gap_no_gap() {
-        // latest_cached = yesterday - 1 → warm path covers [yesterday, today] → no gap
         let today = Local::now().date_naive();
-        let latest_cached = today - chrono::Duration::days(2); // day before yesterday
+        let latest_cached = today - chrono::Duration::days(2);
         let yesterday = today - chrono::Duration::days(1);
         assert!(!has_date_gap(Some(latest_cached), yesterday));
     }
 
     #[test]
     fn test_has_date_gap_with_gap() {
-        // latest_cached = yesterday - 2 → gap of 1 day between cache and warm path
         let today = Local::now().date_naive();
-        let latest_cached = today - chrono::Duration::days(3); // 2 days before yesterday
+        let latest_cached = today - chrono::Duration::days(3);
         let yesterday = today - chrono::Duration::days(1);
         assert!(has_date_gap(Some(latest_cached), yesterday));
     }
 
     #[test]
     fn test_has_date_gap_none_latest() {
-        // No cached date → no gap to detect (cold path handles this)
         let today = Local::now().date_naive();
         let yesterday = today - chrono::Duration::days(1);
         assert!(!has_date_gap(None, yesterday));
@@ -961,7 +931,6 @@ mod tests {
 
     #[test]
     fn test_has_date_gap_latest_is_yesterday() {
-        // latest_cached = yesterday → warm path covers [yesterday, today] → no gap
         let today = Local::now().date_naive();
         let yesterday = today - chrono::Duration::days(1);
         assert!(!has_date_gap(Some(yesterday), yesterday));

--- a/src/services/normalizer.rs
+++ b/src/services/normalizer.rs
@@ -28,42 +28,33 @@ pub fn display_name(normalized: &str) -> String {
     // "gpt-5.3-codex::github-copilot" → "GPT-5.3 Codex::github-copilot".
     let model = normalized.split("::").next().unwrap_or(normalized);
 
-    // Claude: claude-{family}-{version} → {Family} {version}
     if let Some(rest) = model.strip_prefix("claude-") {
         return parse_claude_name(rest);
     }
 
-    // GPT: gpt-{variant}(-{suffix}) → GPT-{variant}( {Suffix})
     if let Some(rest) = model.strip_prefix("gpt-") {
         return parse_gpt_name(rest);
     }
 
-    // Gemini: gemini-{version}-{tier} → Gemini {version} {Tier}
     if let Some(rest) = model.strip_prefix("gemini-") {
         return parse_gemini_name(rest);
     }
 
-    // Codex: codex-{variant}(-latest) → Codex {Variant}
     if let Some(rest) = model.strip_prefix("codex-") {
         return parse_codex_name(rest);
     }
 
-    // OpenAI o-series: o{N}, o{N}-mini, o{N}-pro, etc.
     if let Some(rest) = model.strip_prefix('o') {
         if rest.starts_with(|c: char| c.is_ascii_digit()) {
             return parse_o_series(model);
         }
     }
 
-    // Fallback: return as-is
     model.to_string()
 }
 
 /// Parse Claude model name: {family}-{version} → {Family} {version}
 fn parse_claude_name(rest: &str) -> String {
-    // Split into family and version parts
-    // e.g., "opus-4-5" → family="opus", version="4-5"
-    // e.g., "sonnet-4" → family="sonnet", version="4"
     let parts: Vec<&str> = rest.splitn(2, '-').collect();
     if parts.len() < 2 {
         return format!("Claude {}", capitalize(rest));
@@ -107,16 +98,11 @@ fn parse_gpt_name(rest: &str) -> String {
 
 /// Parse Gemini model name: {version}-{tier} → Gemini {version} {Tier}
 fn parse_gemini_name(rest: &str) -> String {
-    // e.g., "2-5-pro" → "2.5 Pro"
-    // e.g., "2-0-flash" → "2.0 Flash"
-    // Find the tier (last part that's not a number)
     let parts: Vec<&str> = rest.split('-').collect();
     if parts.len() < 2 {
         return format!("Gemini {}", rest);
     }
 
-    // Find where version ends and tier begins
-    // Version parts are numeric, tier is alphabetic
     let mut version_parts = Vec::new();
     let mut tier_parts = Vec::new();
 
@@ -150,8 +136,6 @@ fn parse_codex_name(rest: &str) -> String {
 
 /// Parse OpenAI o-series: o{N}, o{N}-mini, o{N}-pro, etc.
 fn parse_o_series(name: &str) -> String {
-    // e.g., "o1" → "o1"
-    // e.g., "o1-mini" → "o1 Mini"
     if let Some(pos) = name.find('-') {
         let base = &name[..pos];
         let suffix = &name[pos + 1..];
@@ -200,11 +184,8 @@ pub fn normalize_model_name(model: &str) -> String {
         return "gemini-3-pro-preview".to_string();
     }
 
-    // Step 1: Replace dots with hyphens
     let normalized = model.replace('.', "-");
 
-    // Step 2: Remove 8-digit date suffix at end (e.g., -20251101)
-    // Pattern: ends with -YYYYMMDD where YYYYMMDD is 8 digits starting with 20
     if let Some(suffix_start) = normalized.rfind('-') {
         let suffix = &normalized[suffix_start + 1..];
         if suffix.len() == 8
@@ -221,8 +202,6 @@ pub fn normalize_model_name(model: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ========== display_name tests ==========
 
     #[test]
     fn test_display_name_claude_opus_4_5() {
@@ -329,12 +308,8 @@ mod tests {
         assert_eq!(display_name(""), "");
     }
 
-    // ========== Composite key (model::provider) handling ==========
-
     #[test]
     fn test_display_name_strips_provider_suffix_gpt() {
-        // Copilot emits composite keys like "gpt-5.3-codex::github-copilot".
-        // The provider suffix must not leak into the friendly name.
         assert_eq!(
             display_name("gpt-5.3-codex::github-copilot"),
             "GPT-5.3 Codex"
@@ -356,11 +331,8 @@ mod tests {
 
     #[test]
     fn test_display_name_no_provider_suffix_unchanged() {
-        // Plain keys keep their existing behavior.
         assert_eq!(display_name("gpt-5-3-codex"), "GPT-5.3 Codex");
     }
-
-    // ========== Dot to hyphen conversion ==========
 
     #[test]
     fn test_dot_to_hyphen_single() {
@@ -371,8 +343,6 @@ mod tests {
     fn test_dot_to_hyphen_multiple() {
         assert_eq!(normalize_model_name("model-1.2.3"), "model-1-2-3");
     }
-
-    // ========== Date suffix removal ==========
 
     #[test]
     fn test_remove_date_suffix_claude_opus() {
@@ -392,14 +362,11 @@ mod tests {
 
     #[test]
     fn test_remove_date_suffix_with_dot_and_date() {
-        // Combined: dot + date
         assert_eq!(
             normalize_model_name("claude-opus-4.5-20251101"),
             "claude-opus-4-5"
         );
     }
-
-    // ========== No-op cases ==========
 
     #[test]
     fn test_normalize_gemini_default() {
@@ -434,11 +401,8 @@ mod tests {
         assert_eq!(normalize_model_name("unknown-model"), "unknown-model");
     }
 
-    // ========== Edge cases ==========
-
     #[test]
     fn test_short_date_not_removed() {
-        // 8-digit number in middle shouldn't be removed
         assert_eq!(
             normalize_model_name("model-12345678-extra"),
             "model-12345678-extra"
@@ -447,7 +411,6 @@ mod tests {
 
     #[test]
     fn test_date_suffix_at_end_only() {
-        // Date must be at end
         assert_eq!(normalize_model_name("20251101-claude"), "20251101-claude");
     }
 }

--- a/src/services/pricing.rs
+++ b/src/services/pricing.rs
@@ -220,7 +220,6 @@ impl PricingService {
                 custom,
             }),
             Ok(cache) => {
-                // Expired → try refresh, fallback to expired cache
                 if let Ok(fresh) = Self::fetch_pricing() {
                     let _ = Self::save_cache(&cache_path, &fresh);
                     Some(Self {
@@ -237,7 +236,6 @@ impl PricingService {
                 }
             }
             Err(_) => {
-                // Corrupt or unreadable → try fresh fetch, else vendored snapshot.
                 if let Ok(fresh) = Self::fetch_pricing() {
                     let _ = Self::save_cache(&cache_path, &fresh);
                     Some(Self {
@@ -361,17 +359,14 @@ impl PricingService {
 
     /// Load cache from disk or fetch fresh data
     fn load_or_fetch_cache(cache_path: &PathBuf) -> Result<PricingCache> {
-        // Try loading existing cache
         if let Ok(cache) = Self::load_cache(cache_path) {
             if !cache.is_expired() {
                 return Ok(cache);
             }
-            // Cache expired, try to refresh
             if let Ok(fresh_cache) = Self::fetch_pricing() {
                 let _ = Self::save_cache(cache_path, &fresh_cache);
                 return Ok(fresh_cache);
             }
-            // Fetch failed, use expired cache
             return Ok(cache);
         }
 
@@ -451,7 +446,6 @@ impl PricingService {
             None => return 0.0,
         };
 
-        // Custom pricing takes precedence over LiteLLM
         let custom = self.get_custom_pricing(model);
         let litellm = self.get_pricing(model);
 
@@ -531,7 +525,6 @@ impl PricingService {
             .unwrap_or(0.0);
         let reasoning = entry.reasoning_tokens as f64 * reasoning_rate;
 
-        // Web search cost
         let web_search_cost = self.get_web_search_cost(entry, pricing);
         let web_fetch_cost = self.get_web_fetch_cost(entry);
 
@@ -575,12 +568,10 @@ impl PricingService {
 
     /// Get pricing for a model (exact → normalized → fuzzy substring)
     pub fn get_pricing(&self, model: &str) -> Option<&ModelPricing> {
-        // 1. Exact match
         if let Some(pricing) = self.cache.models.get(model) {
             return Some(pricing);
         }
 
-        // 2. Normalized match
         let normalized = super::normalize_model_name(model);
         if normalized != model {
             if let Some(pricing) = self.cache.models.get(&normalized) {
@@ -588,7 +579,6 @@ impl PricingService {
             }
         }
 
-        // 3. Substring fuzzy match (longest key wins)
         let lower = normalized.to_lowercase();
         let mut best: Option<(&str, &ModelPricing)> = None;
         for (key, pricing) in &self.cache.models {
@@ -690,7 +680,6 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let cache_path = temp_dir.path().join("pricing.json");
 
-        // Create mock pricing data
         let mut models = HashMap::new();
         models.insert(
             "claude-sonnet-4".to_string(),
@@ -712,7 +701,6 @@ mod tests {
                 ..Default::default()
             },
         );
-        // Model with tiered pricing (above 200k tokens)
         models.insert(
             "claude-opus-4-6".to_string(),
             ModelPricing {
@@ -738,7 +726,6 @@ mod tests {
             models,
         };
 
-        // Save mock cache
         let content = serde_json::to_string_pretty(&cache).unwrap();
         fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         fs::write(&cache_path, content).unwrap();
@@ -746,8 +733,6 @@ mod tests {
         let service = PricingService::with_cache_path(cache_path).unwrap();
         (service, temp_dir)
     }
-
-    // ========== get_or_calculate_cost tests (auto mode) ==========
 
     #[test]
     fn test_returns_existing_cost_usd_when_present() {
@@ -774,8 +759,6 @@ mod tests {
             cost
         );
     }
-
-    // ========== calculate_cost tests ==========
 
     #[test]
     fn test_calculate_cost_basic() {
@@ -858,8 +841,6 @@ mod tests {
         );
     }
 
-    // ========== get_pricing tests ==========
-
     #[test]
     fn test_get_pricing_exact_match() {
         let (service, _temp) = create_test_service();
@@ -883,7 +864,6 @@ mod tests {
     #[test]
     fn test_get_pricing_normalized_date_suffix() {
         let (service, _temp) = create_test_service();
-        // claude-sonnet-4 is in cache, try with date suffix
         let pricing = service.get_pricing("claude-sonnet-4-20250514");
 
         assert!(pricing.is_some());
@@ -894,13 +874,10 @@ mod tests {
     #[test]
     fn test_get_pricing_normalized_dot_to_hyphen() {
         let (service, _temp) = create_test_service();
-        // claude-opus-4 is in cache, try with dot version
         let pricing = service.get_pricing("claude-opus-4");
 
         assert!(pricing.is_some());
     }
-
-    // ========== fuzzy pricing tests ==========
 
     fn create_fuzzy_test_service() -> (PricingService, TempDir) {
         let temp_dir = TempDir::new().unwrap();
@@ -973,7 +950,6 @@ mod tests {
     #[test]
     fn test_fuzzy_pricing_prefers_exact() {
         let (service, _temp) = create_fuzzy_test_service();
-        // gpt-5-2-codex is an exact match in the cache
         let pricing = service.get_pricing("gpt-5-2-codex");
         assert!(pricing.is_some());
         let p = pricing.unwrap();
@@ -991,8 +967,6 @@ mod tests {
         // Should be "gpt-5" pricing ($0.00001), not "azure/gpt-5" ($0.00002)
         assert!((p.input_cost_per_token.unwrap() - 0.00001).abs() < 1e-10);
     }
-
-    // ========== PricingCache tests ==========
 
     #[test]
     fn test_cache_is_expired_after_1h() {
@@ -1046,10 +1020,8 @@ mod tests {
             models,
         };
 
-        // Save
         PricingService::save_cache(&cache_path, &cache).unwrap();
 
-        // Load
         let loaded = PricingService::load_cache(&cache_path).unwrap();
 
         assert_eq!(loaded.fetched_at, 12345);
@@ -1060,7 +1032,6 @@ mod tests {
     fn test_model_count() {
         let (service, _temp) = create_test_service();
 
-        // We added 3 models in create_test_service
         assert_eq!(service.model_count(), 3);
     }
 
@@ -1087,8 +1058,6 @@ mod tests {
         );
     }
 
-    // ========== from_cache_only tests ==========
-
     #[test]
     fn test_from_cache_only_with_valid_cache() {
         let (_, temp_dir) = create_test_service();
@@ -1113,7 +1082,6 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let cache_path = temp_dir.path().join("pricing.json");
 
-        // Create expired cache (fetched_at = 0 → long expired)
         let mut models = HashMap::new();
         models.insert("test-model".to_string(), ModelPricing::default());
         let cache = PricingCache {
@@ -1133,15 +1101,11 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let cache_path = temp_dir.path().join("pricing.json");
 
-        // Write corrupt JSON
         fs::write(&cache_path, "not valid json{{{").unwrap();
 
-        // Corrupt cache with no network → should return None
         let service = PricingService::from_cache_only_with_path(&cache_path);
         assert!(service.is_none());
     }
-
-    // ========== tiered_cost unit tests ==========
 
     #[test]
     fn test_tiered_cost_below_threshold() {
@@ -1216,16 +1180,12 @@ mod tests {
 
     #[test]
     fn test_tier_resolver_precedence() {
-        // 128k present → wins
         assert_eq!(
             tier(Some(0.1), Some(0.2), Some(0.3), Some(0.4)),
             Some((128_000, 0.1))
         );
-        // only 272k present
         assert_eq!(tier(None, None, None, Some(0.4)), Some((272_000, 0.4)));
-        // only 200k present
         assert_eq!(tier(None, Some(0.2), None, None), Some((200_000, 0.2)));
-        // none → flat
         assert_eq!(tier(None, None, None, None), None);
     }
 
@@ -1280,8 +1240,6 @@ mod tests {
             cost
         );
     }
-
-    // ========== calculate_cost tiered integration tests ==========
 
     #[test]
     fn test_calculate_cost_tiered_model_below_threshold() {
@@ -1352,8 +1310,6 @@ mod tests {
             cost
         );
     }
-
-    // ========== Custom pricing tests ==========
 
     #[test]
     fn test_custom_pricing_overrides_litellm() {
@@ -1426,7 +1382,6 @@ mod tests {
             .unwrap()
             .with_custom_pricing(Some(custom));
 
-        // claude-sonnet-4 not in custom → should use LiteLLM pricing
         let entry = make_entry(Some("claude-sonnet-4"), 1_000_000, 0, 0, 0, None);
         let cost = service.calculate_cost(&entry);
 
@@ -1516,11 +1471,9 @@ mod tests {
             .unwrap()
             .with_custom_pricing(Some(custom));
 
-        // Entry with flat cache_creation but NO TTL breakdown (historical)
         let entry = make_entry(Some("claude-sonnet-4"), 0, 0, 0, 100_000, None);
         let cost = service.calculate_cost(&entry);
 
-        // Should use flat rate: 100k * $3.75/1M = $0.375
         let expected = 100_000.0 * (3.75 / 1_000_000.0);
         assert!(
             (cost - expected).abs() < 1e-6,
@@ -1571,7 +1524,6 @@ mod tests {
 
         let service = PricingService::from_cache_only_with_path(&cache_path).unwrap();
 
-        // No custom pricing loaded → should use LiteLLM as before
         let entry = make_entry(Some("claude-sonnet-4"), 1_000, 500, 200, 100, None);
         let cost = service.calculate_cost(&entry);
 
@@ -1623,8 +1575,6 @@ web_search_per_request = 0.01
         assert_eq!(global.web_search_per_request, Some(0.01));
     }
 
-    // ========== TOKTRACK_PRICING_FILE env var tests ==========
-
     #[test]
     fn test_load_custom_pricing_from_env_var() {
         let temp_dir = TempDir::new().unwrap();
@@ -1639,7 +1589,6 @@ output = 50.0
         )
         .unwrap();
 
-        // Set env var and load
         std::env::set_var("TOKTRACK_PRICING_FILE", toml_path.to_str().unwrap());
         let config = PricingService::load_custom_pricing();
         std::env::remove_var("TOKTRACK_PRICING_FILE");
@@ -1657,12 +1606,8 @@ output = 50.0
         let config = PricingService::load_custom_pricing();
         std::env::remove_var("TOKTRACK_PRICING_FILE");
 
-        // Should fall back to default path (which also likely doesn't exist in test)
-        // The key is it doesn't panic
         let _ = config;
     }
-
-    // ========== Custom tiered pricing tests ==========
 
     #[test]
     fn test_custom_tiered_pricing_above_200k() {
@@ -1759,7 +1704,6 @@ output = 50.0
         let cache_path = temp_dir.path().join("pricing.json");
         create_mock_cache(&cache_path);
 
-        // No _above_200k fields → should use flat rate for all tokens
         let custom = CustomPricingConfig {
             models: Some(HashMap::from([(
                 "flat-only".to_string(),
@@ -1823,8 +1767,6 @@ web_search_per_request = 0.01
         assert_eq!(sonnet.cache_creation_above_200k, Some(7.50));
     }
 
-    // ========== #1 web search: search_context_cost_per_query ==========
-
     /// Write a pricing cache file with a raw JSON `models` object (so tests can
     /// exercise LiteLLM field names without going through the typed struct).
     fn write_cache_json(cache_path: &std::path::Path, models_json: &str) {
@@ -1869,7 +1811,6 @@ web_search_per_request = 0.01
     fn test_web_search_cost_medium_falls_back_to_low_then_high() {
         let temp_dir = TempDir::new().unwrap();
         let cache_path = temp_dir.path().join("pricing.json");
-        // medium absent → fall back to low
         write_cache_json(
             &cache_path,
             r#"{
@@ -1925,7 +1866,6 @@ web_search_per_request = 0.01
         let cache_path = temp_dir.path().join("pricing.json");
         create_mock_cache(&cache_path);
 
-        // No override → web fetch contributes nothing (no LiteLLM source).
         let service = PricingService::from_cache_only_with_path(&cache_path).unwrap();
         let mut entry = make_entry(Some("claude-sonnet-4"), 0, 0, 0, 0, None);
         entry.web_fetch_requests = 4;
@@ -1934,7 +1874,6 @@ web_search_per_request = 0.01
             "web fetch must be free without a custom override"
         );
 
-        // Custom global override → priced per request.
         let custom = CustomPricingConfig {
             models: None,
             global: Some(GlobalPricing {
@@ -1970,13 +1909,10 @@ web_search_per_request = 0.01
         );
     }
 
-    // ========== #2 reasoning/thinking token cost ==========
-
     #[test]
     fn test_reasoning_tokens_priced_at_output_rate_by_default() {
         let temp_dir = TempDir::new().unwrap();
         let cache_path = temp_dir.path().join("pricing.json");
-        // No reasoning-specific rate → thinking billed at output rate.
         write_cache_json(
             &cache_path,
             r#"{
@@ -2035,7 +1971,6 @@ web_search_per_request = 0.01
             r#"{ "claude-x": { "input_cost_per_token": 0.000003, "output_cost_per_token": 0.000015 } }"#,
         );
         let service = PricingService::from_cache_only_with_path(&cache_path).unwrap();
-        // reasoning_tokens defaults to 0 (Claude folds thinking into output)
         let entry = make_entry(Some("claude-x"), 1000, 500, 0, 0, None);
 
         let cost = service.calculate_cost(&entry);

--- a/src/services/update_checker.rs
+++ b/src/services/update_checker.rs
@@ -114,8 +114,6 @@ pub fn execute_update() -> Result<(), String> {
 mod tests {
     use super::*;
 
-    // ========== is_newer_version tests ==========
-
     #[test]
     fn test_is_newer_version_major() {
         assert!(is_newer_version("2.0.0", "1.0.0"));
@@ -166,8 +164,6 @@ mod tests {
         assert!(!is_newer_version("1.0.0", "invalid"));
         assert!(!is_newer_version("", "1.0.0"));
     }
-
-    // ========== UpdateCheckResult tests ==========
 
     #[test]
     fn test_update_check_result_update_available() {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -353,7 +353,6 @@ impl App {
         }
         if let Event::Key(key) = event {
             if key.kind == KeyEventKind::Press {
-                // Ctrl+C shows quit confirmation
                 if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
                     self.quit_confirm = Some(QuitConfirmState::new());
                     return;
@@ -427,7 +426,6 @@ impl App {
 
     /// Handle keyboard events in Dashboard mode
     fn handle_dashboard_event(&mut self, code: KeyCode) {
-        // Common keys for all tabs
         match code {
             KeyCode::Esc => {
                 if self.show_help {
@@ -486,7 +484,6 @@ impl App {
             _ => {}
         }
 
-        // Tab-specific keys
         match self.current_tab() {
             Tab::Overview => match code {
                 KeyCode::Up | KeyCode::Char('k') if self.source_selected > 0 => {
@@ -555,7 +552,6 @@ impl App {
                 if self.show_help {
                     self.show_help = false;
                 } else {
-                    // Return to the tab the drill-down was entered from.
                     let tab = match &self.view_mode {
                         ViewMode::ProjectDetail { .. } => Tab::Projects,
                         _ => Tab::Overview,
@@ -658,27 +654,22 @@ impl App {
         if let Event::Key(key) = event {
             if key.kind == KeyEventKind::Press {
                 match key.code {
-                    // Arrow keys toggle selection
                     KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down => {
                         if let Some(ref mut state) = self.quit_confirm {
                             state.selection = 1 - state.selection;
                         }
                     }
-                    // Enter confirms the selection
                     KeyCode::Enter => {
                         if let Some(ref state) = self.quit_confirm {
                             if state.selection == 0 {
-                                // Yes selected -> quit
                                 self.should_quit = true;
                             }
                         }
                         self.quit_confirm = None;
                     }
-                    // Esc or 'n' cancels
                     KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
                         self.quit_confirm = None;
                     }
-                    // 'y' quits immediately
                     KeyCode::Char('y') | KeyCode::Char('Y') => {
                         self.should_quit = true;
                         self.quit_confirm = None;
@@ -708,7 +699,6 @@ impl App {
         if let Event::Key(key) = event {
             if key.kind == KeyEventKind::Press {
                 match (&self.update_status, key.code) {
-                    // Available state: up/down to select, Enter to confirm, Esc to dismiss
                     (UpdateStatus::Available { .. }, KeyCode::Up | KeyCode::Down) => {
                         self.update_selection = 1 - self.update_selection;
                     }
@@ -720,12 +710,10 @@ impl App {
                             self.consume_pending_data();
                         }
                     }
-                    // Esc dismisses update overlay (skip update)
                     (UpdateStatus::Available { .. }, KeyCode::Esc) => {
                         self.update_status = UpdateStatus::Resolved;
                         self.consume_pending_data();
                     }
-                    // UpdateDone state: any key dismisses
                     (UpdateStatus::UpdateDone { success, .. }, _) => {
                         if *success {
                             self.should_quit = true;
@@ -1050,13 +1038,11 @@ impl Widget for &App {
                     }
                 }
 
-                // Render help popup overlay if active
                 if self.show_help {
                     let popup_area = HelpPopup::centered_area(area);
                     HelpPopup::new(self.theme).render(popup_area, buf);
                 }
 
-                // Render model breakdown popup if active
                 if let Some(ref state) = self.model_breakdown {
                     DimOverlay.render(area, buf);
                     let popup_area = ModelBreakdownPopup::centered_area(area, state.models.len());
@@ -1192,7 +1178,6 @@ fn build_app_data_from_summaries(
 
     let daily_data = DailyData::from_daily_summaries(summaries);
 
-    // Build per-source data
     let mut source_daily_data = HashMap::new();
     let mut source_models_data = HashMap::new();
     let mut source_stats_data = HashMap::new();
@@ -1234,17 +1219,14 @@ fn run_app(terminal: &mut DefaultTerminal, config: TuiConfig, theme: Theme) -> a
     let mut app = App::new(config, theme);
     app.terminal_height = terminal.size()?.height;
 
-    // Kick off the startup data load on a background thread
     app.start_data_load();
 
-    // Spawn background thread for update check
     let (update_tx, update_rx) = mpsc::channel();
     thread::spawn(move || {
         let result = check_for_update();
         let _ = update_tx.send(result);
     });
 
-    // Channel for async execute_update result
     let (execute_tx, execute_rx) = mpsc::channel();
 
     loop {
@@ -1254,13 +1236,10 @@ fn run_app(terminal: &mut DefaultTerminal, config: TuiConfig, theme: Theme) -> a
             break;
         }
 
-        // Check for data loading completion (non-blocking)
         app.poll_data();
 
-        // Check for on-demand audit completion (non-blocking)
         app.poll_audit();
 
-        // Check for update check completion (non-blocking)
         if app.update_status == UpdateStatus::Checking {
             if let Ok(result) = update_rx.try_recv() {
                 match result {
@@ -1274,7 +1253,6 @@ fn run_app(terminal: &mut DefaultTerminal, config: TuiConfig, theme: Theme) -> a
             }
         }
 
-        // Handle Updating state: spawn background thread for npm update
         if app.update_status == UpdateStatus::Updating {
             app.update_status = UpdateStatus::UpdateRunning;
             let tx = execute_tx.clone();
@@ -1284,7 +1262,6 @@ fn run_app(terminal: &mut DefaultTerminal, config: TuiConfig, theme: Theme) -> a
             });
         }
 
-        // Check for execute_update completion (non-blocking)
         if app.update_status == UpdateStatus::UpdateRunning {
             if let Ok(result) = execute_rx.try_recv() {
                 match result {
@@ -1304,7 +1281,6 @@ fn run_app(terminal: &mut DefaultTerminal, config: TuiConfig, theme: Theme) -> a
             }
         }
 
-        // Poll for events with 100ms timeout for spinner animation
         if event::poll(Duration::from_millis(100))? {
             let ev = event::read()?;
             // Priority chain: quit_confirm > model_breakdown > update > main
@@ -1478,7 +1454,6 @@ mod tests {
     #[test]
     fn test_enter_navigates_to_source_detail() {
         let mut app = make_ready_app();
-        // source_selected defaults to 0, source_usage has "claude"
         let event = Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         app.handle_event(event);
 
@@ -1506,7 +1481,6 @@ mod tests {
     #[test]
     fn test_source_selection_up_down() {
         let mut app = make_ready_app();
-        // Add a second source
         if let AppState::Ready { data } = &mut app.state {
             data.source_usage.push(SourceUsage {
                 source: "opencode".to_string(),
@@ -1519,19 +1493,15 @@ mod tests {
 
         assert_eq!(app.source_selected, 0);
 
-        // Down
         app.handle_event(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)));
         assert_eq!(app.source_selected, 1);
 
-        // Down again should stay at 1 (max)
         app.handle_event(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)));
         assert_eq!(app.source_selected, 1);
 
-        // Up
         app.handle_event(Event::Key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)));
         assert_eq!(app.source_selected, 0);
 
-        // Up again should stay at 0
         app.handle_event(Event::Key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)));
         assert_eq!(app.source_selected, 0);
     }
@@ -1588,8 +1558,6 @@ mod tests {
         )));
         assert_eq!(app.daily_view_mode, DailyViewMode::Daily);
     }
-
-    // ========== Sort toggle tests (issue #206) ==========
 
     fn jan(day: u32) -> chrono::NaiveDate {
         chrono::NaiveDate::from_ymd_opt(2025, 1, day).unwrap()
@@ -1675,11 +1643,10 @@ mod tests {
 
         press(&mut app, KeyCode::Char('s')); // cost descending
 
-        assert_eq!(first_daily_date(&app), jan(5)); // most expensive first
+        assert_eq!(first_daily_date(&app), jan(5));
         assert_eq!(app.daily_selected, None);
         assert_eq!(app.weekly_selected, None);
         assert_eq!(app.monthly_selected, None);
-        // The ranking starts at the top, not at the latest date.
         assert_eq!(app.daily_scroll, 0);
         assert_eq!(app.weekly_scroll, 0);
         assert_eq!(app.monthly_scroll, 0);
@@ -1692,7 +1659,7 @@ mod tests {
         press(&mut app, KeyCode::Char('s'));
         press(&mut app, KeyCode::Char('s')); // tokens descending
 
-        assert_eq!(first_daily_date(&app), jan(7)); // cache-heavy day first
+        assert_eq!(first_daily_date(&app), jan(7));
     }
 
     #[test]
@@ -1702,7 +1669,7 @@ mod tests {
         press(&mut app, KeyCode::Char('S')); // date descending
         assert_eq!(app.sort_key, SortKey::Date);
         assert_eq!(app.sort_direction, SortDirection::Desc);
-        assert_eq!(first_daily_date(&app), jan(20)); // newest first
+        assert_eq!(first_daily_date(&app), jan(20));
         assert_eq!(app.daily_scroll, 0);
 
         press(&mut app, KeyCode::Char('S')); // back to ascending
@@ -1739,7 +1706,7 @@ mod tests {
             _ => panic!("expected Ready state"),
         };
         assert!(expected > 0, "fixture must be taller than the viewport");
-        assert_eq!(app.daily_scroll, expected); // latest days visible again
+        assert_eq!(app.daily_scroll, expected);
     }
 
     #[test]
@@ -1753,9 +1720,9 @@ mod tests {
 
         press(&mut app, KeyCode::Enter); // re-enter the claude drill-down
         assert!(matches!(app.view_mode, ViewMode::SourceDetail { .. }));
-        assert_eq!(first_daily_date(&app), jan(5)); // still sorted by cost
+        assert_eq!(first_daily_date(&app), jan(5));
         assert_eq!(app.daily_selected, None);
-        assert_eq!(app.daily_scroll, 0); // entry respects the active sort
+        assert_eq!(app.daily_scroll, 0);
     }
 
     #[test]
@@ -1763,7 +1730,6 @@ mod tests {
         let mut app = make_sort_test_app();
         press(&mut app, KeyCode::Char('s')); // cost descending
 
-        // A fresh load arrives date-ascending, like real loads do.
         let mut fresh = marker_app_data(1);
         fresh.daily_data = DailyData::from_daily_summaries(vec![
             sort_test_summary(1, 100, 0, 0.10),
@@ -1777,7 +1743,7 @@ mod tests {
         tx.send(Ok(fresh)).unwrap();
         app.poll_data();
 
-        assert_eq!(first_daily_date(&app), jan(2)); // most expensive first
+        assert_eq!(first_daily_date(&app), jan(2));
         assert_eq!(app.daily_selected, None);
         assert_eq!(app.daily_scroll, 0);
     }
@@ -1788,7 +1754,7 @@ mod tests {
 
         press(&mut app, KeyCode::Char('j')); // default date-ascending order
 
-        assert_eq!(app.daily_selected, Some(19)); // latest day (bottom row)
+        assert_eq!(app.daily_selected, Some(19));
     }
 
     #[test]
@@ -1798,8 +1764,8 @@ mod tests {
 
         press(&mut app, KeyCode::Char('j'));
 
-        assert_eq!(app.daily_selected, Some(0)); // most expensive day (top row)
-        assert_eq!(app.daily_scroll, 0); // view must not jump to the bottom
+        assert_eq!(app.daily_selected, Some(0));
+        assert_eq!(app.daily_scroll, 0);
     }
 
     #[test]
@@ -1809,7 +1775,7 @@ mod tests {
 
         press(&mut app, KeyCode::Char('k'));
 
-        assert_eq!(app.daily_selected, Some(0)); // today (top row)
+        assert_eq!(app.daily_selected, Some(0));
         assert_eq!(app.daily_scroll, 0);
     }
 
@@ -1824,8 +1790,6 @@ mod tests {
         let breakdown = app.model_breakdown.expect("breakdown popup must open");
         assert_eq!(breakdown.date_label, "2025-01-05");
     }
-
-    // ========== Update overlay tests ==========
 
     #[test]
     fn test_app_initial_update_status() {
@@ -1997,8 +1961,6 @@ mod tests {
         assert_eq!(app.update_status, UpdateStatus::Resolved);
     }
 
-    // ========== TuiConfig & App::new tests ==========
-
     #[test]
     fn test_tuiconfig_default_values() {
         let config = TuiConfig::default();
@@ -2070,8 +2032,6 @@ mod tests {
             ),
         }
     }
-
-    // ========== Quit confirm popup tests ==========
 
     #[test]
     fn test_ctrl_c_shows_quit_confirm_popup() {
@@ -2212,8 +2172,6 @@ mod tests {
         assert!(app.quit_confirm.is_none());
     }
 
-    // ========== Model breakdown popup tests ==========
-
     #[test]
     fn test_app_new_has_no_model_breakdown() {
         let app = App::new(TuiConfig::default(), Theme::Dark);
@@ -2278,8 +2236,6 @@ mod tests {
         assert_eq!(app.daily_scroll, 5);
     }
 
-    // ========== Tab switching tests ==========
-
     #[test]
     fn test_tab_key_switches_tab() {
         let mut app = App::default();
@@ -2323,7 +2279,6 @@ mod tests {
     fn test_backtab_switches_tab() {
         let mut app = App::default();
 
-        // From Overview, BackTab wraps to the last tab (Audit).
         app.handle_event(Event::Key(KeyEvent::new(
             KeyCode::BackTab,
             KeyModifiers::SHIFT,
@@ -2465,7 +2420,6 @@ mod tests {
         let key = "/srv/work/alpha/beta";
         let mut app = ready_app_with_one_project(key);
 
-        // Jump to the Projects tab (key '4').
         app.handle_event(Event::Key(KeyEvent::new(
             KeyCode::Char('4'),
             KeyModifiers::NONE,
@@ -2475,7 +2429,6 @@ mod tests {
             ViewMode::Dashboard { tab: Tab::Projects }
         ));
 
-        // Enter drills into the selected project.
         app.handle_event(Event::Key(KeyEvent::new(
             KeyCode::Enter,
             KeyModifiers::NONE,
@@ -2485,7 +2438,6 @@ mod tests {
             other => panic!("expected ProjectDetail, got {:?}", other),
         }
 
-        // Esc returns to the Projects tab (not Overview).
         app.handle_event(Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
         assert!(matches!(
             app.view_mode,
@@ -2505,8 +2457,6 @@ mod tests {
             ViewMode::Dashboard { tab: Tab::Audit }
         ));
     }
-
-    // ========== Manual refresh tests (issue #198) ==========
 
     /// Stub loader for refresh tests — never touches the real filesystem.
     fn stub_loader(_: RemoteOptions) -> Result<Box<AppData>, String> {
@@ -2550,7 +2500,6 @@ mod tests {
 
         assert!(app.refreshing);
         assert!(app.data_rx.is_some());
-        // Current data stays on screen — no flicker back to the loading spinner.
         assert!(matches!(app.state, AppState::Ready { .. }));
     }
 
@@ -2562,10 +2511,8 @@ mod tests {
         app.data_rx = Some(rx);
         app.refreshing = true;
 
-        // 'r' must not replace the in-flight channel.
         press_r(&mut app);
 
-        // The original channel must still be the one polled.
         tx.send(Ok(marker_app_data(999))).unwrap();
         app.poll_data();
 
@@ -2607,7 +2554,6 @@ mod tests {
         }
         assert!(!app.refreshing);
         assert!(app.data_rx.is_none());
-        // Refreshed data invalidates the previously computed audit.
         assert!(app.audit.is_none());
         assert!(app.audit_error.is_none());
         // The in-flight audit receiver must be dropped so poll_audit can never
@@ -2632,7 +2578,6 @@ mod tests {
         tx.send(Err("boom".to_string())).unwrap();
         app.poll_data();
 
-        // Graceful degrade: old data survives a failed refresh.
         assert!(matches!(app.state, AppState::Ready { .. }));
         assert!(!app.refreshing);
         assert!(app.data_rx.is_none());
@@ -2645,7 +2590,6 @@ mod tests {
         app.data_rx = Some(rx);
         app.refreshing = true;
 
-        // Sender dropped without sending — as if the worker thread panicked.
         drop(tx);
         app.poll_data();
 
@@ -2679,7 +2623,6 @@ mod tests {
 
         press_r(&mut app);
 
-        // Retry from the error screen goes back to the loading spinner.
         assert!(matches!(app.state, AppState::Loading { .. }));
         assert!(app.data_rx.is_some());
         assert!(!app.refreshing);
@@ -2696,13 +2639,11 @@ mod tests {
         press_r(&mut app);
         assert!(app.refreshing);
 
-        // Swap in a deterministic channel and apply the result.
         let (tx, rx) = mpsc::channel();
         app.data_rx = Some(rx);
         tx.send(Ok(marker_app_data(555))).unwrap();
         app.poll_data();
 
-        // The drill-down view survives the refresh.
         assert!(matches!(app.view_mode, ViewMode::SourceDetail { .. }));
         assert!(matches!(app.state, AppState::Ready { .. }));
     }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -230,8 +230,6 @@ mod tests {
         assert_eq!(t.heatmap_color(HeatmapLevel::Max), Color::Indexed(28));
     }
 
-    // ========== Spike level tests ==========
-
     #[test]
     fn test_spike_level_normal() {
         assert_eq!(spike_level(1.0, 1.0), SpikeLevel::Normal);
@@ -260,8 +258,6 @@ mod tests {
     fn test_spike_level_zero_cost() {
         assert_eq!(spike_level(0.0, 1.0), SpikeLevel::Normal);
     }
-
-    // ========== Spike color tests ==========
 
     #[test]
     fn test_dark_spike_color() {

--- a/src/tui/widgets/audit.rs
+++ b/src/tui/widgets/audit.rs
@@ -312,7 +312,6 @@ mod tests {
 
     #[test]
     fn test_segment_widths_split_proportionally() {
-        // 50/50 live vs missing over 48 cells.
         let (l, c, m) = segment_widths(10, 0, 10, 48);
         assert_eq!(c, 0);
         assert_eq!(l + c + m, 48);
@@ -321,7 +320,6 @@ mod tests {
 
     #[test]
     fn test_segment_widths_keeps_single_preserved_day_visible() {
-        // 1 preserved day out of 1000 must still light at least one cell.
         let (_l, c, _m) = segment_widths(999, 1, 0, 48);
         assert!(c >= 1, "preserved segment vanished");
     }

--- a/src/tui/widgets/daily.rs
+++ b/src/tui/widgets/daily.rs
@@ -238,7 +238,6 @@ const COLUMNS: [(&str, u16); 8] = [
 /// Columns are hidden in priority order: Input first, then Output, Cache, Usage.
 /// This prioritizes showing Usage (visual bar) in narrow views.
 pub fn visible_columns(width: u16) -> Vec<usize> {
-    // Ordered by hide priority: first element is hidden first
     const HIDE_ORDER: [usize; 4] = [COL_INPUT, COL_OUTPUT, COL_CACHE, COL_USAGE];
 
     let mut visible: Vec<usize> = (0..COLUMNS.len()).collect();
@@ -301,7 +300,6 @@ impl<'a> DailyView<'a> {
 
 impl Widget for DailyView<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // Apply max width constraint and center the content
         let content_width = area.width.min(MAX_CONTENT_WIDTH);
         let x_offset = (area.width.saturating_sub(content_width)) / 2;
         let centered_area = Rect {
@@ -311,10 +309,8 @@ impl Widget for DailyView<'_> {
             height: area.height,
         };
 
-        // Determine visible columns based on available width
         let visible = visible_columns(centered_area.width);
 
-        // Calculate layout
         let chunks = Layout::vertical([
             Constraint::Length(1), // Top padding
             Constraint::Length(1), // Tabs
@@ -327,22 +323,16 @@ impl Widget for DailyView<'_> {
         ])
         .split(centered_area);
 
-        // Render separator (no tabs, just separator at line 1 position too)
         self.render_separator(chunks[2], buf);
 
-        // Render mode indicator
         self.render_mode_indicator(chunks[3], buf);
 
-        // Render header
         self.render_header(chunks[4], buf, &visible);
 
-        // Render daily rows
         self.render_daily_rows(chunks[5], buf, &visible);
 
-        // Render separator
         self.render_separator(chunks[6], buf);
 
-        // Render keybindings
         self.render_keybindings(chunks[7], buf);
     }
 }
@@ -475,7 +465,6 @@ impl DailyView<'_> {
 
         let cache_tokens = summary.total_cache_read_tokens + summary.total_cache_creation_tokens;
 
-        // Get primary model (highest cost) + count of others, filtering out zero-token models
         let non_zero_models: Vec<_> = summary
             .models
             .iter()
@@ -488,13 +477,11 @@ impl DailyView<'_> {
             })
             .collect();
 
-        // Separate primary model name and count suffix for different coloring
         let (primary_model, count_suffix) = if non_zero_models.len() == 1 {
             (display_name(non_zero_models[0].0), None)
         } else if non_zero_models.is_empty() {
             ("unknown".to_string(), None)
         } else {
-            // Find model with highest cost among non-zero models
             let primary = non_zero_models
                 .iter()
                 .max_by(|a, b| {
@@ -525,7 +512,6 @@ impl DailyView<'_> {
 
         let sparkline = format_sparkline(total_tokens, max_tokens, 14);
 
-        // Format date based on view mode
         let date_str = match self.view_mode {
             DailyViewMode::Daily | DailyViewMode::Weekly => {
                 summary.date.format("%Y-%m-%d").to_string()
@@ -533,7 +519,6 @@ impl DailyView<'_> {
             DailyViewMode::Monthly => summary.date.format("%Y-%m").to_string(),
         };
 
-        // Selection marker and style modifier
         let selection_modifier = if is_selected {
             Modifier::BOLD | Modifier::REVERSED
         } else {
@@ -542,7 +527,6 @@ impl DailyView<'_> {
 
         let mut spans = Vec::new();
 
-        // Add selection marker for first column
         for (col_idx, &col) in visible.iter().enumerate() {
             // COL_MODEL is special: renders primary model (accent) + count (muted)
             if col == COL_MODEL {
@@ -576,7 +560,6 @@ impl DailyView<'_> {
 
             let (text, base_style) = match col {
                 COL_DATE => {
-                    // Prepend marker to date column
                     let marker = if is_selected { "▸ " } else { "  " };
                     // Adjust width: marker takes 2 chars, so date field is 12
                     (
@@ -619,11 +602,9 @@ impl DailyView<'_> {
                 _ => unreachable!(),
             };
 
-            // Apply selection highlight to all columns except first (which has marker)
             let style = if is_selected && col_idx > 0 {
                 base_style.add_modifier(selection_modifier)
             } else if is_selected && col_idx == 0 {
-                // First column already has marker, just make it bold
                 base_style.add_modifier(Modifier::BOLD)
             } else {
                 base_style
@@ -666,8 +647,6 @@ mod tests {
     use chrono::NaiveDate;
     use std::collections::HashMap;
 
-    // ========== format_sparkline tests ==========
-
     #[test]
     fn test_format_sparkline_zero() {
         assert_eq!(format_sparkline(0, 1000, 8), "░░░░░░░░");
@@ -685,7 +664,6 @@ mod tests {
 
     #[test]
     fn test_format_sparkline_zero_max() {
-        // When max is 0, should return all empty
         assert_eq!(format_sparkline(100, 0, 8), "░░░░░░░░");
     }
 
@@ -696,11 +674,8 @@ mod tests {
 
     #[test]
     fn test_format_sparkline_overflow_ratio() {
-        // When tokens > max (ratio > 1.0), should clamp to width
         assert_eq!(format_sparkline(2000, 1000, 8), "▓▓▓▓▓▓▓▓");
     }
-
-    // ========== DailyData tests ==========
 
     #[allow(clippy::too_many_arguments)]
     fn make_daily_summary(
@@ -738,7 +713,6 @@ mod tests {
 
     #[test]
     fn test_daily_data_sorted_asc() {
-        // Input is ascending (as from Aggregator::daily)
         let summaries = vec![
             make_daily_summary(2024, 1, 10, 100, 50, 10, 5, 0.01),
             make_daily_summary(2024, 1, 15, 200, 100, 20, 10, 0.02),
@@ -748,7 +722,6 @@ mod tests {
         let data = DailyData::from_daily_summaries(summaries);
 
         assert_eq!(data.daily_summaries.len(), 3);
-        // Should remain ascending (oldest first)
         assert_eq!(data.daily_summaries[0].date.to_string(), "2024-01-10");
         assert_eq!(data.daily_summaries[1].date.to_string(), "2024-01-15");
         assert_eq!(data.daily_summaries[2].date.to_string(), "2024-01-20");
@@ -757,17 +730,15 @@ mod tests {
     #[test]
     fn test_daily_data_max_tokens() {
         let summaries = vec![
-            make_daily_summary(2024, 1, 10, 100, 50, 10, 5, 0.01), // total: 165
-            make_daily_summary(2024, 1, 15, 200, 100, 20, 10, 0.02), // total: 330
-            make_daily_summary(2024, 1, 20, 300, 150, 30, 15, 0.03), // total: 495
+            make_daily_summary(2024, 1, 10, 100, 50, 10, 5, 0.01),
+            make_daily_summary(2024, 1, 15, 200, 100, 20, 10, 0.02),
+            make_daily_summary(2024, 1, 20, 300, 150, 30, 15, 0.03),
         ];
 
         let data = DailyData::from_daily_summaries(summaries);
 
         assert_eq!(data.daily_max_tokens, 495);
     }
-
-    // ========== DailyView scroll tests ==========
 
     #[test]
     fn test_daily_view_scroll_bounds_empty() {
@@ -785,7 +756,6 @@ mod tests {
             make_daily_summary(2024, 1, 15, 200, 100, 20, 10, 0.02),
         ];
         let data = DailyData::from_daily_summaries(summaries);
-        // 2 items < VISIBLE_ROWS (15), so max offset is 0
         assert_eq!(
             DailyView::max_scroll_offset(&data, DailyViewMode::Daily, VISIBLE_ROWS),
             0
@@ -798,18 +768,14 @@ mod tests {
             .map(|d| make_daily_summary(2024, 1, d, 100, 50, 10, 5, 0.01))
             .collect();
         let data = DailyData::from_daily_summaries(summaries);
-        // 20 items, VISIBLE_ROWS = 15, so max offset = 5
         assert_eq!(
             DailyView::max_scroll_offset(&data, DailyViewMode::Daily, VISIBLE_ROWS),
             5
         );
     }
 
-    // ========== DailyData multi-mode tests ==========
-
     #[test]
     fn test_daily_data_has_all_modes() {
-        // 3 days across 2 weeks, 1 month
         let summaries = vec![
             make_daily_summary(2025, 1, 13, 100, 50, 0, 0, 0.01), // Mon, week of Jan 12
             make_daily_summary(2025, 1, 15, 200, 100, 0, 0, 0.02), // Wed, week of Jan 12
@@ -835,13 +801,11 @@ mod tests {
         assert_eq!(daily.len(), 3);
 
         let (weekly, _) = data.for_mode(DailyViewMode::Weekly);
-        assert_eq!(weekly.len(), 3); // 3 different weeks
+        assert_eq!(weekly.len(), 3);
 
         let (monthly, _) = data.for_mode(DailyViewMode::Monthly);
-        assert_eq!(monthly.len(), 2); // Jan and Feb
+        assert_eq!(monthly.len(), 2);
     }
-
-    // ========== Sort tests ==========
 
     #[test]
     fn test_sort_key_cycle() {
@@ -896,7 +860,6 @@ mod tests {
 
     #[test]
     fn test_apply_sort_tokens_differs_from_cost() {
-        // Jan 14 is cache-heavy: the most tokens but the lowest cost.
         let mut data = DailyData::from_daily_summaries(vec![
             make_daily_summary(2025, 1, 13, 500, 200, 0, 0, 2.00),
             make_daily_summary(2025, 1, 14, 100, 50, 10_000, 0, 0.50),
@@ -917,7 +880,6 @@ mod tests {
 
     #[test]
     fn test_apply_sort_all_period_modes() {
-        // Two days in different weeks and months so each mode has 2 entries.
         let mut data = DailyData::from_daily_summaries(vec![
             make_daily_summary(2025, 1, 13, 100, 0, 0, 0, 1.00),
             make_daily_summary(2025, 2, 10, 100, 0, 0, 0, 3.00),
@@ -989,13 +951,8 @@ mod tests {
         assert_eq!(DailyViewMode::Monthly.date_column_label(), "Month");
     }
 
-    // ========== Responsive column tests ==========
-    // Hide order: Input → Output → Cache → Usage (keeps Usage visible longest)
-    // Full: 141, -Input: 123, -Output: 105, -Cache: 87, -Usage: 69
-
     #[test]
     fn test_visible_columns_full_width() {
-        // >= 141: all 8 columns visible
         let cols = visible_columns(141);
         assert_eq!(cols.len(), 8);
         assert_eq!(cols, vec![0, 1, 2, 3, 4, 5, 6, 7]);
@@ -1003,37 +960,33 @@ mod tests {
 
     #[test]
     fn test_visible_columns_hide_input() {
-        // 123..140: 7 columns (Input hidden first)
         let cols = visible_columns(123);
         assert_eq!(cols.len(), 7);
         assert!(!cols.contains(&COL_INPUT));
-        assert!(cols.contains(&COL_USAGE)); // Usage still visible
+        assert!(cols.contains(&COL_USAGE));
     }
 
     #[test]
     fn test_visible_columns_hide_input_and_output() {
-        // 105..122: 6 columns (Input + Output hidden)
         let cols = visible_columns(105);
         assert_eq!(cols.len(), 6);
         assert!(!cols.contains(&COL_INPUT));
         assert!(!cols.contains(&COL_OUTPUT));
-        assert!(cols.contains(&COL_USAGE)); // Usage still visible
+        assert!(cols.contains(&COL_USAGE));
     }
 
     #[test]
     fn test_visible_columns_hide_three() {
-        // 87..104: 5 columns (Input + Output + Cache hidden)
         let cols = visible_columns(87);
         assert_eq!(cols.len(), 5);
         assert!(!cols.contains(&COL_INPUT));
         assert!(!cols.contains(&COL_OUTPUT));
         assert!(!cols.contains(&COL_CACHE));
-        assert!(cols.contains(&COL_USAGE)); // Usage still visible
+        assert!(cols.contains(&COL_USAGE));
     }
 
     #[test]
     fn test_visible_columns_minimum() {
-        // < 87: 4 columns (Date + Model + Total + Cost)
         let cols = visible_columns(69);
         assert_eq!(cols.len(), 4);
         assert_eq!(cols, vec![COL_DATE, COL_MODEL, COL_TOTAL, COL_COST]);
@@ -1053,7 +1006,6 @@ mod tests {
 
     #[test]
     fn test_visible_columns_wide_terminal() {
-        // Very wide terminal should still show all 8
         let cols = visible_columns(200);
         assert_eq!(cols.len(), 8);
     }

--- a/src/tui/widgets/heatmap.rs
+++ b/src/tui/widgets/heatmap.rs
@@ -131,17 +131,13 @@ pub fn build_grid(
         all_values.push(tokens);
     }
 
-    // Calculate percentiles for intensity mapping
     let percentiles = calculate_percentiles(&all_values);
 
-    // Find the start of the current week (Monday)
     let days_since_monday = today.weekday().num_days_from_monday();
     let week_start = today - Duration::days(days_since_monday as i64);
 
-    // Go back (weeks_to_show - 1) more weeks
     let grid_start = week_start - Duration::weeks((weeks_to_show - 1) as i64);
 
-    // Build grid: 7 rows (Mon-Sun) x weeks_to_show columns
     let mut grid: Vec<Vec<Option<HeatmapCell>>> = vec![vec![None; weeks_to_show]; 7];
 
     #[allow(clippy::needless_range_loop)]
@@ -150,7 +146,6 @@ pub fn build_grid(
             let date =
                 grid_start + Duration::weeks(week_idx as i64) + Duration::days(day_idx as i64);
 
-            // Skip future dates
             if date > today {
                 continue;
             }
@@ -199,7 +194,6 @@ impl Heatmap {
     /// Compute weeks to show based on terminal width
     /// Returns weeks count for responsive layout (2-char cells, no borders)
     pub fn weeks_for_width(width: u16) -> usize {
-        // Account for label only (no border)
         let available = width.saturating_sub(LABEL_WIDTH);
         let max_weeks = (available / CELL_WIDTH) as usize;
 
@@ -231,7 +225,6 @@ impl Heatmap {
         let start_x = area.x + x_offset + LABEL_WIDTH;
         let max_x = area.x + area.width;
 
-        // Draw weekday label
         buf.set_string(
             area.x + x_offset,
             y,
@@ -239,7 +232,6 @@ impl Heatmap {
             Style::default().fg(self.theme.muted()),
         );
 
-        // Cells (no borders)
         let row = &self.grid[day_idx];
         for (col_idx, cell) in row.iter().enumerate() {
             if col_idx >= self.weeks_to_show {
@@ -250,7 +242,6 @@ impl Heatmap {
                 break;
             }
 
-            // Cell content (2 chars)
             if let Some(cell) = cell {
                 let style = Style::default().fg(cell.intensity.color(self.theme));
                 buf.set_string(x, y, "██", style);
@@ -275,18 +266,15 @@ impl Widget for Heatmap {
         let x_offset = self.calculate_x_offset(area);
         let start_x = area.x + x_offset + LABEL_WIDTH;
 
-        // Render 7 rows (Mon-Sun) directly, no borders
         for (day_idx, (_, label)) in DISPLAY_ROWS.iter().enumerate() {
             let y = area.y + day_idx as u16;
             if y >= area.y + area.height {
                 break;
             }
 
-            // Content row: Mon ████████
             self.render_content_row(area, buf, y, day_idx, label, x_offset);
         }
 
-        // Render month labels below the grid (after 7 rows)
         let month_label_y = area.y + 7;
         if month_label_y < area.y + area.height && !self.grid[0].is_empty() {
             self.render_month_labels(area, buf, start_x, month_label_y, CELL_WIDTH);
@@ -337,8 +325,6 @@ mod tests {
     use super::*;
     use chrono::NaiveDate;
 
-    // ========== HeatmapIntensity tests ==========
-
     #[test]
     fn test_intensity_to_char() {
         assert_eq!(HeatmapIntensity::None.to_char(), ' ');
@@ -350,7 +336,6 @@ mod tests {
 
     #[test]
     fn test_intensity_to_cell_str() {
-        // Each intensity uses distinct block characters for colorblind accessibility
         assert_eq!(HeatmapIntensity::None.to_cell_str(), "░░ ");
         assert_eq!(HeatmapIntensity::Low.to_cell_str(), "▒▒ ");
         assert_eq!(HeatmapIntensity::Medium.to_cell_str(), "▓▓ ");
@@ -380,8 +365,6 @@ mod tests {
         assert_eq!(HeatmapIntensity::Max.color(theme), Color::Indexed(28));
     }
 
-    // ========== calculate_percentiles tests ==========
-
     #[test]
     fn test_calculate_percentiles_empty() {
         let result = calculate_percentiles(&[]);
@@ -404,7 +387,6 @@ mod tests {
 
     #[test]
     fn test_calculate_percentiles_four_values() {
-        // [10, 20, 30, 40] sorted
         let result = calculate_percentiles(&[40, 10, 30, 20]).unwrap();
         assert_eq!(result.p25, 10); // 25% of 4 = 1 -> index 0
         assert_eq!(result.p50, 20); // 50% of 4 = 2 -> index 1
@@ -414,13 +396,10 @@ mod tests {
     #[test]
     fn test_calculate_percentiles_ignores_zeros() {
         let result = calculate_percentiles(&[0, 100, 0, 200, 0, 300, 0, 400]).unwrap();
-        // Non-zero: [100, 200, 300, 400]
         assert_eq!(result.p25, 100);
         assert_eq!(result.p50, 200);
         assert_eq!(result.p75, 300);
     }
-
-    // ========== Percentiles::to_intensity tests ==========
 
     #[test]
     fn test_intensity_mapping() {
@@ -440,8 +419,6 @@ mod tests {
         assert_eq!(p.intensity(400), HeatmapIntensity::Max);
     }
 
-    // ========== build_grid tests ==========
-
     #[test]
     fn test_build_grid_dimensions() {
         let today = NaiveDate::from_ymd_opt(2024, 6, 15).unwrap(); // Saturday
@@ -449,9 +426,7 @@ mod tests {
 
         let grid = build_grid(&daily_tokens, today, 52);
 
-        // Should be 7 rows (weekdays)
         assert_eq!(grid.len(), 7);
-        // Each row should have 52 columns (weeks)
         for row in &grid {
             assert_eq!(row.len(), 52);
         }
@@ -493,7 +468,6 @@ mod tests {
 
         let grid = build_grid(&daily_tokens, today, 52);
 
-        // Find today's cell and verify it has data
         let mut found = false;
         for row in &grid {
             for cell in row.iter().flatten() {
@@ -513,7 +487,6 @@ mod tests {
 
         let grid = build_grid(&daily_tokens, today, 52);
 
-        // Future dates (Thu, Fri, Sat, Sun of current week) should be None
         for row in &grid {
             for cell in row.iter().flatten() {
                 assert!(cell.date <= today, "Grid should not contain future dates");
@@ -521,12 +494,8 @@ mod tests {
         }
     }
 
-    // ========== weeks_for_width tests ==========
-
     #[test]
     fn test_weeks_for_width_wide() {
-        // 52 weeks needs: label 4 + 52*2 = 108 (2-char cells, no borders)
-        // So width >= 108 -> 52 weeks
         assert_eq!(Heatmap::weeks_for_width(108), 52);
         assert_eq!(Heatmap::weeks_for_width(120), 52);
         assert_eq!(Heatmap::weeks_for_width(200), 52);
@@ -534,8 +503,6 @@ mod tests {
 
     #[test]
     fn test_weeks_for_width_medium() {
-        // 26 weeks needs: label 4 + 26*2 = 56
-        // So width 56-107 -> 26 weeks
         assert_eq!(Heatmap::weeks_for_width(56), 26);
         assert_eq!(Heatmap::weeks_for_width(80), 26);
         assert_eq!(Heatmap::weeks_for_width(107), 26);
@@ -543,23 +510,15 @@ mod tests {
 
     #[test]
     fn test_weeks_for_width_narrow() {
-        // 13 weeks needs: label 4 + 13*2 = 30
-        // So width < 56 -> 13 weeks
         assert_eq!(Heatmap::weeks_for_width(30), 13);
         assert_eq!(Heatmap::weeks_for_width(55), 13);
     }
 
-    // ========== CELL_WIDTH tests ==========
-
     #[test]
     fn test_cell_dimensions() {
-        // Cell should be 2 chars wide (no border)
         assert_eq!(CELL_WIDTH, 2);
-        // Label width should be 4 chars ("Mon ")
         assert_eq!(LABEL_WIDTH, 4);
     }
-
-    // ========== Grid rendering tests (borderless) ==========
 
     /// Helper to create a test buffer and heatmap
     fn create_test_heatmap(weeks: usize) -> (Heatmap, Rect, Buffer) {
@@ -570,7 +529,6 @@ mod tests {
         ];
         let heatmap = Heatmap::new(&daily_tokens, today, weeks, Theme::Dark);
 
-        // Create area large enough for grid: label(4) + weeks*2
         let width = LABEL_WIDTH + (weeks as u16 * CELL_WIDTH);
         let height = 8; // 7 rows + 1 month label
         let area = Rect::new(0, 0, width, height);
@@ -583,10 +541,8 @@ mod tests {
     fn test_render_content_row_has_label() {
         let (heatmap, area, mut buf) = create_test_heatmap(3);
 
-        // x_offset is 0 when buffer width equals heatmap width
         heatmap.render_content_row(area, &mut buf, 0, 0, "Mon", 0);
 
-        // Check label at x=0
         let cell = buf.cell((0, 0)).unwrap();
         assert_eq!(cell.symbol(), "M");
         let cell = buf.cell((1, 0)).unwrap();
@@ -599,14 +555,11 @@ mod tests {
     fn test_render_content_row_no_borders() {
         let (heatmap, area, mut buf) = create_test_heatmap(3);
 
-        // x_offset is 0 when buffer width equals heatmap width
         heatmap.render_content_row(area, &mut buf, 0, 0, "Mon", 0);
 
         let start_x = LABEL_WIDTH as usize;
 
-        // Cell content should be directly at start_x (no left border)
         let cell = buf.cell((start_x as u16, 0)).unwrap();
-        // Should be a block char from intensity, not a border
         assert_ne!(cell.symbol(), "│");
     }
 
@@ -614,15 +567,12 @@ mod tests {
     fn test_full_grid_structure_borderless() {
         let (heatmap, area, mut buf) = create_test_heatmap(3);
 
-        // Render full heatmap
         heatmap.render(area, &mut buf);
 
-        // Row 0: Mon content row - should have label
         assert_eq!(buf.cell((0, 0)).unwrap().symbol(), "M");
         assert_eq!(buf.cell((1, 0)).unwrap().symbol(), "o");
         assert_eq!(buf.cell((2, 0)).unwrap().symbol(), "n");
 
-        // Row 6: Sun content row - should have label
         assert_eq!(buf.cell((0, 6)).unwrap().symbol(), "S");
         assert_eq!(buf.cell((1, 6)).unwrap().symbol(), "u");
         assert_eq!(buf.cell((2, 6)).unwrap().symbol(), "n");

--- a/src/tui/widgets/help.rs
+++ b/src/tui/widgets/help.rs
@@ -48,10 +48,8 @@ impl Default for HelpPopup {
 
 impl Widget for HelpPopup {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // Clear the area first (for overlay effect)
         Clear.render(area, buf);
 
-        // Create block with border
         let title = format!(" toktrack v{} ", VERSION);
         let block = Block::default()
             .title(title)
@@ -62,7 +60,6 @@ impl Widget for HelpPopup {
         let inner = block.inner(area);
         block.render(area, buf);
 
-        // Layout for content
         let chunks = Layout::vertical([
             Constraint::Length(1), // [0] Padding
             Constraint::Length(1), // [1] Navigation header
@@ -87,7 +84,6 @@ impl Widget for HelpPopup {
         ])
         .split(inner);
 
-        // Navigation section
         let nav_header = Line::from(vec![Span::styled(
             "Navigation",
             Style::default()
@@ -98,7 +94,6 @@ impl Widget for HelpPopup {
             .alignment(Alignment::Left)
             .render(chunks[1], buf);
 
-        // Separator
         let sep = "─".repeat(inner.width as usize);
         buf.set_string(
             chunks[2].x,
@@ -107,7 +102,6 @@ impl Widget for HelpPopup {
             Style::default().fg(self.theme.muted()),
         );
 
-        // Keybindings
         render_keybinding(chunks[3], buf, "Tab / Shift+Tab", "Switch view", self.theme);
         render_keybinding(
             chunks[4],
@@ -135,7 +129,6 @@ impl Widget for HelpPopup {
             self.theme,
         );
 
-        // General section
         let gen_header = Line::from(vec![Span::styled(
             "General",
             Style::default()
@@ -146,7 +139,6 @@ impl Widget for HelpPopup {
             .alignment(Alignment::Left)
             .render(chunks[12], buf);
 
-        // Separator
         buf.set_string(
             chunks[13].x,
             chunks[13].y,
@@ -158,7 +150,6 @@ impl Widget for HelpPopup {
         render_keybinding(chunks[15], buf, "Ctrl+C", "Quit", self.theme);
         render_keybinding(chunks[16], buf, "?", "Toggle help", self.theme);
 
-        // Close hint
         let hint = Line::from(vec![Span::styled(
             "Press ? to close",
             Style::default().fg(self.theme.muted()),
@@ -192,7 +183,6 @@ mod tests {
         let area = Rect::new(0, 0, 100, 50);
         let popup_area = HelpPopup::centered_area(area);
 
-        // Should be centered
         assert_eq!(popup_area.width, POPUP_WIDTH);
         assert_eq!(popup_area.height, POPUP_HEIGHT);
         assert_eq!(popup_area.x, (100 - POPUP_WIDTH) / 2);
@@ -222,11 +212,9 @@ mod tests {
 
     #[test]
     fn test_help_popup_small_terminal() {
-        // Terminal smaller than popup
         let area = Rect::new(0, 0, 30, 10);
         let popup_area = HelpPopup::centered_area(area);
 
-        // Should clamp to terminal size
         assert_eq!(popup_area.width, 30);
         assert_eq!(popup_area.height, 10);
     }

--- a/src/tui/widgets/legend.rs
+++ b/src/tui/widgets/legend.rs
@@ -17,7 +17,6 @@ impl Legend {
 
     /// Returns the minimum width needed to render the legend
     pub fn min_width() -> u16 {
-        // "Less ▪▪ ▪▪ ▪▪ ▪▪ More" = 21 chars (2-char cells with spaces)
         21
     }
 }
@@ -41,31 +40,26 @@ impl Widget for Legend {
             HeatmapIntensity::Max,
         ];
 
-        // Right-align the legend
         let legend_width = Self::min_width();
         let start_x = area.x + area.width.saturating_sub(legend_width);
         let y = area.y;
 
         let mut x = start_x;
 
-        // "Less "
         buf.set_string(x, y, "Less ", Style::default().fg(self.theme.muted()));
         x += 5;
 
-        // Intensity cells (2-char each) - use uniform block for consistent visual size
         for intensity in intensities {
             let style = Style::default().fg(intensity.color(self.theme));
             buf.set_string(x, y, "██", style);
             x += 2; // 2-char cell
 
-            // Space between cells except last
             if intensity != HeatmapIntensity::Max {
                 buf.set_string(x, y, " ", Style::default());
                 x += 1;
             }
         }
 
-        // " More"
         buf.set_string(x, y, " More", Style::default().fg(self.theme.muted()));
     }
 }
@@ -76,7 +70,6 @@ mod tests {
 
     #[test]
     fn test_legend_min_width() {
-        // "Less ▪▪ ▪▪ ▪▪ ▪▪ More" = 21 chars (2-char cells)
         assert_eq!(Legend::min_width(), 21);
     }
 

--- a/src/tui/widgets/model_breakdown.rs
+++ b/src/tui/widgets/model_breakdown.rs
@@ -31,7 +31,6 @@ pub struct ModelBreakdownState {
 impl ModelBreakdownState {
     /// Create a new state from date label and model map
     pub fn new(date_label: String, models: Vec<(String, ModelUsage)>) -> Self {
-        // Filter out zero-token models and sort by cost descending
         let mut models: Vec<_> = models
             .into_iter()
             .filter(|(_, usage)| {
@@ -81,10 +80,8 @@ impl<'a> ModelBreakdownPopup<'a> {
 
 impl Widget for ModelBreakdownPopup<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // Clear the area first (for overlay effect)
         Clear.render(area, buf);
 
-        // Create block with border and date title
         let title = format!(" {} ", self.state.date_label);
         let block = Block::default()
             .title(title)
@@ -95,7 +92,6 @@ impl Widget for ModelBreakdownPopup<'_> {
         let inner = block.inner(area);
         block.render(area, buf);
 
-        // Apply internal padding: 1 top, 2 left/right
         let padded = Rect {
             x: inner.x + 2,
             y: inner.y + 1,
@@ -103,11 +99,9 @@ impl Widget for ModelBreakdownPopup<'_> {
             height: inner.height.saturating_sub(1), // Only top padding
         };
 
-        // Calculate visible rows (minus header, separator, padding, footer)
         let available_rows = padded.height.saturating_sub(4) as usize;
         let models_to_show = self.state.models.len().min(available_rows);
 
-        // Build layout
         let mut constraints = vec![
             Constraint::Length(1), // Header
             Constraint::Length(1), // Separator
@@ -120,7 +114,6 @@ impl Widget for ModelBreakdownPopup<'_> {
 
         let chunks = Layout::vertical(constraints).split(padded);
 
-        // Header
         let header_style = Style::default()
             .fg(self.theme.text())
             .add_modifier(Modifier::BOLD);
@@ -133,7 +126,6 @@ impl Widget for ModelBreakdownPopup<'_> {
             .alignment(Alignment::Left)
             .render(chunks[0], buf);
 
-        // Separator
         let sep = "─".repeat(padded.width as usize);
         buf.set_string(
             padded.x,
@@ -142,7 +134,6 @@ impl Widget for ModelBreakdownPopup<'_> {
             Style::default().fg(self.theme.muted()),
         );
 
-        // Model rows
         for (i, (model_name, usage)) in self.state.models.iter().take(models_to_show).enumerate() {
             let chunk_idx = i + 2;
             let display = display_name(model_name);
@@ -176,7 +167,6 @@ impl Widget for ModelBreakdownPopup<'_> {
                 .render(chunks[chunk_idx], buf);
         }
 
-        // Footer hint
         let footer_idx = chunks.len() - 1;
         let footer = Line::from(Span::styled(
             "Press Esc to close",
@@ -236,7 +226,6 @@ mod tests {
         assert_eq!(popup_area.width, POPUP_WIDTH);
         assert!(popup_area.height >= POPUP_MIN_HEIGHT);
         assert!(popup_area.height <= POPUP_MAX_HEIGHT);
-        // Should be centered
         assert_eq!(popup_area.x, (100 - POPUP_WIDTH) / 2);
     }
 
@@ -245,7 +234,6 @@ mod tests {
         let area = Rect::new(0, 0, 100, 50);
         let popup_area = ModelBreakdownPopup::centered_area(area, 20);
 
-        // Should cap at max height
         assert!(popup_area.height <= POPUP_MAX_HEIGHT);
     }
 
@@ -254,7 +242,6 @@ mod tests {
         let area = Rect::new(0, 0, 40, 10);
         let popup_area = ModelBreakdownPopup::centered_area(area, 5);
 
-        // Should fit within terminal bounds
         assert!(popup_area.width <= area.width);
         assert!(popup_area.height <= area.height);
     }
@@ -278,7 +265,6 @@ mod tests {
         let mut buf = Buffer::empty(area);
         ModelBreakdownPopup::new(&state, Theme::Dark).render(popup_area, &mut buf);
 
-        // Verify content rendered
         let content: String = buf.content().iter().map(|c| c.symbol()).collect();
         assert!(content.contains("2026-02-05"));
         assert!(content.contains("Model"));
@@ -301,7 +287,6 @@ mod tests {
         ModelBreakdownPopup::new(&state, Theme::Dark).render(popup_area, &mut buf);
 
         let content: String = buf.content().iter().map(|c| c.symbol()).collect();
-        // display_name converts claude-opus-4-5-20251101 to "Opus 4.5"
         assert!(content.contains("Opus 4.5"));
     }
 
@@ -319,7 +304,6 @@ mod tests {
         ModelBreakdownPopup::new(&state, Theme::Dark).render(popup_area, &mut buf);
 
         let content: String = buf.content().iter().map(|c| c.symbol()).collect();
-        // Should contain truncation marker
         assert!(content.contains('…'));
     }
 }

--- a/src/tui/widgets/models.rs
+++ b/src/tui/widgets/models.rs
@@ -59,10 +59,9 @@ impl ModelsData {
                     cost_usd: usage.cost_usd,
                 }
             })
-            .filter(|m| m.total_tokens > 0) // Filter out zero-token models
+            .filter(|m| m.total_tokens > 0)
             .collect();
 
-        // Sort by cost descending (NaN-safe)
         models.sort_by(|a, b| {
             b.cost_usd
                 .partial_cmp(&a.cost_usd)
@@ -103,7 +102,6 @@ impl<'a> ModelsView<'a> {
 
 impl Widget for ModelsView<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // Apply max width constraint and center the content
         let content_width = area.width.min(MAX_CONTENT_WIDTH);
         let x_offset = (area.width.saturating_sub(content_width)) / 2;
         let centered_area = Rect {
@@ -113,8 +111,7 @@ impl Widget for ModelsView<'_> {
             height: area.height,
         };
 
-        // Calculate layout with models list
-        let max_model_rows = self.data.models.len().min(10) as u16; // Show up to 10 models
+        let max_model_rows = self.data.models.len().min(10) as u16;
         let chunks = Layout::vertical([
             Constraint::Length(1),              // Tabs
             Constraint::Length(1),              // Separator
@@ -126,22 +123,16 @@ impl Widget for ModelsView<'_> {
         ])
         .split(centered_area);
 
-        // Render tab bar
         TabBar::new(self.tab, self.theme).render(chunks[0], buf);
 
-        // Render separator
         self.render_separator(chunks[1], buf);
 
-        // Render header
         self.render_header(chunks[2], buf);
 
-        // Render model rows
         self.render_models(chunks[3], buf);
 
-        // Render separator
         self.render_separator(chunks[4], buf);
 
-        // Render keybindings
         self.render_keybindings(chunks[5], buf);
     }
 }
@@ -165,7 +156,6 @@ impl ModelsView<'_> {
     fn render_header(&self, area: Rect, buf: &mut Buffer) {
         let offset = self.calculate_table_offset(area.width);
 
-        // Column widths: Model(30), Tokens(18), Cost(12), Usage(18)
         let header = Line::from(vec![
             Span::styled(
                 format!("{:<30}", "Model"),
@@ -228,7 +218,6 @@ impl ModelsView<'_> {
 
             let bar = format_percentage_bar(percent, 14);
 
-            // Convert to display name and truncate if too long (UTF-8 safe)
             let name = display_name(&model.name);
             let name = if name.chars().count() > 28 {
                 format!("{}…", name.chars().take(27).collect::<String>())
@@ -289,8 +278,6 @@ impl ModelsView<'_> {
 mod tests {
     use super::*;
 
-    // ========== format_percentage_bar tests ==========
-
     #[test]
     fn test_format_percentage_bar_zero() {
         assert_eq!(format_percentage_bar(0.0, 10), "░░░░░░░░░░");
@@ -308,17 +295,13 @@ mod tests {
 
     #[test]
     fn test_format_percentage_bar_twenty_five() {
-        // 25% of 8 = 2 filled
         assert_eq!(format_percentage_bar(25.0, 8), "██░░░░░░");
     }
 
     #[test]
     fn test_format_percentage_bar_rounding() {
-        // 33% of 10 = 3.3 → rounds to 3
         assert_eq!(format_percentage_bar(33.0, 10), "███░░░░░░░");
     }
-
-    // ========== ModelsData tests ==========
 
     #[test]
     fn test_models_data_empty() {
@@ -352,7 +335,7 @@ mod tests {
 
         assert_eq!(data.models.len(), 1);
         assert_eq!(data.models[0].name, "claude-sonnet-4");
-        assert_eq!(data.models[0].total_tokens, 1650); // 1000+500+100+50
+        assert_eq!(data.models[0].total_tokens, 1650);
         assert!((data.models[0].cost_usd - 0.05).abs() < f64::EPSILON);
         assert!((data.total_cost - 0.05).abs() < f64::EPSILON);
     }
@@ -409,7 +392,6 @@ mod tests {
         let data = ModelsData::from_model_usage(&model_map);
 
         assert_eq!(data.models.len(), 3);
-        // Should be sorted by cost descending: opus (0.50) > sonnet (0.10) > haiku (0.01)
         assert_eq!(data.models[0].name, "claude-opus");
         assert_eq!(data.models[1].name, "claude-sonnet");
         assert_eq!(data.models[2].name, "claude-haiku");

--- a/src/tui/widgets/overview.rs
+++ b/src/tui/widgets/overview.rs
@@ -66,7 +66,6 @@ impl<'a> Overview<'a> {
 
 impl Widget for Overview<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // Apply max width constraint and center the content
         let content_width = area.width.min(MAX_CONTENT_WIDTH);
         let x_offset = (area.width.saturating_sub(content_width)) / 2;
         let centered_area = Rect {
@@ -76,11 +75,9 @@ impl Widget for Overview<'_> {
             height: area.height,
         };
 
-        // Determine source section height (1 row per source, 0-4 sources shown)
         let source_rows = self.data.source_usage.len().min(4) as u16;
         let show_sources = source_rows > 0;
 
-        // Build layout constraints dynamically
         let mut constraints = vec![
             Constraint::Length(1), // 0: TabBar
             Constraint::Length(1), // 1: Separator
@@ -121,31 +118,23 @@ impl Widget for Overview<'_> {
 
         let chunks = Layout::vertical(constraints).split(centered_area);
 
-        // Render tab bar
         TabBar::new(self.data.selected_tab, self.theme).render(chunks[0], buf);
 
-        // Render separator
         self.render_separator(chunks[1], buf);
 
-        // Render hero stat
         self.render_hero_stat(chunks[2], buf);
 
-        // Render sub-stats (Cost only)
         self.render_sub_stats(chunks[3], buf);
 
-        // Render sources section if present
         if show_sources {
             self.render_sources_label(chunks[sources_label_idx], buf);
             self.render_source_bars(chunks[sources_bars_idx], buf);
         }
 
-        // Render heatmap with legend
         self.render_heatmap_section(chunks[heatmap_idx], buf);
 
-        // Render separator
         self.render_separator(chunks[sep_idx], buf);
 
-        // Render keybindings
         self.render_keybindings(chunks[keybindings_idx], buf);
     }
 }
@@ -223,7 +212,6 @@ impl Overview<'_> {
             .max()
             .unwrap_or(1);
 
-        // Bar rendering config
         const SOURCE_NAME_WIDTH: usize = 12;
         const BAR_WIDTH: usize = 20;
         const TOTAL_LINE_WIDTH: usize = SOURCE_NAME_WIDTH + 2 + BAR_WIDTH + 2 + 15; // name + "  " + bar + "  " + count
@@ -239,11 +227,9 @@ impl Overview<'_> {
                 break;
             }
 
-            // Selection marker
             let is_selected = self.data.selected_source == Some(i);
             let marker = if is_selected { "▸ " } else { "  " };
 
-            // Source name (left-padded, fixed width)
             let name = if source.source.chars().count() > SOURCE_NAME_WIDTH - 1 {
                 format!(
                     "{}…",
@@ -258,7 +244,6 @@ impl Overview<'_> {
             };
             let name_display = format!("{:>width$}", name, width = SOURCE_NAME_WIDTH);
 
-            // Bar representation
             let ratio = source.total_tokens as f64 / max_tokens as f64;
             let filled = (ratio * BAR_WIDTH as f64).round() as usize;
             let filled = if source.total_tokens > 0 {
@@ -269,7 +254,6 @@ impl Overview<'_> {
             let filled = filled.min(BAR_WIDTH);
             let bar = format!("{}{}", "█".repeat(filled), "░".repeat(BAR_WIDTH - filled));
 
-            // Token count
             let count_str = format_number(source.total_tokens);
 
             // Unsupported sources render as a dimmed, bar-less notice row
@@ -289,7 +273,6 @@ impl Overview<'_> {
                 continue;
             }
 
-            // Build the line
             let name_style = if is_selected {
                 Style::default()
                     .fg(self.theme.accent())
@@ -317,7 +300,6 @@ impl Overview<'_> {
                 ));
             }
 
-            // Render centered
             let line = Line::from(spans);
             buf.set_line(area.x + x_offset, y, &line, area.width - x_offset);
         }
@@ -394,8 +376,6 @@ impl Overview<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ========== format_number tests ==========
 
     #[test]
     fn test_format_number_zero() {

--- a/src/tui/widgets/projects.rs
+++ b/src/tui/widgets/projects.rs
@@ -68,7 +68,6 @@ impl ProjectsData {
             .filter(|p| p.total_tokens > 0)
             .collect();
 
-        // Sort by cost descending (NaN-safe), tie-break by tokens.
         projects.sort_by(|a, b| {
             b.cost_usd
                 .partial_cmp(&a.cost_usd)
@@ -196,7 +195,6 @@ impl ProjectsView<'_> {
             return;
         }
 
-        // Auto-scroll so the selected row stays visible.
         let selected = self.selected.unwrap_or(0);
         let scroll = if selected >= height {
             selected + 1 - height
@@ -300,9 +298,7 @@ mod tests {
 
     #[test]
     fn test_project_display_name_two_segments() {
-        // Forward slashes (POSIX-style).
         assert_eq!(project_display_name("/srv/work/alpha/beta"), "alpha/beta");
-        // Backslashes (Windows-style) — synthetic placeholder, not a real path.
         assert_eq!(project_display_name("Z:\\work\\alpha\\beta"), "alpha/beta");
     }
 

--- a/src/tui/widgets/quit_confirm.rs
+++ b/src/tui/widgets/quit_confirm.rs
@@ -54,10 +54,8 @@ impl QuitConfirmPopup {
 
 impl Widget for QuitConfirmPopup {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // Clear the area first (for overlay effect)
         Clear.render(area, buf);
 
-        // Create block with border
         let block = Block::default()
             .title(" Quit? ")
             .title_alignment(Alignment::Center)
@@ -67,7 +65,6 @@ impl Widget for QuitConfirmPopup {
         let inner = block.inner(area);
         block.render(area, buf);
 
-        // Layout for content
         let chunks = Layout::vertical([
             Constraint::Length(1), // [0] Padding
             Constraint::Length(1), // [1] Question
@@ -79,7 +76,6 @@ impl Widget for QuitConfirmPopup {
         ])
         .split(inner);
 
-        // Question line
         let question_line = Line::from(Span::styled(
             "Are you sure you want to quit?",
             Style::default().fg(self.theme.text()),
@@ -88,7 +84,6 @@ impl Widget for QuitConfirmPopup {
             .alignment(Alignment::Center)
             .render(chunks[1], buf);
 
-        // Buttons: Yes / No
         let (yes_marker, yes_style) = if self.selection == 0 {
             (
                 "▸ ",
@@ -122,7 +117,6 @@ impl Widget for QuitConfirmPopup {
             .alignment(Alignment::Center)
             .render(chunks[3], buf);
 
-        // Key hints - two lines
         let hint_line1 = Line::from(vec![
             Span::styled("  ←→", Style::default().fg(self.theme.accent())),
             Span::styled("  Select", Style::default().fg(self.theme.muted())),
@@ -148,13 +142,12 @@ mod tests {
     #[test]
     fn test_quit_confirm_default_selection_is_yes() {
         let state = QuitConfirmState::new();
-        assert_eq!(state.selection, 0); // 0 = Yes
+        assert_eq!(state.selection, 0);
     }
 
     #[test]
     fn test_quit_confirm_state_default_is_yes() {
         let state = QuitConfirmState::default();
-        // Both default() and new() should give selection=0 (Yes)
         assert_eq!(state.selection, 0);
     }
 
@@ -192,10 +185,9 @@ mod tests {
         let area = Rect::new(0, 0, 60, 20);
         let popup_area = QuitConfirmPopup::centered_area(area);
         let mut buf = Buffer::empty(area);
-        let popup = QuitConfirmPopup::new(0, Theme::Dark); // Yes selected
+        let popup = QuitConfirmPopup::new(0, Theme::Dark);
         popup.render(popup_area, &mut buf);
 
-        // Should render without panic
         let content: String = buf.content().iter().map(|c| c.symbol()).collect();
         assert!(content.contains("Quit?"));
         assert!(content.contains("Yes"));

--- a/src/tui/widgets/source_detail.rs
+++ b/src/tui/widgets/source_detail.rs
@@ -88,7 +88,6 @@ impl Widget for SourceDetailView<'_> {
         self.render_separator(chunks[2], buf);
         self.render_mode_indicator(chunks[3], buf);
 
-        // Render daily table (header + rows)
         let daily_view = DailyView::new(
             self.daily_data,
             self.scroll_offset,
@@ -448,7 +447,6 @@ mod tests {
         let area = Rect::new(0, 0, 60, 15);
         let mut buf = Buffer::empty(area);
         view.render(area, &mut buf);
-        // Should not panic even on narrow terminal
     }
 
     #[test]
@@ -467,7 +465,6 @@ mod tests {
         let area = Rect::new(0, 0, 120, 20);
         let mut buf = Buffer::empty(area);
         view.render(area, &mut buf);
-        // Should render with selected row without panic
     }
 
     #[test]
@@ -536,7 +533,6 @@ mod tests {
         let area = Rect::new(0, 0, 120, 20);
         let mut buf = Buffer::empty(area);
         view.render(area, &mut buf);
-        // Should render with light theme without panic
     }
 
     #[test]

--- a/src/tui/widgets/spinner.rs
+++ b/src/tui/widgets/spinner.rs
@@ -69,10 +69,8 @@ impl Widget for Spinner {
             return;
         }
 
-        // Calculate center Y (4 lines: name, tagline, empty, spinner)
         let center_y = area.y + area.height / 2;
 
-        // App name with version (bold)
         let name_with_version = format!("{} v{}", APP_NAME, VERSION);
         let name_y = center_y.saturating_sub(2);
         let name_x = area.x + (area.width.saturating_sub(name_with_version.len() as u16)) / 2;
@@ -85,7 +83,6 @@ impl Widget for Spinner {
                 .add_modifier(Modifier::BOLD),
         );
 
-        // Tagline (muted)
         let tag_y = name_y + 1;
         let tag_x = area.x + (area.width.saturating_sub(TAGLINE.len() as u16)) / 2;
         buf.set_string(
@@ -95,7 +92,6 @@ impl Widget for Spinner {
             Style::default().fg(self.theme.muted()),
         );
 
-        // Spinner (accent) - 1 blank line after tagline
         let spinner_text = format!("{} {}", self.current_char(), self.stage.message());
         let spinner_y = tag_y + 2;
         let spinner_x = area.x + (area.width.saturating_sub(spinner_text.len() as u16)) / 2;
@@ -129,7 +125,7 @@ mod tests {
     #[test]
     fn test_spinner_wraps() {
         let spinner = Spinner::new(10, LoadingStage::Scanning, Theme::Dark);
-        assert_eq!(spinner.current_char(), '⠋'); // 10 % 10 = 0
+        assert_eq!(spinner.current_char(), '⠋');
     }
 
     #[test]

--- a/src/tui/widgets/stats.rs
+++ b/src/tui/widgets/stats.rs
@@ -54,7 +54,6 @@ impl<'a> StatsView<'a> {
 
 impl Widget for StatsView<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // Apply max width constraint and center the content
         let content_width = area.width.min(MAX_CONTENT_WIDTH);
         let x_offset = (area.width.saturating_sub(content_width)) / 2;
         let centered_area = Rect {
@@ -64,7 +63,6 @@ impl Widget for StatsView<'_> {
             height: area.height,
         };
 
-        // Calculate grid layout
         let cols = cards_per_row(centered_area.width);
         let rows = 6_usize.div_ceil(cols); // 6 cards total
         let grid_height = (rows as u16) * (CARD_HEIGHT + 1); // +1 for spacing
@@ -81,22 +79,16 @@ impl Widget for StatsView<'_> {
         ])
         .split(centered_area);
 
-        // Render tabs
         self.render_tabs(chunks[0], buf);
 
-        // Render separator
         self.render_separator(chunks[1], buf);
 
-        // Render title
         self.render_title(chunks[2], buf);
 
-        // Render card grid
         self.render_card_grid(chunks[4], buf, cols);
 
-        // Render separator
         self.render_separator(chunks[5], buf);
 
-        // Render keybindings
         self.render_keybindings(chunks[6], buf);
     }
 }
@@ -131,7 +123,6 @@ impl StatsView<'_> {
     fn render_card_grid(&self, area: Rect, buf: &mut Buffer, cols: usize) {
         let cards = self.build_cards();
 
-        // Calculate grid positioning
         let total_cards_width = (cols as u16) * CARD_WIDTH + ((cols - 1) as u16) * 2; // 2 = spacing
         let start_x = area.x + (area.width.saturating_sub(total_cards_width)) / 2;
 
@@ -142,7 +133,6 @@ impl StatsView<'_> {
             let card_x = start_x + (col as u16) * (CARD_WIDTH + 2);
             let card_y = area.y + (row as u16) * (CARD_HEIGHT + 1);
 
-            // Skip if card is outside area
             if card_y + CARD_HEIGHT > area.y + area.height {
                 continue;
             }
@@ -206,13 +196,11 @@ impl StatsView<'_> {
     }
 
     fn render_card(&self, area: Rect, buf: &mut Buffer, card: &StatCard) {
-        // Draw card border with card-specific color
         let block = Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(card.border_color));
         block.render(area, buf);
 
-        // Render title (centered, line 1 inside border) with matching border color
         if area.height > 2 {
             let title_y = area.y + 1;
             let title = &card.title;
@@ -225,7 +213,6 @@ impl StatsView<'_> {
             );
         }
 
-        // Render value (centered, line 2-3 inside border)
         if area.height > 3 {
             let value_y = area.y + 3;
             let value = &card.value;
@@ -289,21 +276,18 @@ mod tests {
 
     #[test]
     fn test_cards_per_row_narrow() {
-        // Width 60 should fit 1-2 cards
         let cols = cards_per_row(60);
         assert!((1..=2).contains(&cols));
     }
 
     #[test]
     fn test_cards_per_row_wide() {
-        // Width 170 should fit max 3 cards (FIXED_COLS)
         let cols = cards_per_row(170);
         assert_eq!(cols, 3);
     }
 
     #[test]
     fn test_cards_per_row_minimum() {
-        // Even with very narrow width, should return at least 1
         assert_eq!(cards_per_row(20), 1);
         assert_eq!(cards_per_row(10), 1);
     }

--- a/src/tui/widgets/tabs.rs
+++ b/src/tui/widgets/tabs.rs
@@ -96,7 +96,6 @@ impl Widget for TabBar {
             return;
         }
 
-        // Calculate total width of all tabs for centering
         let total_width: u16 = Tab::all()
             .iter()
             .map(|tab| {
@@ -111,7 +110,6 @@ impl Widget for TabBar {
             .sum::<u16>()
             .saturating_sub(2); // Remove trailing spacing
 
-        // Center the tabs
         let start_x = area.x + (area.width.saturating_sub(total_width)) / 2;
         let mut x = start_x;
 
@@ -119,7 +117,6 @@ impl Widget for TabBar {
             let is_selected = *tab == self.selected;
             let label = tab.label();
 
-            // Calculate display string
             let display = if is_selected {
                 format!("[{}]", label)
             } else {
@@ -131,7 +128,6 @@ impl Widget for TabBar {
                 break;
             }
 
-            // Style based on selection
             let style = if is_selected {
                 Style::default()
                     .fg(self.theme.accent())

--- a/src/tui/widgets/update_popup.rs
+++ b/src/tui/widgets/update_popup.rs
@@ -63,10 +63,8 @@ impl<'a> UpdatePopup<'a> {
 
 impl<'a> Widget for UpdatePopup<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // Clear the area first (for overlay effect)
         Clear.render(area, buf);
 
-        // Create block with border
         let block = Block::default()
             .title(" Update Available ")
             .title_alignment(Alignment::Center)
@@ -76,7 +74,6 @@ impl<'a> Widget for UpdatePopup<'a> {
         let inner = block.inner(area);
         block.render(area, buf);
 
-        // Layout for content
         let chunks = Layout::vertical([
             Constraint::Length(1), // [0] Padding
             Constraint::Length(1), // [1] Version info
@@ -91,7 +88,6 @@ impl<'a> Widget for UpdatePopup<'a> {
         ])
         .split(inner);
 
-        // Version info line
         let version_line = Line::from(vec![
             Span::styled("  v", Style::default().fg(self.theme.text())),
             Span::styled(
@@ -113,7 +109,6 @@ impl<'a> Widget for UpdatePopup<'a> {
             .alignment(Alignment::Center)
             .render(chunks[1], buf);
 
-        // Separator
         let sep = "─".repeat(inner.width as usize);
         buf.set_string(
             chunks[3].x,
@@ -122,7 +117,6 @@ impl<'a> Widget for UpdatePopup<'a> {
             Style::default().fg(self.theme.muted()),
         );
 
-        // Selection items
         let (update_marker, update_style) = if self.selection == 0 {
             (
                 "▸ ",
@@ -159,7 +153,6 @@ impl<'a> Widget for UpdatePopup<'a> {
             .alignment(Alignment::Center)
             .render(chunks[6], buf);
 
-        // Key hints - two lines
         let hint_line1 = Line::from(vec![
             Span::styled("  ↑↓", Style::default().fg(self.theme.accent())),
             Span::styled("  Select", Style::default().fg(self.theme.muted())),
@@ -237,7 +230,6 @@ mod tests {
     fn test_dim_overlay_sets_colors() {
         let area = Rect::new(0, 0, 10, 5);
         let mut buf = Buffer::empty(area);
-        // Write some content first
         buf.set_string(
             0,
             0,
@@ -247,7 +239,6 @@ mod tests {
 
         DimOverlay.render(area, &mut buf);
 
-        // Every cell should have DarkGray fg and Black bg
         for y in 0..5 {
             for x in 0..10 {
                 let cell = buf.cell(Position { x, y }).unwrap();
@@ -300,7 +291,6 @@ mod tests {
         let area = Rect::new(0, 0, 60, 20);
         let popup_area = UpdateMessagePopup::centered_area(area);
 
-        // Success message
         let mut buf = Buffer::empty(area);
         let popup_success =
             UpdateMessagePopup::new("Updated! Press any key to exit.", Color::Green);
@@ -312,7 +302,6 @@ mod tests {
             "Success message not found in buffer"
         );
 
-        // Error message
         let mut buf2 = Buffer::empty(area);
         let popup_error = UpdateMessagePopup::new("Failed: npm error", Color::Red);
         popup_error.render(popup_area, &mut buf2);

--- a/src/types/usage.rs
+++ b/src/types/usage.rs
@@ -29,7 +29,6 @@ impl StatsData {
 
         let active_days = summaries.len() as u32;
 
-        // Calculate totals
         let mut total_tokens: u64 = 0;
         let mut total_cost: f64 = 0.0;
         let mut peak_day: Option<(NaiveDate, u64)> = None;
@@ -492,7 +491,7 @@ mod tests {
         let summaries = vec![make_summary(2024, 1, 15, 1000, 500, 100, 50, 0.10)];
         let data = StatsData::from_daily_summaries(&summaries);
 
-        assert_eq!(data.total_tokens, 1650); // 1000 + 500 + 100 + 50
+        assert_eq!(data.total_tokens, 1650);
         assert_eq!(data.daily_avg_tokens, 1650);
         assert_eq!(
             data.peak_day,
@@ -506,14 +505,14 @@ mod tests {
     #[test]
     fn test_stats_data_multiple_days() {
         let summaries = vec![
-            make_summary(2024, 1, 10, 100, 50, 10, 5, 0.05), // 165 tokens
-            make_summary(2024, 1, 15, 500, 250, 50, 25, 0.20), // 825 tokens (peak)
-            make_summary(2024, 1, 20, 200, 100, 20, 10, 0.10), // 330 tokens
+            make_summary(2024, 1, 10, 100, 50, 10, 5, 0.05),
+            make_summary(2024, 1, 15, 500, 250, 50, 25, 0.20),
+            make_summary(2024, 1, 20, 200, 100, 20, 10, 0.10),
         ];
         let data = StatsData::from_daily_summaries(&summaries);
 
-        assert_eq!(data.total_tokens, 165 + 825 + 330); // 1320
-        assert_eq!(data.daily_avg_tokens, 1320 / 3); // 440
+        assert_eq!(data.total_tokens, 165 + 825 + 330);
+        assert_eq!(data.daily_avg_tokens, 1320 / 3);
         assert_eq!(
             data.peak_day,
             Some((NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(), 825))
@@ -525,15 +524,13 @@ mod tests {
 
     #[test]
     fn test_stats_data_peak_day_tie_keeps_first() {
-        // When multiple days have the same max tokens, first one wins
         let summaries = vec![
-            make_summary(2024, 1, 10, 500, 250, 50, 25, 0.10), // 825 tokens (first peak)
-            make_summary(2024, 1, 15, 500, 250, 50, 25, 0.10), // 825 tokens (tie)
-            make_summary(2024, 1, 20, 100, 50, 10, 5, 0.05),   // 165 tokens
+            make_summary(2024, 1, 10, 500, 250, 50, 25, 0.10),
+            make_summary(2024, 1, 15, 500, 250, 50, 25, 0.10),
+            make_summary(2024, 1, 20, 100, 50, 10, 5, 0.05),
         ];
         let data = StatsData::from_daily_summaries(&summaries);
 
-        // First day with max should win
         assert_eq!(
             data.peak_day,
             Some((NaiveDate::from_ymd_opt(2024, 1, 10).unwrap(), 825))
@@ -694,7 +691,6 @@ mod tests {
         };
 
         let local_date = entry.local_date();
-        // Verify it matches what chrono::Local would produce
         let expected = utc_ts.with_timezone(&Local).date_naive();
         assert_eq!(local_date, expected);
 


### PR DESCRIPTION
## Summary

- remove redundant, decorative, and code-restating comments across Rust sources, hooks, build scripts, benchmarks, and the demo tape
- retain comments that document invariants, external schemas, safety and concurrency constraints, cache preservation, pricing semantics, layout indices, privacy, and failure policy
- normalize necessary code and configuration comments to English

## Verification

- `make check` (format, Clippy, 681 tests passed, 1 existing network test ignored, 1 doc-test passed)
- `cargo build --verbose`
- `bash -n .claude/hooks/*.sh`
- `make -n check`
- `git diff --check`
- comment/whitespace equivalence probe across every changed tracked file

## Review

- PASS: all tracked changes are comment/whitespace-only
- no behavior, API, fixture, or test expectation changes
- no blocking findings or unresolved risks
