### PR TITLE
fix(tui): make overview sources list scrollable

### DIFF
--- a/src/tui/widgets/overview.rs
+++ b/src/tui/widgets/overview.rs
@@ -51,6 +51,31 @@ pub struct OverviewData<'a> {
 /// 52 weeks * 3-char cells + 4 label = 160, so 170 gives some padding
 const MAX_CONTENT_WIDTH: u16 = 170;
 
+/// Maximum source rows shown at once. Anything past this stays reachable
+/// through the existing Up/Down selection, which scrolls the list window.
+const MAX_VISIBLE_SOURCES: usize = 4;
+
+/// Minimum rows reserved for the heatmap so short terminals keep context.
+/// Matches `REQUIRED_HEIGHT` in `render_heatmap_section` (grid + labels +
+/// blank + legend).
+const HEATMAP_MIN_HEIGHT: u16 = 10;
+
+/// Fixed non-fill rows around the sources section when sources are shown:
+/// tab bar, separators, hero stat, sub-stats, blanks, label, keybindings.
+const OVERVIEW_FIXED_ROWS: u16 = 11;
+
+/// Visible slice of the sources list for one frame.
+struct SourceWindow {
+    /// Absolute index of the first rendered source.
+    start: usize,
+    /// Number of source rows rendered.
+    visible: usize,
+    /// Whether the estimated-cost legend row is rendered.
+    show_legend: bool,
+    /// Total sources left out of view (drives the "N more" hint).
+    hidden: usize,
+}
+
 /// Overview widget combining all elements
 pub struct Overview<'a> {
     data: OverviewData<'a>,
@@ -75,8 +100,17 @@ impl Widget for Overview<'_> {
             height: area.height,
         };
 
-        let source_rows = self.data.source_usage.len().min(4) as u16;
-        let show_sources = source_rows > 0;
+        let total_sources = self.data.source_usage.len();
+        let show_sources = total_sources > 0;
+
+        // The legend row is reserved whenever any source is estimated so the
+        // layout stays stable while the list scrolls.
+        let any_estimated = self
+            .data
+            .source_usage
+            .iter()
+            .any(|s| s.supported && s.estimated);
+        let window = self.source_window(area.height, any_estimated);
 
         let mut constraints = vec![
             Constraint::Length(1), // 0: TabBar
@@ -89,17 +123,11 @@ impl Widget for Overview<'_> {
         let sources_label_idx = constraints.len(); // 5
         constraints.push(Constraint::Length(if show_sources { 1 } else { 0 }));
 
-        // Reserve one extra line for the estimated-cost legend when any shown
+        // Reserve one extra line for the estimated-cost legend when any
         // source is estimated.
-        let any_estimated = self
-            .data
-            .source_usage
-            .iter()
-            .take(4)
-            .any(|s| s.supported && s.estimated);
         let sources_bars_idx = constraints.len(); // 6
         constraints.push(Constraint::Length(if show_sources {
-            source_rows + u16::from(any_estimated)
+            window.visible as u16 + u16::from(window.show_legend) + u16::from(window.hidden > 0)
         } else {
             0
         }));
@@ -128,7 +156,7 @@ impl Widget for Overview<'_> {
 
         if show_sources {
             self.render_sources_label(chunks[sources_label_idx], buf);
-            self.render_source_bars(chunks[sources_bars_idx], buf);
+            self.render_source_bars(chunks[sources_bars_idx], buf, window);
         }
 
         self.render_heatmap_section(chunks[heatmap_idx], buf);
@@ -140,6 +168,50 @@ impl Widget for Overview<'_> {
 }
 
 impl Overview<'_> {
+    /// Slice of the sources list shown in one frame. At most
+    /// `MAX_VISIBLE_SOURCES` rows render at once; anything past that (or
+    /// past what fits on a short terminal) stays reachable through the
+    /// existing Up/Down selection, which scrolls the window. The heatmap
+    /// floor is reserved first so short terminals shrink the list instead
+    /// of the heatmap.
+    fn source_window(&self, term_height: u16, show_legend: bool) -> SourceWindow {
+        let total = self.data.source_usage.len();
+        if total == 0 {
+            return SourceWindow {
+                start: 0,
+                visible: 0,
+                show_legend: false,
+                hidden: 0,
+            };
+        }
+        let reserved = OVERVIEW_FIXED_ROWS + HEATMAP_MIN_HEIGHT + u16::from(show_legend);
+        // Rows available for the source rows plus the truncation hint.
+        let fit = term_height.saturating_sub(reserved) as usize;
+        let mut visible = total.min(MAX_VISIBLE_SOURCES);
+        if visible + usize::from(total > visible) > fit {
+            // Short terminal: shrink the list (keeping at least one source
+            // reachable) instead of squeezing the heatmap.
+            visible = fit.saturating_sub(1).max(1).min(total);
+        }
+        let selected = self
+            .data
+            .selected_source
+            .unwrap_or(0)
+            .min(total.saturating_sub(1));
+        let start = if selected >= visible {
+            selected + 1 - visible
+        } else {
+            0
+        }
+        .min(total.saturating_sub(visible));
+        SourceWindow {
+            start,
+            visible,
+            show_legend,
+            hidden: total.saturating_sub(visible),
+        }
+    }
+
     fn render_separator(&self, area: Rect, buf: &mut Buffer) {
         let line = "─".repeat(area.width as usize);
         buf.set_string(
@@ -199,7 +271,7 @@ impl Overview<'_> {
         label.render(area, buf);
     }
 
-    fn render_source_bars(&self, area: Rect, buf: &mut Buffer) {
+    fn render_source_bars(&self, area: Rect, buf: &mut Buffer, window: SourceWindow) {
         if self.data.source_usage.is_empty() {
             return;
         }
@@ -220,9 +292,15 @@ impl Overview<'_> {
         let full_width = 2 + TOTAL_LINE_WIDTH;
         let x_offset = area.width.saturating_sub(full_width as u16) / 2;
 
-        let mut any_estimated = false;
-        for (i, source) in self.data.source_usage.iter().take(4).enumerate() {
-            let y = area.y + i as u16;
+        for (i, source) in self
+            .data
+            .source_usage
+            .iter()
+            .enumerate()
+            .skip(window.start)
+            .take(window.visible)
+        {
+            let y = area.y + (i - window.start) as u16;
             if y >= area.y + area.height {
                 break;
             }
@@ -291,7 +369,6 @@ impl Overview<'_> {
             ];
             // Estimated-cost marker: this source's cost is LiteLLM-calculated.
             if source.estimated {
-                any_estimated = true;
                 spans.push(Span::styled(
                     " ~",
                     Style::default()
@@ -304,9 +381,31 @@ impl Overview<'_> {
             buf.set_line(area.x + x_offset, y, &line, area.width - x_offset);
         }
 
+        // Position indicator adjacent to the list rows it refers to. The
+        // pager-style range is dynamic in both directions, so reaching the
+        // end of the list never shows a stale count.
+        if window.hidden > 0 {
+            let y = area.y + window.visible as u16;
+            if y < area.y + area.height {
+                let hint = format!(
+                    "  … {}–{} of {} (↑↓ to scroll)",
+                    window.start + 1,
+                    window.start + window.visible,
+                    self.data.source_usage.len()
+                );
+                let hint = Line::from(Span::styled(
+                    hint,
+                    Style::default()
+                        .fg(self.theme.muted())
+                        .add_modifier(Modifier::DIM),
+                ));
+                buf.set_line(area.x + x_offset, y, &hint, area.width - x_offset);
+            }
+        }
+
         // Legend for the estimated-cost marker (only when shown).
-        if any_estimated {
-            let y = area.y + self.data.source_usage.len().min(4) as u16;
+        if window.show_legend {
+            let y = area.y + window.visible as u16 + u16::from(window.hidden > 0);
             if y < area.y + area.height {
                 let legend = Line::from(Span::styled(
                     "  ~ = estimated cost (LiteLLM)",
@@ -486,6 +585,146 @@ mod tests {
         assert!(
             text.contains("estimated cost"),
             "overview should render the estimated-cost legend"
+        );
+    }
+
+    fn make_sources(names: &[&str]) -> Vec<SourceUsage> {
+        names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| SourceUsage {
+                source: (*name).to_string(),
+                total_tokens: ((names.len() - i) * 1000) as u64,
+                total_cost_usd: 1.0,
+                supported: true,
+                estimated: false,
+            })
+            .collect()
+    }
+
+    fn render_overview_text(
+        sources: &[SourceUsage],
+        selected: Option<usize>,
+        width: u16,
+        height: u16,
+    ) -> String {
+        let total = TotalSummary::default();
+        let daily: Vec<(NaiveDate, u64)> = vec![];
+        let data = OverviewData {
+            total: &total,
+            daily_tokens: &daily,
+            source_usage: sources,
+            selected_source: selected,
+            selected_tab: Tab::Overview,
+        };
+        let area = Rect::new(0, 0, width, height);
+        let mut buf = Buffer::empty(area);
+        Overview::new(
+            data,
+            NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+            Theme::Dark,
+        )
+        .render(area, &mut buf);
+
+        let mut text = String::new();
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                text.push_str(buf[(x, y)].symbol());
+            }
+        }
+        text
+    }
+
+    #[test]
+    fn test_tall_terminal_caps_at_four_with_hint() {
+        let sources = make_sources(&["claude", "copilot", "codex", "gemini", "qwen", "opencode"]);
+        let text = render_overview_text(&sources, None, 120, 40);
+        for name in ["claude", "copilot", "codex", "gemini"] {
+            assert!(
+                text.contains(name),
+                "overview should show the first four sources, missing '{name}'"
+            );
+        }
+        assert!(
+            !text.contains("qwen"),
+            "overview should paginate sources past the four-row cap"
+        );
+        assert!(
+            text.contains("1–4 of 6"),
+            "overview should show a position range for the visible window, got:\n{text}"
+        );
+        assert!(
+            text.contains("to scroll"),
+            "overview should tell the user the list scrolls"
+        );
+    }
+
+    #[test]
+    fn test_selection_scrolls_past_four_row_cap() {
+        let sources = make_sources(&["claude", "copilot", "codex", "gemini", "qwen", "opencode"]);
+        let text = render_overview_text(&sources, Some(5), 120, 40);
+        assert!(
+            text.contains("opencode"),
+            "overview should scroll the selected source into view past the cap"
+        );
+        assert!(
+            text.contains("3–6 of 6"),
+            "overview should move the position range with the scrolled window"
+        );
+    }
+
+    #[test]
+    fn test_hint_at_end_shows_window_range() {
+        let sources = make_sources(&["claude", "copilot", "codex", "gemini", "qwen", "opencode"]);
+        let text = render_overview_text(&sources, Some(5), 120, 40);
+        assert!(
+            text.contains("3–6 of 6"),
+            "overview at the end of the list should show the visible window range, got:\n{text}"
+        );
+        assert!(
+            !text.contains("1–4 of 6"),
+            "overview at the end of the list should not show a stale range"
+        );
+    }
+
+    #[test]
+    fn test_hint_sits_above_estimated_legend() {
+        let mut sources = make_sources(&["claude", "copilot", "codex", "gemini", "qwen"]);
+        sources[4].estimated = true;
+        let text = render_overview_text(&sources, None, 120, 40);
+        let hint = text.find("to scroll").expect("hint should render");
+        let legend = text.find("estimated cost").expect("legend should render");
+        assert!(
+            hint < legend,
+            "truncation hint should render above the estimated-cost legend"
+        );
+    }
+
+    #[test]
+    fn test_short_terminal_truncates_with_range_hint() {
+        let sources = make_sources(&["claude", "copilot", "codex", "gemini", "qwen", "opencode"]);
+        let text = render_overview_text(&sources, None, 120, 24);
+        assert!(
+            text.contains("1–2 of 6"),
+            "short overview should show a position range for the visible window, got:\n{text}"
+        );
+        assert!(
+            text.contains("to scroll"),
+            "short overview should tell the user the list scrolls"
+        );
+    }
+
+    #[test]
+    fn test_selected_source_below_fold_scrolls_into_view() {
+        let sources = make_sources(&["claude", "copilot", "codex", "gemini", "qwen", "opencode"]);
+        let text = render_overview_text(&sources, Some(5), 120, 24);
+        assert!(
+            text.contains("opencode"),
+            "short overview should scroll the selected source into view"
+        );
+        assert!(
+            !text.contains("claude"),
+            "short overview should scroll the first source out of view when the last one is selected"
         );
     }
 }


### PR DESCRIPTION
Closes #241.

The Overview tab hardcoded the Sources list to 4 rows (`.take(4)` / `.min(4)` in `src/tui/widgets/overview.rs`), silently hiding every source ranked #5+ with no truncation cue.

This change keeps the existing 4-row cap and paginates past it:

- At most 4 source rows render at once; anything past that stays reachable through the existing Up/Down selection, which now scrolls the list window (no new config surface, no `app.rs` changes).
- A pager-style position hint sits directly below the list rows: `… 1–4 of 6 (↑↓ to scroll)`. The range is dynamic in both directions, so reaching the end of the list never shows a stale count.
- The estimated-cost legend (`~`) still renders, now below the hint row, and its layout row is reserved whenever any source is estimated so scrolling does not shift the layout.
- Short terminals shrink the visible window (minimum 1 row) while reserving a 10-row heatmap floor first, instead of squeezing the heatmap.

Note: this keeps a fixed cap instead of the fully adaptive layout first suggested in #241 — a smaller, layout-stable change that still guarantees every source with usage is reachable from Overview with a visible truncation cue.

Tests: 6 new widget tests (cap + hint, scroll past the cap, short-terminal window, dynamic end-of-list range, hint-above-legend order). `make check` passes: `cargo fmt --check`, `cargo clippy -- -D warnings`, 1420 tests green.