### PR TITLE
fix(tui): keep four source rows on short terminals

### DIFF
--- a/src/tui/widgets/overview.rs
+++ b/src/tui/widgets/overview.rs
@@ -771,4 +771,32 @@ mod tests {
             "no pager hint should render when nothing is hidden, got:\n{text}"
         );
     }
+
+    #[test]
+    fn test_default_terminal_keeps_heatmap_day_grid() {
+        let sources = make_sources(&["claude", "copilot", "codex", "gemini", "qwen", "opencode"]);
+        let text = render_overview_text(&sources, None, 80, 24);
+        for day in ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] {
+            assert!(
+                text.contains(day),
+                "four source rows must not cost the heatmap day grid, missing '{day}', got:\n{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_estimated_costs_keep_heatmap_day_grid() {
+        let mut sources =
+            make_sources(&["claude", "copilot", "codex", "gemini", "qwen", "opencode"]);
+        for source in sources.iter_mut() {
+            source.estimated = true;
+        }
+        let text = render_overview_text(&sources, None, 80, 24);
+        for day in ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] {
+            assert!(
+                text.contains(day),
+                "the legend row must not cost the heatmap day grid, missing '{day}', got:\n{text}"
+            );
+        }
+    }
 }

--- a/src/tui/widgets/overview.rs
+++ b/src/tui/widgets/overview.rs
@@ -55,11 +55,6 @@ const MAX_CONTENT_WIDTH: u16 = 170;
 /// through the existing Up/Down selection, which scrolls the list window.
 const MAX_VISIBLE_SOURCES: usize = 4;
 
-/// Minimum rows reserved for the heatmap so short terminals keep context.
-/// Matches `REQUIRED_HEIGHT` in `render_heatmap_section` (grid + labels +
-/// blank + legend).
-const HEATMAP_MIN_HEIGHT: u16 = 10;
-
 /// Fixed non-fill rows around the sources section when sources are shown:
 /// tab bar, separators, hero stat, sub-stats, blanks, label, keybindings.
 const OVERVIEW_FIXED_ROWS: u16 = 11;
@@ -72,7 +67,7 @@ struct SourceWindow {
     visible: usize,
     /// Whether the estimated-cost legend row is rendered.
     show_legend: bool,
-    /// Total sources left out of view (drives the "N more" hint).
+    /// Sources outside the rendered window. Non-zero draws the pager hint.
     hidden: usize,
 }
 
@@ -171,9 +166,7 @@ impl Overview<'_> {
     /// Slice of the sources list shown in one frame. At most
     /// `MAX_VISIBLE_SOURCES` rows render at once; anything past that (or
     /// past what fits on a short terminal) stays reachable through the
-    /// existing Up/Down selection, which scrolls the window. The heatmap
-    /// floor is reserved first so short terminals shrink the list instead
-    /// of the heatmap.
+    /// existing Up/Down selection, which scrolls the window.
     fn source_window(&self, term_height: u16, show_legend: bool) -> SourceWindow {
         let total = self.data.source_usage.len();
         if total == 0 {
@@ -184,14 +177,15 @@ impl Overview<'_> {
                 hidden: 0,
             };
         }
-        let reserved = OVERVIEW_FIXED_ROWS + HEATMAP_MIN_HEIGHT + u16::from(show_legend);
-        // Rows available for the source rows plus the truncation hint.
-        let fit = term_height.saturating_sub(reserved) as usize;
+        // Rows left for the source rows plus the pager hint. The heatmap is
+        // `Constraint::Fill(1)`, so it yields space on its own; reserving a
+        // floor for it here would cost source rows on an 80x24 terminal.
+        let avail =
+            term_height.saturating_sub(OVERVIEW_FIXED_ROWS + u16::from(show_legend)) as usize;
         let mut visible = total.min(MAX_VISIBLE_SOURCES);
-        if visible + usize::from(total > visible) > fit {
-            // Short terminal: shrink the list (keeping at least one source
-            // reachable) instead of squeezing the heatmap.
-            visible = fit.saturating_sub(1).max(1).min(total);
+        if visible + usize::from(total > visible) > avail {
+            // Keep at least one source reachable even when nothing fits.
+            visible = avail.saturating_sub(1).max(1).min(total);
         }
         let selected = self
             .data
@@ -703,7 +697,7 @@ mod tests {
     #[test]
     fn test_short_terminal_truncates_with_range_hint() {
         let sources = make_sources(&["claude", "copilot", "codex", "gemini", "qwen", "opencode"]);
-        let text = render_overview_text(&sources, None, 120, 24);
+        let text = render_overview_text(&sources, None, 120, 14);
         assert!(
             text.contains("1–2 of 6"),
             "short overview should show a position range for the visible window, got:\n{text}"
@@ -725,6 +719,56 @@ mod tests {
         assert!(
             !text.contains("claude"),
             "short overview should scroll the first source out of view when the last one is selected"
+        );
+    }
+
+    #[test]
+    fn test_default_terminal_keeps_four_source_rows() {
+        let sources = make_sources(&["claude", "copilot", "codex", "gemini", "qwen", "opencode"]);
+        let text = render_overview_text(&sources, None, 80, 24);
+        for name in ["claude", "copilot", "codex", "gemini"] {
+            assert!(
+                text.contains(name),
+                "an 80x24 terminal should fit four source rows, missing '{name}', got:\n{text}"
+            );
+        }
+        assert!(
+            text.contains("1–4 of 6"),
+            "an 80x24 terminal should page four of six sources, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn test_default_terminal_keeps_four_rows_with_estimated_costs() {
+        let mut sources =
+            make_sources(&["claude", "copilot", "codex", "gemini", "qwen", "opencode"]);
+        for source in sources.iter_mut() {
+            source.estimated = true;
+        }
+        let text = render_overview_text(&sources, None, 80, 24);
+        assert!(
+            text.contains("1–4 of 6"),
+            "the reserved legend row should not cost source rows at 80x24, got:\n{text}"
+        );
+        assert!(
+            text.contains("estimated cost"),
+            "the estimated-cost legend should still render, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn test_exact_cap_renders_no_pager_hint() {
+        let sources = make_sources(&["claude", "copilot", "codex", "gemini"]);
+        let text = render_overview_text(&sources, None, 80, 24);
+        for name in ["claude", "copilot", "codex", "gemini"] {
+            assert!(
+                text.contains(name),
+                "every source should render when the list fits, missing '{name}', got:\n{text}"
+            );
+        }
+        assert!(
+            !text.contains("to scroll"),
+            "no pager hint should render when nothing is hidden, got:\n{text}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Overview sized its source window by reserving a 10-row heatmap floor first, so an 80x24 terminal rendered 2 source rows instead of 4, and 1 when any source had an estimated cost. #242 introduced the reservation while fixing the hard `.take(4)` truncation from #241.
- The heatmap is `Constraint::Fill(1)` and already yields space on its own, so the reservation only took rows from the list it was meant to surface. The window is now sized against the rows actually left on screen.
- `HEATMAP_MIN_HEIGHT` is removed along with the floor invariant its doc comment claimed. That invariant did not hold: the one-row minimum plus the pager hint kept the sources section at 2 rows minimum, so at heights 21-23 the heatmap was still squeezed below ten rows and lost its `Less … More` legend.
- Corrected the `SourceWindow::hidden` doc comment, which described an `N more` hint that was never implemented (the code renders a pager range).

Visible source rows with 6 sources:

| terminal height | before #242 | after #242 | this PR |
|---|---|---|---|
| 24 | 4 | 2 | 4 |
| 24, estimated costs | 4 | 1 | 4 |
| 26 | 4 | 4 | 4 |

Heatmap trade-off at 80x24, measured by rendering the widget directly:

| | source rows | month labels | intensity legend |
|---|---|---|---|
| before #242 (`dda9424`) | 4 | yes | no |
| after #242 (`c5dd07e`) | 2, or 1 with estimated costs | yes | yes |
| this PR | 4 | yes, except with estimated costs | no |

The intensity legend needs a 10-row heatmap, which an 80x24 terminal never had before #242 — #242 only gained it by cutting the list to 2 rows. With estimated costs the pager hint pushes the heatmap to 7 rows and the month labels drop, which is a real loss against `dda9424`; the day grid itself stays intact.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — all clean, 1426 tests.
- Rendered the widget directly at 80x24 in both the plain and estimated-cost variants to confirm four rows, the pager hint, the legend, and an intact heatmap.

## Review

- `test_short_terminal_truncates_with_range_hint` pinned `1–2 of 6` at height 24, which locked in the regression. It now exercises height 14, where truncation genuinely happens.
- Added three tests: four rows at 80x24, the same with the estimated-cost legend reserved, and a boundary case asserting no pager hint renders when the source count equals the cap.
- Existing scroll and selection tests are unchanged and still pass.

Closes #244
